### PR TITLE
Use numpy for frame xforms; add drivers

### DIFF
--- a/install/install_dependencies.sh
+++ b/install/install_dependencies.sh
@@ -19,6 +19,14 @@ main(){
     fi
 }
 
+installRgbMatrix(){
+    info "Installing RGBMatrix..."
+
+    git clone https://github.com/hzeller/rpi-rgb-led-matrix
+    make -C rpi-rgb-led-matrix build-python PYTHON=$(command -v python3)
+    sudo make -C rpi-rgb-led-matrix install-python PYTHON=$(command -v python3)
+}
+
 updateAndInstallPackages(){
     info "Updating and installing packages..."
 
@@ -38,7 +46,7 @@ updateAndInstallPackages(){
     sudo apt -y build-dep python3-pygame # other dependencies needed for pygame
     sudo apt -y full-upgrade
 
-    sudo pip3 install --upgrade youtube_dl yt-dlp numpy apa102-pi pytz websockets simpleaudio pygame
+    sudo pip3 install --upgrade youtube_dl yt-dlp numpy apa102-pi pytz websockets simpleaudio pygame python-pillow
 }
 
 clearYoutubeDlCache(){

--- a/pifi/driver.py
+++ b/pifi/driver.py
@@ -1,0 +1,74 @@
+from apa102_pi.driver import apa102
+from rgbmatrix import RGBMatrix, RGBMatrixOptions
+from PIL import Image
+
+class APA102Driver():
+    # LED Settings
+    __MOSI_PIN = 10
+    __SCLK_PIN = 11
+    __LED_ORDER = 'rbg'
+
+    def __init__(self, led_settings, clear_screen=False):
+        self.__led_settings = led_settings
+        # Add 8 because otherwise the last 8 LEDs don't powered correctly. Weird driver glitch?
+        self.__pixels = apa102.APA102(
+            num_led=(led_settings.display_width * led_settings.display_height + 8),
+            mosi=self.__MOSI_PIN,
+            sclk=self.__SCLK_PIN,
+            order=self.__LED_ORDER
+        )
+        self.__pixels.set_global_brightness(led_settings.brightness)
+        if clear_screen:
+            self.clear_screen()
+
+    # CAUTION:
+    # This method has been heavily optimized. The program spends the bulk of its execution time in this loop.
+    # If making any changes, profile your code first to see if there are regressions, i.e.:
+    #
+    #   python3 -m cProfile -s cumtime video --url https://www.youtube.com/watch?v=AxuvUAjHYWQ --color-mode color
+    #
+    # In the nested for loop, function calls are to be avoided. Inlining them is more performant.
+    #
+    # See: https://github.com/dasl-/pifi/commit/9640268084acb0c46b2624178f350017ab666d41
+    def display_frame(self, frame):
+        width, height = self.__led_settings.display_width, self.__led_settings.display_height
+        for x in range(width):
+            for y in range(height):
+                # TODO(dasl): re-implement this logic using numpy vectorization
+                # to improve performance.
+                # each row is zig-zagged, so every other row needs to be flipped horizontally
+                if (y % 2 == 0):
+                    pixel_index = (y * width) + (width - x - 1)
+                else:
+                    pixel_index = (y * width) + x
+
+                # order on the strip is RBG (refer to self.__LED_ORDER)
+                self.__pixels.set_pixel(x, y, r, b, g)
+        self.__pixels.show()
+
+    def clear_screen(self):
+        self.__pixels.clear_strip()
+
+class RGBMatrixDriver():
+    def __init__(self, led_settings, clear_screen=False):
+        options = RGBMatrixOptions()
+        options.rows = led_settings.display_height
+        options.cols = led_settings.display_width
+        options.chain_length = 1
+        options.parallel = 1
+        options.hardware_mapping = 'adafruit-hat'
+        options.drop_privileges = False
+
+        self.__matrix = RGBMatrix(options = options)
+        self.__pixels = self.__matrix.CreateFrameCanvas()
+        if clear_screen:
+            self.clear_screen()
+
+    def display_frame(self, frame):
+        img = Image.fromarray(frame, mode='RGB')
+        self.__pixels.SetImage(img)
+        self.__pixels = self.__matrix.SwapOnVSync(self.__pixels)
+
+    def clear_screen(self):
+        self.__pixels.Clear()
+        self.__matrix.Clear()

--- a/pifi/settings/ledsettings.py
+++ b/pifi/settings/ledsettings.py
@@ -10,6 +10,9 @@ class LedSettings:
     COLOR_MODE_INVERT_COLOR = 'inv_color'
     COLOR_MODE_INVERT_BW = 'inv_bw'
 
+    DRIVER_APA102 = 'apa102'
+    DRIVER_RGBMATRIX = 'rgbmatrix'
+
     COLOR_MODES = [
         COLOR_MODE_COLOR,
         COLOR_MODE_BW,
@@ -31,9 +34,10 @@ class LedSettings:
     # brightness: int - Global brightness value, max of 31
     # flip_x: boolean - swap left to right, depending on wiring
     # flip_y: boolean - swap top to bottom, depending on wiring
+    # driver: one of the DRIVER_ constants
     def __init__(
         self, color_mode = None, display_width = None, display_height = None,
-        brightness = None, flip_x = False, flip_y = False,
+        brightness = None, flip_x = False, flip_y = False, driver = None
     ):
         # logger: used in child class(es)
         self._logger = Logger().set_namespace(self.__class__.__name__)
@@ -57,6 +61,10 @@ class LedSettings:
         self.flip_x = flip_x
         self.flip_y = flip_y
 
+        if driver is None:
+            driver = self.DRIVER_APA102
+        self.driver = driver
+
     def from_config(self):
         config = self.get_values_from_config()
 
@@ -70,6 +78,8 @@ class LedSettings:
             self.flip_x = config['flip_x']
         if 'flip_y' in config:
             self.flip_y = config['flip_y']
+        if 'driver' in config:
+            self.driver = config['driver']
 
         return self
 


### PR DESCRIPTION
Closes #24

This commit does 3 major things:

1. Reimplement the frame transformations (gamma mapping and frame
   flipping) using numpy vectorization. This should provide a major
   speedup in the inner loop for the apa102 implementation, since it
   removes decisionmaking and cache thrashing from the inner loop.
2. Extract the responsibility of displaying an RGB frame to the LEDs and
   clearing the LEDs into a new interface, the "Driver".
3. Implement a new driver for the Adafruit RGBMatrix, which uses PIL to
   write entire frames to the RGBMatrix. This invokes a C++ routine
   which is more efficient than writing pixel-by-pixel from Python.