### PR TITLE
Remove screensaver list from config, use database exclusively

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -94,9 +94,6 @@
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "screensavers": {
 
-        // Optional, array, default: ["game_of_life", "cyclic_automaton"]. The screensavers to cycle through.
-        "screensavers": ["game_of_life", "cyclic_automaton", "boids", "starfield", "mandelbrot", "wave_interference", "starfield", "matrix_rain", "aurora", "cosmic_dream", "shadebobs"],
-
         // Optional, array, default: []. Videos that may be cycled through as screensavers.
         // Add videos to the data/screensavers directory and update this value with those names.
         "saved_videos": [],

--- a/pifi/screensavermanager.py
+++ b/pifi/screensavermanager.py
@@ -70,12 +70,18 @@ class ScreensaverManager:
         # Cache of instantiated screensavers
         self.__screensaver_cache = {}
 
-    def __get_enabled_screensavers(self):
-        """Get list of enabled screensaver IDs, checking SettingsDb first, then Config."""
-        enabled_json = self.__settings_db.get(SettingsDb.ENABLED_SCREENSAVERS)
+    @staticmethod
+    def get_enabled_screensavers():
+        """Get list of enabled screensaver IDs from database."""
+        settings_db = SettingsDb()
+        enabled_json = settings_db.get(SettingsDb.ENABLED_SCREENSAVERS)
         if enabled_json:
             return json.loads(enabled_json)
-        return Config.get("screensavers.screensavers", ['game_of_life', 'cyclic_automaton'])
+        return ['game_of_life', 'cyclic_automaton']
+
+    def __get_enabled_screensavers(self):
+        """Get list of enabled screensaver IDs from SettingsDb."""
+        return ScreensaverManager.get_enabled_screensavers()
 
     def __get_screensaver(self, screensaver_id):
         """Get or create a screensaver instance."""

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -17,6 +17,7 @@ from pifi.games.pong import Pong
 from pifi.games.unixsockethelper import UnixSocketHelper
 from pifi.settingsdb import SettingsDb
 from pifi.database import Database
+from pifi.screensavermanager import ScreensaverManager
 
 class PifiAPI():
 
@@ -232,12 +233,8 @@ class PifiAPI():
             {'id': 'cloudscape', 'name': 'Cloudscape', 'description': 'Drifting clouds over gradient sky'},
         ]
 
-        # Get enabled screensavers from settings, fall back to config
-        enabled_json = self.__settings_db.get(SettingsDb.ENABLED_SCREENSAVERS)
-        if enabled_json:
-            enabled = json.loads(enabled_json)
-        else:
-            enabled = Config.get('screensavers.screensavers', ['game_of_life', 'cyclic_automaton'])
+        # Get enabled screensavers from settings
+        enabled = ScreensaverManager.get_enabled_screensavers()
 
         return {
             'success': True,


### PR DESCRIPTION
## Summary
- Remove the enabled screensavers list from `default_config.json` since it's now stored in the database
- Centralize screensaver retrieval logic in `ScreensaverManager.get_enabled_screensavers()`
- Update `server.py` to use the centralized method instead of reading from config

## Changes
- **default_config.json**: Removed the `screensavers` array that duplicated database storage
- **pifi/screensavermanager.py**: Added static `get_enabled_screensavers()` method to centralize the logic
- **pifi/server.py**: Updated to use `ScreensaverManager.get_enabled_screensavers()`

## Test plan
- [ ] Verify screensavers still work correctly when enabled via UI
- [ ] Confirm the default screensavers (game_of_life, cyclic_automaton) appear when database is empty
- [ ] Test that changes made in the UI are persisted and reflected in the screensaver rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)