### PR TITLE
Screensaver transitions, timeout lifecycle, and API consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ app/src/css/custom-theme.css
 app/src/css/themes/*.css
 app/src/css/**/*.css.map
 
-# Claude instructions file
+# Claude Code
 CLAUDE.local.md
+pifi/settings.json

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -25,12 +25,12 @@
         </section>
 
         <section class="settings-section">
-            <h2>Rotation Settings</h2>
+            <h2>Transition Settings</h2>
             <p class="description">Configure how screensavers rotate and transition.</p>
 
             <div class="config-field">
-                <label class="config-label" for="dwell-time">Dwell Time (seconds)</label>
-                <input type="number" class="config-input" id="dwell-time" min="0" step="1" placeholder="Per-screensaver default">
+                <label class="config-label" for="screensaver-timeout">Screensaver Timeout (seconds)</label>
+                <input type="number" class="config-input" id="screensaver-timeout" min="0" step="1" placeholder="Per-screensaver default">
                 <span class="field-hint">How long each screensaver plays. Empty or 0 uses per-screensaver defaults.</span>
             </div>
 
@@ -52,10 +52,10 @@
             </div>
 
             <div class="actions">
-                <button id="save-rotation-btn" class="save-btn">Save Rotation Settings</button>
+                <button id="save-transition-btn" class="save-btn">Save Transition Settings</button>
             </div>
 
-            <div id="rotation-status-message" class="status-message"></div>
+            <div id="transition-status-message" class="status-message"></div>
         </section>
 
         <section class="settings-section">
@@ -121,17 +121,17 @@
 
             loadBrightness();
 
-            // Rotation settings
-            function loadRotationSettings() {
-                $.get('/api/global_settings').done(function(data) {
+            // Transition settings
+            function loadTransitionSettings() {
+                $.get('/api/screensavers').done(function(data) {
                     if (!data.success) return;
-                    var c = data.current;
+                    var c = data.global_settings.current;
 
-                    var dwellTime = c.screensavers.dwell_time;
-                    if (dwellTime !== null && dwellTime !== 0) {
-                        $('#dwell-time').val(dwellTime);
+                    var timeout = c.screensavers.screensaver_timeout;
+                    if (timeout !== null && timeout !== 0) {
+                        $('#screensaver-timeout').val(timeout);
                     } else {
-                        $('#dwell-time').val('');
+                        $('#screensaver-timeout').val('');
                     }
 
                     $('#transitions-enabled').prop('checked', c.transitions.enabled);
@@ -140,9 +140,9 @@
                 });
             }
 
-            $('#save-rotation-btn').on('click', function() {
-                var dwellVal = $('#dwell-time').val();
-                var dwellTime = (dwellVal === '' || parseFloat(dwellVal) === 0) ? null : parseFloat(dwellVal);
+            $('#save-transition-btn').on('click', function() {
+                var timeoutVal = $('#screensaver-timeout').val();
+                var screensaverTimeout = (timeoutVal === '' || parseFloat(timeoutVal) === 0) ? null : parseFloat(timeoutVal);
 
                 var durationVal = $('#transition-duration').val();
                 var duration = parseFloat(durationVal);
@@ -151,32 +151,34 @@
                 var numSteps = parseInt(stepsVal, 10);
 
                 var payload = {
-                    screensavers: {
-                        dwell_time: dwellTime
-                    },
-                    transitions: {
-                        enabled: $('#transitions-enabled').is(':checked'),
-                        duration: duration,
-                        num_steps: numSteps
+                    global_settings: {
+                        screensavers: {
+                            screensaver_timeout: screensaverTimeout
+                        },
+                        transitions: {
+                            enabled: $('#transitions-enabled').is(':checked'),
+                            duration: duration,
+                            num_steps: numSteps
+                        }
                     }
                 };
 
                 $.post({
-                    url: '/api/global_settings',
+                    url: '/api/screensavers',
                     data: JSON.stringify(payload),
                     contentType: 'application/json'
                 }).done(function(data) {
                     if (data.success) {
-                        showStatus('Rotation settings saved! Screensaver restarting...', 'success', '#rotation-status-message');
+                        showStatus('Transition settings saved! Screensaver restarting...', 'success', '#transition-status-message');
                     } else {
-                        showStatus('Error saving rotation settings', 'error', '#rotation-status-message');
+                        showStatus('Error saving transition settings', 'error', '#transition-status-message');
                     }
                 }).fail(function() {
-                    showStatus('Failed to save rotation settings', 'error', '#rotation-status-message');
+                    showStatus('Failed to save transition settings', 'error', '#transition-status-message');
                 });
             });
 
-            loadRotationSettings();
+            loadTransitionSettings();
 
             function loadScreensavers() {
                 // Load both screensavers and their configs in parallel

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -125,18 +125,18 @@
             function loadTransitionSettings() {
                 $.get('/api/screensavers').done(function(data) {
                     if (!data.success) return;
-                    var c = data.global_settings.current;
 
-                    var timeout = c.screensavers.timeout;
+                    var timeout = data.timeout.current;
                     if (timeout !== null && timeout !== 0) {
                         $('#screensaver-timeout').val(timeout);
                     } else {
                         $('#screensaver-timeout').val('');
                     }
 
-                    $('#transitions-enabled').prop('checked', c.transitions.enabled);
-                    $('#transition-duration').val(c.transitions.duration);
-                    $('#transition-steps').val(c.transitions.num_steps);
+                    var transitions = data.transitions.current;
+                    $('#transitions-enabled').prop('checked', transitions.enabled);
+                    $('#transition-duration').val(transitions.duration);
+                    $('#transition-steps').val(transitions.num_steps);
                 });
             }
 
@@ -151,15 +151,11 @@
                 var numSteps = parseInt(stepsVal, 10);
 
                 var payload = {
-                    global_settings: {
-                        screensavers: {
-                            timeout: screensaverTimeout
-                        },
-                        transitions: {
-                            enabled: $('#transitions-enabled').is(':checked'),
-                            duration: duration,
-                            num_steps: numSteps
-                        }
+                    timeout: screensaverTimeout,
+                    transitions: {
+                        enabled: $('#transitions-enabled').is(':checked'),
+                        duration: duration,
+                        num_steps: numSteps
                     }
                 };
 
@@ -181,22 +177,15 @@
             loadTransitionSettings();
 
             function loadScreensavers() {
-                // Load both screensavers and their configs in parallel
-                $.when(
-                    $.get('/api/screensavers'),
-                    $.get('/api/screensaver_configs')
-                ).done(function(screensaversResp, configsResp) {
-                    var screensaversData = screensaversResp[0];
-                    var configsData = configsResp[0];
-
-                    if (!screensaversData.success) {
+                $.get('/api/screensavers').done(function(data) {
+                    if (!data.success) {
                         showStatus('Error loading screensavers', 'error');
                         return;
                     }
 
-                    screensaverConfigs = configsData.configs || {};
-                    originalEnabled = screensaversData.enabled.slice();
-                    renderScreensavers(screensaversData.screensavers, screensaversData.enabled);
+                    screensaverConfigs = data.configs || {};
+                    originalEnabled = data.enabled.slice();
+                    renderScreensavers(data.screensavers, data.enabled);
                     $('#save-btn').prop('disabled', true);
                 }).fail(function() {
                     showStatus('Failed to load screensavers', 'error');

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -47,8 +47,8 @@
             </div>
 
             <div class="config-field">
-                <label class="config-label" for="transition-steps">Transition Steps</label>
-                <input type="number" class="config-input" id="transition-steps" min="1" step="1">
+                <label class="config-label" for="transition-tick-sleep">Transition Tick Sleep (seconds)</label>
+                <input type="number" class="config-input" id="transition-tick-sleep" min="0" step="0.01">
             </div>
 
             <div class="actions">
@@ -121,11 +121,14 @@
 
             loadBrightness();
 
-            // Transition settings
-            function loadTransitionSettings() {
+            function loadSettings() {
                 $.get('/api/screensavers').done(function(data) {
-                    if (!data.success) return;
+                    if (!data.success) {
+                        showStatus('Error loading screensavers', 'error');
+                        return;
+                    }
 
+                    // Transition settings
                     var timeout = data.timeout.current;
                     if (timeout !== null && timeout !== 0) {
                         $('#screensaver-timeout').val(timeout);
@@ -136,7 +139,15 @@
                     var transitions = data.transitions.current;
                     $('#transitions-enabled').prop('checked', transitions.enabled);
                     $('#transition-duration').val(transitions.duration);
-                    $('#transition-steps').val(transitions.num_steps);
+                    $('#transition-tick-sleep').val(transitions.tick_sleep);
+
+                    // Screensaver list
+                    screensaverConfigs = data.configs || {};
+                    originalEnabled = data.enabled.slice();
+                    renderScreensavers(data.screensavers, data.enabled);
+                    $('#save-btn').prop('disabled', true);
+                }).fail(function() {
+                    showStatus('Failed to load screensavers', 'error');
                 });
             }
 
@@ -147,15 +158,15 @@
                 var durationVal = $('#transition-duration').val();
                 var duration = parseFloat(durationVal);
 
-                var stepsVal = $('#transition-steps').val();
-                var numSteps = parseInt(stepsVal, 10);
+                var tickSleepVal = $('#transition-tick-sleep').val();
+                var tickSleep = parseFloat(tickSleepVal);
 
                 var payload = {
                     timeout: screensaverTimeout,
                     transitions: {
                         enabled: $('#transitions-enabled').is(':checked'),
                         duration: duration,
-                        num_steps: numSteps
+                        tick_sleep: tickSleep
                     }
                 };
 
@@ -174,23 +185,7 @@
                 });
             });
 
-            loadTransitionSettings();
-
-            function loadScreensavers() {
-                $.get('/api/screensavers').done(function(data) {
-                    if (!data.success) {
-                        showStatus('Error loading screensavers', 'error');
-                        return;
-                    }
-
-                    screensaverConfigs = data.configs || {};
-                    originalEnabled = data.enabled.slice();
-                    renderScreensavers(data.screensavers, data.enabled);
-                    $('#save-btn').prop('disabled', true);
-                }).fail(function() {
-                    showStatus('Failed to load screensavers', 'error');
-                });
-            }
+            loadSettings();
 
             function formatConfigKey(key) {
                 // Convert snake_case to Title Case
@@ -527,7 +522,6 @@
                 $('#screensaver-list input[type="checkbox"][value]').prop('checked', false).trigger('change');
             });
 
-            loadScreensavers();
         });
     </script>
 </body>

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -127,7 +127,7 @@
                     if (!data.success) return;
                     var c = data.global_settings.current;
 
-                    var timeout = c.screensavers.screensaver_timeout;
+                    var timeout = c.screensavers.timeout;
                     if (timeout !== null && timeout !== 0) {
                         $('#screensaver-timeout').val(timeout);
                     } else {
@@ -153,7 +153,7 @@
                 var payload = {
                     global_settings: {
                         screensavers: {
-                            screensaver_timeout: screensaverTimeout
+                            timeout: screensaverTimeout
                         },
                         transitions: {
                             enabled: $('#transitions-enabled').is(':checked'),

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -30,8 +30,8 @@
 
             <div class="config-field">
                 <label class="config-label" for="screensaver-timeout">Screensaver Timeout (seconds)</label>
-                <input type="number" class="config-input" id="screensaver-timeout" min="0" step="1" placeholder="Per-screensaver default">
-                <span class="field-hint">How long each screensaver plays. Empty or 0 uses per-screensaver defaults.</span>
+                <input type="number" class="config-input" id="screensaver-timeout" min="0" step="1" placeholder="Unlimited">
+                <span class="field-hint">How long each screensaver plays. Empty or 0 means unlimited.</span>
             </div>
 
             <div class="config-field">

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -25,6 +25,40 @@
         </section>
 
         <section class="settings-section">
+            <h2>Rotation Settings</h2>
+            <p class="description">Configure how screensavers rotate and transition.</p>
+
+            <div class="config-field">
+                <label class="config-label" for="dwell-time">Dwell Time (seconds)</label>
+                <input type="number" class="config-input" id="dwell-time" min="0" step="1" placeholder="Per-screensaver default">
+                <span class="field-hint">How long each screensaver plays. Empty or 0 uses per-screensaver defaults.</span>
+            </div>
+
+            <div class="config-field">
+                <label class="config-label" for="transitions-enabled">
+                    <input type="checkbox" class="config-input" id="transitions-enabled" checked>
+                    Transitions Enabled
+                </label>
+            </div>
+
+            <div class="config-field">
+                <label class="config-label" for="transition-duration">Transition Duration (seconds)</label>
+                <input type="number" class="config-input" id="transition-duration" min="0.1" step="0.1">
+            </div>
+
+            <div class="config-field">
+                <label class="config-label" for="transition-steps">Transition Steps</label>
+                <input type="number" class="config-input" id="transition-steps" min="1" step="1">
+            </div>
+
+            <div class="actions">
+                <button id="save-rotation-btn" class="save-btn">Save Rotation Settings</button>
+            </div>
+
+            <div id="rotation-status-message" class="status-message"></div>
+        </section>
+
+        <section class="settings-section">
             <h2>Screensavers</h2>
             <p class="description">Select which screensavers to include in the rotation. Click "Settings" to configure options.</p>
 
@@ -86,6 +120,63 @@
             });
 
             loadBrightness();
+
+            // Rotation settings
+            function loadRotationSettings() {
+                $.get('/api/global_settings').done(function(data) {
+                    if (!data.success) return;
+                    var c = data.current;
+
+                    var dwellTime = c.screensavers.dwell_time;
+                    if (dwellTime !== null && dwellTime !== 0) {
+                        $('#dwell-time').val(dwellTime);
+                    } else {
+                        $('#dwell-time').val('');
+                    }
+
+                    $('#transitions-enabled').prop('checked', c.transitions.enabled);
+                    $('#transition-duration').val(c.transitions.duration);
+                    $('#transition-steps').val(c.transitions.num_steps);
+                });
+            }
+
+            $('#save-rotation-btn').on('click', function() {
+                var dwellVal = $('#dwell-time').val();
+                var dwellTime = (dwellVal === '' || parseFloat(dwellVal) === 0) ? null : parseFloat(dwellVal);
+
+                var durationVal = $('#transition-duration').val();
+                var duration = parseFloat(durationVal);
+
+                var stepsVal = $('#transition-steps').val();
+                var numSteps = parseInt(stepsVal, 10);
+
+                var payload = {
+                    screensavers: {
+                        dwell_time: dwellTime
+                    },
+                    transitions: {
+                        enabled: $('#transitions-enabled').is(':checked'),
+                        duration: duration,
+                        num_steps: numSteps
+                    }
+                };
+
+                $.post({
+                    url: '/api/global_settings',
+                    data: JSON.stringify(payload),
+                    contentType: 'application/json'
+                }).done(function(data) {
+                    if (data.success) {
+                        showStatus('Rotation settings saved! Screensaver restarting...', 'success', '#rotation-status-message');
+                    } else {
+                        showStatus('Error saving rotation settings', 'error', '#rotation-status-message');
+                    }
+                }).fail(function() {
+                    showStatus('Failed to save rotation settings', 'error', '#rotation-status-message');
+                });
+            });
+
+            loadRotationSettings();
 
             function loadScreensavers() {
                 // Load both screensavers and their configs in parallel
@@ -398,8 +489,8 @@
                 return true;
             }
 
-            function showStatus(message, type) {
-                var $status = $('#status-message');
+            function showStatus(message, type, selector) {
+                var $status = $(selector || '#status-message');
                 $status.text(message)
                     .removeClass('success error')
                     .addClass(type)

--- a/assets/settings/settings.html
+++ b/assets/settings/settings.html
@@ -357,13 +357,12 @@
 
             function saveScreensaverConfig(screensaverId) {
                 var config = getConfigValues(screensaverId);
+                var configs = {};
+                configs[screensaverId] = config;
 
                 $.post({
-                    url: '/api/screensaver_config',
-                    data: JSON.stringify({
-                        screensaver_id: screensaverId,
-                        config: config
-                    }),
+                    url: '/api/screensavers',
+                    data: JSON.stringify({ configs: configs }),
                     contentType: 'application/json'
                 }).done(function(data) {
                     if (data.success) {
@@ -389,11 +388,12 @@
                     return;
                 }
 
+                var configs = {};
+                configs[screensaverId] = null;
+
                 $.post({
-                    url: '/api/screensaver_config_reset',
-                    data: JSON.stringify({
-                        screensaver_id: screensaverId
-                    }),
+                    url: '/api/screensavers',
+                    data: JSON.stringify({ configs: configs }),
                     contentType: 'application/json'
                 }).done(function(data) {
                     if (data.success) {

--- a/assets/settings/style.css
+++ b/assets/settings/style.css
@@ -332,6 +332,11 @@ header h1 {
     border-color: #4ecca3;
 }
 
+.field-hint {
+    font-size: 0.8em;
+    color: #666;
+}
+
 .config-actions {
     display: flex;
     gap: 8px;

--- a/default_config.json
+++ b/default_config.json
@@ -105,7 +105,7 @@
 
         // Optional, ?float, default: null. Screensaver timeout in seconds.
         // When set, each screensaver will end after this many seconds regardless of its own
-        // max_ticks setting. When null (default), each screensaver uses its own max_ticks.
+        // max_ticks setting. Set to null or 0 to disable (each screensaver uses its own max_ticks).
         "timeout": null,
 
         // Configuration for transitions between screensavers.

--- a/default_config.json
+++ b/default_config.json
@@ -113,6 +113,11 @@
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "screensavers": {
 
+        // Optional, ?float, default: null. Central dwell time in seconds for all screensavers.
+        // When set, each screensaver will end after this many seconds regardless of its own
+        // max_ticks setting. When null (default), each screensaver uses its own max_ticks.
+        "dwell_time": null,
+
         // Optional, array, default: []. Videos that may be cycled through as screensavers.
         // Add videos to the data/screensavers directory and update this value with those names.
         "saved_videos": [],

--- a/default_config.json
+++ b/default_config.json
@@ -99,14 +99,14 @@
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "screensavers": {
 
+        // Optional, array of strings, default: ["game_of_life", "cyclic_automaton"].
+        // Which screensavers are included in the rotation. Use screensaver IDs.
+        "enabled": ["game_of_life", "cyclic_automaton"],
+
         // Optional, ?float, default: null. Screensaver timeout in seconds.
         // When set, each screensaver will end after this many seconds regardless of its own
         // max_ticks setting. When null (default), each screensaver uses its own max_ticks.
         "timeout": null,
-
-        // Optional, array, default: []. Videos that may be cycled through as screensavers.
-        // Add videos to the data/screensavers directory and update this value with those names.
-        "saved_videos": [],
 
         // Configuration for transitions between screensavers.
         // Optional. This whole stanza is optional because none of the keys within it are required.
@@ -842,6 +842,15 @@
                 // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
                 // When false, lyrics display at a steady dimmer brightness.
                 "pulse_lyrics": true,
+            },
+
+            // Configuration specific to video screensaver.
+            // Plays saved video files from the data/screensavers directory.
+            "video_screensaver": {
+
+                // Optional, array, default: []. Videos that may be cycled through as screensavers.
+                // Add videos to the data/screensavers directory and update this value with those names.
+                "saved_videos": [],
             },
         },
     },

--- a/default_config.json
+++ b/default_config.json
@@ -120,8 +120,8 @@
             // Optional, float, default: 1.0. Duration of the transition in seconds.
             "duration": 1.0,
 
-            // Optional, integer, default: 30. Number of interpolation steps (~frames) per transition.
-            "num_steps": 30,
+            // Optional, float, default: 0.03. Seconds to sleep between transition frames.
+            "tick_sleep": 0.03,
         },
 
         // Optional, float, default: 0.05. Seconds to sleep between ticks (frame rate).
@@ -788,6 +788,27 @@
         // Optional, string, default: "random". The color mode for the game.
         // Valid values: "random", "red", "green", "blue", "bw", "rainbow".
         "game_color_mode": "random",
+    },
+
+    // Configuration specific to the RGB Matrix driver (HUB75 panels).
+    // Optional. This whole stanza is optional because none of the keys within it are required.
+    "rgbmatrix": {
+
+        // Optional, integer, default: 4. GPIO slowdown for Pi 3/4. Try 2-5 if you see issues.
+        "gpio_slowdown": 4,
+
+        // Optional, integer, default: 11. PWM bits for color depth (1-11). Lower = faster refresh.
+        "pwm_bits": 11,
+
+        // Optional, integer, default: 130. PWM timing in nanoseconds. Try 100-300.
+        "pwm_lsb_nanoseconds": 130,
+
+        // Optional, integer, default: 0. Limit refresh rate in Hz (0 = unlimited).
+        "limit_refresh_rate_hz": 0,
+
+        // Optional, boolean, default: false. Use software PWM instead of hardware.
+        // Enable if you have audio conflicts.
+        "disable_hardware_pulsing": false,
     },
 
     // Configuration specific to playing pong.

--- a/default_config.json
+++ b/default_config.json
@@ -95,20 +95,6 @@
         "limited_max_vol_val": null,
     },
 
-    // Configuration for transitions between screensavers.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "transitions": {
-
-        // Optional, boolean, default: true. Whether to play animated transitions between screensavers.
-        "enabled": true,
-
-        // Optional, float, default: 1.0. Duration of the transition in seconds.
-        "duration": 1.0,
-
-        // Optional, integer, default: 30. Number of interpolation steps (~frames) per transition.
-        "num_steps": 30,
-    },
-
     // Configuration specific to the screensavers that play while nothing is in the playlist queue.
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "screensavers": {
@@ -116,79 +102,750 @@
         // Optional, ?float, default: null. Screensaver timeout in seconds.
         // When set, each screensaver will end after this many seconds regardless of its own
         // max_ticks setting. When null (default), each screensaver uses its own max_ticks.
-        "screensaver_timeout": null,
+        "timeout": null,
 
         // Optional, array, default: []. Videos that may be cycled through as screensavers.
         // Add videos to the data/screensavers directory and update this value with those names.
         "saved_videos": [],
+
+        // Configuration for transitions between screensavers.
+        // Optional. This whole stanza is optional because none of the keys within it are required.
+        "transitions": {
+
+            // Optional, boolean, default: true. Whether to play animated transitions between screensavers.
+            "enabled": true,
+
+            // Optional, float, default: 1.0. Duration of the transition in seconds.
+            "duration": 1.0,
+
+            // Optional, integer, default: 30. Number of interpolation steps (~frames) per transition.
+            "num_steps": 30,
+        },
+
+        // Per-screensaver configuration.
+        // Each screensaver has its own stanza with configurable options.
+        "configs": {
+            // Configuration specific to the game of life.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "game_of_life": {
+    
+                // Optional, float in range: [0,1], default: 0.3333. How likely each pixel is to be alive (on)
+                // in the initial state.
+                "seed_liveness_probability": 0.3333,
+    
+                // Optional, float, default: 0.07. How long to sleep between ticks, in seconds,
+                "tick_sleep": 0.07,
+    
+                // Optional, integer, default: 16. How many frames are analyzed to determine if we are stuck in a loop
+                // and if we should to end the game.
+                "game_over_detection_lookback": 16,
+    
+                // Optional, string, default: "random". The color mode for the game.
+                // Valid values: "random", "red", "green", "blue", "bw", "rainbow".
+                "game_color_mode": "random",
+    
+                // Optional, string, default: "random". The variant for the game.
+                // Valid values: "normal", "immigration".
+                // See: https://cs.stanford.edu/people/eroberts/courses/soco/projects/2008-09/modeling-natural-systems/gameOfLife2.html
+                "variant": "random",
+    
+                // Optional, boolean, default: false. Whether to do fade transitions between frames of the game.
+                "fade": false,
+    
+                // Optional, boolean, default: false. Whether to invert the colors.
+                "invert": false,
+            },
+    
+            // Configuration specific to cyclic automaton: https://en.wikipedia.org/wiki/Cyclic_cellular_automaton
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "cyclic_automaton": {
+    
+                // Optional, float, default: 0.07. How long to sleep between ticks, in seconds,
+                "tick_sleep": 0.07,
+    
+                // Optional, integer, default: 16. How many frames are analyzed to determine if we are stuck in a loop
+                // and if we should to end the game.
+                "game_over_detection_lookback": 16,
+    
+                // Optional, boolean, default: false. Whether to do fade transitions between frames of the game.
+                "fade": false,
+            },
+    
+            // Configuration specific to boids flocking screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "boids": {
+    
+                // Optional, integer, default: 15. Number of boids in the simulation.
+                "num_boids": 15,
+    
+                // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 2000. Maximum number of ticks before ending.
+                "max_ticks": 2000,
+    
+                // Optional, float, default: 1.5. Maximum speed of boids.
+                "max_speed": 1.5,
+    
+                // Optional, float, default: 8.0. Perception radius for flocking behavior.
+                "perception_radius": 8.0,
+    
+                // Optional, float, default: 2.0. Minimum distance for separation behavior.
+                "min_distance": 2.0,
+    
+                // Optional, float, default: 1.5. Weight for separation steering.
+                "separation_weight": 1.5,
+    
+                // Optional, float, default: 1.0. Weight for alignment steering.
+                "alignment_weight": 1.0,
+    
+                // Optional, float, default: 1.0. Weight for cohesion steering.
+                "cohesion_weight": 1.0,
+            },
+    
+            // Configuration specific to cosmic dream psychedelic screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "cosmic_dream": {
+    
+                // Optional, integer, default: 20. Number of particles in the flow field.
+                "num_particles": 20,
+    
+                // Optional, integer, default: 8. Length of particle trails.
+                "trail_length": 8,
+    
+                // Optional, float, default: 0.5. Speed of particles.
+                "particle_speed": 0.5,
+    
+                // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 3000. Maximum number of ticks before ending.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to mandelbrot zoom screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "mandelbrot": {
+    
+                // Optional, integer, default: 100. Maximum iterations for escape calculation.
+                // Higher values show more detail but are slower.
+                "max_iterations": 100,
+    
+                // Optional, float, default: 1.02. Zoom multiplier per tick.
+                // Values closer to 1.0 zoom slower.
+                "zoom_speed": 1.02,
+    
+                // Optional, float, default: 0.02. How fast the view moves toward the target.
+                // Values closer to 0 move slower.
+                "lerp_factor": 0.02,
+    
+                // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 1500. Maximum number of ticks before ending.
+                "max_ticks": 1500,
+            },
+    
+            // Configuration specific to wave interference screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "wave_interference": {
+    
+                // Optional, integer, default: 4. Number of wave sources.
+                "num_sources": 4,
+    
+                // Optional, float, default: 0.5. Frequency of the waves (higher = tighter ripples).
+                "wave_frequency": 0.5,
+    
+                // Optional, float, default: 0.15. How fast time advances (wave animation speed).
+                "time_speed": 0.15,
+    
+                // Optional, float, default: 0.3. How fast sources drift around.
+                "drift_speed": 0.3,
+    
+                // Optional, string, default: "rainbow". Color mode for the waves.
+                // Valid values: "rainbow", "monochrome", "plasma", "classic".
+                "color_mode": "rainbow",
+    
+                // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 2000. Maximum number of ticks before ending.
+                "max_ticks": 2000,
+            },
+    
+            // Configuration specific to spirograph screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "spirograph": {
+    
+                // Optional, integer, default: 500. Number of points in the trail.
+                "trail_length": 500,
+    
+                // Optional, boolean, default: true. Whether older trail points fade out.
+                "fade_trail": true,
+    
+                // Optional, float, default: 1.0. Speed multiplier for pattern generation.
+                "time_speed": 1.0,
+    
+                // Optional, float, default: 0.02. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.02,
+    
+                // Optional, integer, default: 2000. Maximum number of ticks before ending.
+                "max_ticks": 2000,
+            },
+    
+            // Configuration specific to lorenz attractor screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "lorenz": {
+    
+                // Optional, float, default: 10.0. Lorenz sigma parameter.
+                "sigma": 10.0,
+    
+                // Optional, float, default: 28.0. Lorenz rho parameter.
+                "rho": 28.0,
+    
+                // Optional, float, default: 2.667. Lorenz beta parameter.
+                "beta": 2.667,
+    
+                // Optional, float, default: 0.01. Time step for integration.
+                "dt": 0.01,
+    
+                // Optional, integer, default: 5. Integration steps per frame.
+                "steps_per_frame": 5,
+    
+                // Optional, integer, default: 800. Number of points in the trail.
+                "trail_length": 800,
+    
+                // Optional, float, default: 0.005. Speed of view rotation.
+                "rotation_speed": 0.005,
+    
+                // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 3000. Maximum number of ticks before ending.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to metaballs screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "metaballs": {
+    
+                // Optional, integer, default: 5. Number of metaballs.
+                "num_balls": 5,
+    
+                // Optional, float, default: 0.5. Movement speed of metaballs.
+                "speed": 0.5,
+    
+                // Optional, float, default: 1.0. Threshold for blob surface (lower = larger blobs).
+                "threshold": 1.0,
+    
+                // Optional, boolean, default: true. Whether to add glow effect at blob edges.
+                "glow": true,
+    
+                // Optional, float, default: 0.04. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.04,
+    
+                // Optional, integer, default: 2000. Maximum number of ticks before ending.
+                "max_ticks": 2000,
+            },
+    
+            // Configuration specific to starfield screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "starfield": {
+    
+                // Optional, integer, default: 80. Number of stars.
+                "num_stars": 80,
+    
+                // Optional, float, default: 0.02. Speed of stars moving toward viewer.
+                "speed": 0.02,
+    
+                // Optional, boolean, default: true. Whether to show motion trails on close stars.
+                "show_trails": true,
+    
+                // Optional, integer, default: 3. Length of motion trails.
+                "trail_length": 3,
+    
+                // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 3000. Maximum number of ticks before ending.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to matrix rain screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "matrix_rain": {
+    
+                // Optional, float, default: 0.2. Minimum drop fall speed.
+                "min_speed": 0.2,
+    
+                // Optional, float, default: 0.8. Maximum drop fall speed.
+                "max_speed": 0.8,
+    
+                // Optional, integer, default: 4. Minimum trail length.
+                "min_length": 4,
+    
+                // Optional, integer, default: 12. Maximum trail length.
+                "max_length": 12,
+    
+                // Optional, float, default: 0.85. Trail fade rate per tick (0-1).
+                "fade_rate": 0.85,
+    
+                // Optional, float, default: 0.08. Probability of spawning new drops.
+                "spawn_rate": 0.08,
+    
+                // Optional, string, default: "green". Color mode for the rain.
+                // Valid values: "green", "blue", "rainbow", "white".
+                "color_mode": "green",
+    
+                // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 3000. Maximum number of ticks before ending.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to melting clock screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "melting_clock": {
+    
+                // Optional, boolean, default: false. Whether to show seconds (HH:MM:SS vs HH:MM).
+                "show_seconds": false,
+    
+                // Optional, string, default: null (local time). Timezone to display time in.
+                // Examples: "America/New_York", "Europe/London", "Asia/Tokyo", "UTC".
+                // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+                "timezone": null,
+    
+                // Optional, float, default: 0.15. Speed of melting/dripping animation.
+                "melt_speed": 0.15,
+    
+                // Optional, float, default: 0.05. Speed of new digit forming.
+                "form_speed": 0.05,
+    
+                // Optional, float, default: 0.85. Trail fade rate per tick (0-1).
+                "trail_fade": 0.85,
+    
+                // Optional, float, default: 0.001. Speed of color hue cycling.
+                "hue_speed": 0.001,
+    
+                // Optional, string, default: "rainbow". Color mode.
+                // Valid values: "rainbow", "green", "blue", "red", "white".
+                "color_mode": "rainbow",
+    
+                // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 5000. Maximum number of ticks before ending.
+                "max_ticks": 5000,
+            },
+    
+            // Configuration specific to aurora borealis screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "aurora": {
+    
+                // Optional, integer, default: 4. Number of aurora curtains.
+                "num_curtains": 4,
+    
+                // Optional, boolean, default: true. Whether to show twinkling background stars.
+                "show_stars": true,
+    
+                // Optional, integer, default: 15. Number of background stars.
+                "num_stars": 15,
+    
+                // Optional, float, default: 1.0. Overall animation speed multiplier.
+                "time_speed": 1.0,
+    
+                // Optional, float, default: 0.04. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.04,
+    
+                // Optional, integer, default: 3000. Maximum number of ticks before ending.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to shadebobs screensaver.
+            // Optional. This whole stanza is optional because none of the keys within it are required.
+            "shadebobs": {
+    
+                // Optional, integer, default: 5. Number of bobs (glowing circles).
+                "num_bobs": 5,
+    
+                // Optional, float, default: 0.92. Fade rate per frame (lower = faster fade).
+                "fade": 0.92,
+    
+                // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 2000. Maximum number of ticks before ending.
+                "max_ticks": 2000,
+            },
+    
+            // Configuration specific to flow field screensaver.
+            "flowfield": {
+    
+                // Optional, integer, default: 50. Number of particles.
+                "num_particles": 50,
+    
+                // Optional, float, default: 0.95. Fade rate per frame.
+                "fade": 0.95,
+    
+                // Optional, float, default: 0.5. Particle movement speed.
+                "speed": 0.5,
+    
+                // Optional, float, default: 0.03. Tick sleep time.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 2500. Maximum ticks.
+                "max_ticks": 2500,
+            },
+    
+            // Configuration specific to lava lamp screensaver.
+            "lavalamp": {
+    
+                // Optional, integer, default: 10. Number of blobs.
+                "num_blobs": 10,
+    
+                // Optional, float, default: 0.03. How fast blobs heat up.
+                "heat_rate": 0.03,
+    
+                // Optional, float, default: 0.02. How fast blobs cool down.
+                "cool_rate": 0.02,
+    
+                // Optional, float, default: 0.08. Buoyancy force strength.
+                "buoyancy": 0.08,
+    
+                // Optional, float, default: 0.05. Tick sleep time.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 3000. Maximum ticks.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to reaction diffusion screensaver.
+            "reactiondiffusion": {
+    
+                // Optional, integer, default: 8. Number of initial seed points.
+                "num_seeds": 8,
+    
+                // Optional, integer, default: 10. Simulation steps per frame.
+                "steps_per_frame": 10,
+    
+                // Optional, integer, default: 100. Frames between injecting new seeds.
+                "inject_interval": 100,
+    
+                // Optional, float, default: 0.05. Tick sleep time.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 2000. Maximum ticks.
+                "max_ticks": 2000,
+            },
+    
+            // Configuration specific to ink in water screensaver.
+            "inkinwater": {
+    
+                // Optional, float, default: 0.06. Chance of new drop per frame.
+                "drop_chance": 0.06,
+    
+                // Optional, float, default: 0.15. How fast ink diffuses.
+                "diffusion_rate": 0.15,
+    
+                // Optional, float, default: 0.03. Upward flow strength (0 to disable).
+                "flow_strength": 0.03,
+    
+                // Optional, float, default: 0.997. Slow fade rate.
+                "fade": 0.997,
+    
+                // Optional, float, default: 0.04. Tick sleep time.
+                "tick_sleep": 0.04,
+    
+                // Optional, integer, default: 2500. Maximum ticks.
+                "max_ticks": 2500,
+            },
+    
+            // Configuration specific to perlin worms screensaver.
+            "perlinworms": {
+    
+                // Optional, integer, default: 8. Number of worms.
+                "num_worms": 8,
+    
+                // Optional, integer, default: 12. Length of each worm in segments.
+                "worm_length": 12,
+    
+                // Optional, float, default: 0.8. Worm movement speed.
+                "speed": 0.8,
+    
+                // Optional, float, default: 0.1. Scale of noise field.
+                "noise_scale": 0.1,
+    
+                // Optional, float, default: 0.02. How fast noise field evolves.
+                "time_speed": 0.02,
+    
+                // Optional, float, default: 0.92. Trail fade rate.
+                "fade": 0.92,
+    
+                // Optional, float, default: 1.5. Glow radius around worm segments.
+                "glow_size": 1.5,
+    
+                // Optional, float, default: 0.03. Tick sleep time.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 10000. Maximum ticks.
+                "max_ticks": 10000,
+            },
+    
+            // Configuration specific to pendulum waves screensaver.
+            "pendulumwaves": {
+    
+                // Optional, integer, default: 0. Number of pendulums (0 = auto based on width).
+                "num_pendulums": 0,
+    
+                // Optional, float, default: 60.0. Base period in frames for longest pendulum.
+                "base_period": 60.0,
+    
+                // Optional, integer, default: 600. Frames for full pattern cycle.
+                "cycle_time": 600,
+    
+                // Optional, float, default: 1.5. Size of pendulum bob.
+                "bob_size": 1.5,
+    
+                // Optional, float, default: 0.85. Trail fade rate.
+                "trail_fade": 0.85,
+    
+                // Optional, string, default: rainbow. Color mode: rainbow, gradient, white.
+                "color_mode": "rainbow",
+    
+                // Optional, float, default: 0.03. Tick sleep time.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 10000. Maximum ticks.
+                "max_ticks": 10000,
+            },
+    
+            // Configuration specific to string art screensaver.
+            "stringart": {
+    
+                // Optional, integer, default: 64. Number of points on the circle.
+                "num_points": 64,
+    
+                // Optional, integer, default: 32. Number of strings to draw.
+                "num_strings": 32,
+    
+                // Optional, float, default: 0.02. Speed of multiplier change.
+                "multiplier_speed": 0.02,
+    
+                // Optional, float, default: 0.01. Rotation speed.
+                "rotation_speed": 0.01,
+    
+                // Optional, float, default: 0.15. Fade rate per frame.
+                "fade": 0.15,
+    
+                // Optional, float, default: 0.4. Line brightness.
+                "line_brightness": 0.4,
+    
+                // Optional, float, default: 0.03. Tick sleep time.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 10000. Maximum ticks.
+                "max_ticks": 10000,
+            },
+    
+            // Configuration specific to unknown pleasures screensaver.
+            "unknownpleasures": {
+    
+                // Optional, integer, default: 0. Number of wave lines (0 = auto based on height).
+                "num_lines": 0,
+    
+                // Optional, float, default: 0.05. Wave animation speed.
+                "wave_speed": 0.05,
+    
+                // Optional, float, default: 0.15. Noise scale for wave generation.
+                "noise_scale": 0.15,
+    
+                // Optional, float, default: 0.4. Wave amplitude.
+                "amplitude": 0.4,
+    
+                // Optional, float, default: 1.0. Line brightness.
+                "line_brightness": 1.0,
+    
+                // Optional, boolean, default: true. Fill below wave lines (solid mountain effect).
+                "fill_below": true,
+    
+                // Optional, string, default: white. Color mode: white, blue, rainbow.
+                "color_mode": "white",
+    
+                // Optional, float, default: 0.05. Tick sleep time.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 10000. Maximum ticks.
+                "max_ticks": 10000,
+            },
+    
+            // Configuration specific to cloudscape screensaver.
+            "cloudscape": {
+    
+                // Optional, integer, default: 3. Number of cloud layers.
+                "num_layers": 3,
+    
+                // Optional, float, default: 0.2. Cloud drift speed.
+                "drift_speed": 0.2,
+    
+                // Optional, string, default: pastel. Sky mode: pastel, day, dawn, sunset, night.
+                "sky_mode": "pastel",
+    
+                // Optional, float, default: 0.7. Cloud density (0-1).
+                "cloud_density": 0.7,
+    
+                // Optional, float, default: 0.04. Cloud scale (smaller = bigger clouds).
+                "cloud_scale": 0.04,
+    
+                // Optional, float, default: 0.001. Sky color shift speed.
+                "sky_shift_speed": 0.001,
+    
+                // Optional, float, default: 0.05. Tick sleep time.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 10000. Maximum ticks.
+                "max_ticks": 10000,
+            },
+    
+            // Configuration specific to gradient test screensaver (for debugging flicker).
+            "gradient_test": {
+    
+                // Optional, string, default: pastel_sky. Test pattern to display.
+                // Valid values: pastel_sky, white, half_white, dim_white, red, green, blue,
+                // horizontal_gradient, vertical_gradient, checkerboard, stripes, color_bars
+                "mode": "pastel_sky",
+    
+                // Optional, float, default: 0.1. Tick sleep time (high = low CPU).
+                "tick_sleep": 0.1,
+    
+                // Optional, integer, default: 3000. Maximum ticks.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to DVD bounce screensaver.
+            "dvd_bounce": {
+    
+                // Optional, integer, default: 8. Width of the bouncing logo in pixels.
+                "logo_width": 8,
+    
+                // Optional, integer, default: 4. Height of the bouncing logo in pixels.
+                "logo_height": 4,
+    
+                // Optional, float, default: 0.5. Movement speed of the logo.
+                "speed": 0.5,
+    
+                // Optional, string, default: random. Color mode for the logo.
+                // Valid values: "random", "rainbow", "pastel", "white".
+                "color_mode": "random",
+    
+                // Optional, boolean, default: true. Whether to show a border around the logo.
+                "show_border": true,
+    
+                // Optional, boolean, default: false. Whether to show "DVD" text in the logo.
+                "show_text": false,
+    
+                // Optional, float, default: 0.03. Tick sleep time.
+                "tick_sleep": 0.03,
+    
+                // Optional, integer, default: 10000. Maximum ticks.
+                "max_ticks": 10000,
+            },
+    
+            // Configuration specific to NYC Subway arrival times screensaver.
+            // Requires nyct-gtfs library: pip install nyct-gtfs
+            "nyc_subway": {
+    
+                // Optional, array of strings, default: ["127N", "127S"].
+                // Stop IDs to monitor. Format: stop_id + direction (N=uptown/north, S=downtown/south).
+                // Find stop IDs at: https://transitfeeds.com/p/mta/79/latest/stops
+                // Examples:
+                //   "127N"/"127S" = 34 St-Penn Station (1/2/3)
+                //   "A32N"/"A32S" = 34 St-Penn Station (A/C/E)
+                //   "R17N"/"R17S" = 34 St-Herald Sq (N/Q/R/W/B/D/F/M)
+                //   "L01N"/"L01S" = 8 Av (L)
+                //   "631N"/"631S" = Grand Central-42 St (4/5/6)
+                "stop_ids": ["D25N", "237N", "A44N"],
+    
+                // Optional, array of strings, default: ["1", "2", "3"].
+                // Subway lines to display. Use line letters/numbers.
+                "lines": ["B", "Q", "2", "3", "4", "5", "A", "C"],
+    
+                // Optional, integer, default: 30. How often to refresh data from MTA, in seconds.
+                "update_interval": 30,
+    
+                // Optional, integer, default: 4. Maximum number of arrivals to show.
+                "max_arrivals": 4,
+    
+                // Optional, float, default: 1.0. How long to sleep between display updates, in seconds.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 3000. Maximum ticks before ending screensaver.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to WFMU radio now-playing screensaver.
+            // Shows current track, artist, and show name from WFMU streams.
+            "wfmu": {
+    
+                // Optional, string, default: "wfmu". Which WFMU stream to display.
+                // Valid values: "wfmu" (main 91.1), "gtd" (Give the Drummer Radio),
+                // "rock_n_soul" (Rock'n'Soul Radio).
+                "channel": "wfmu",
+    
+                // Optional, integer, default: 15. How often to refresh data, in seconds.
+                "update_interval": 15,
+    
+                // Optional, float, default: 0.05. How long to sleep between display updates.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 3000. Maximum ticks before ending screensaver.
+                "max_ticks": 3000,
+            },
+    
+            // Configuration specific to AirPlay Karaoke screensaver.
+            // Displays synced lyrics for music playing via AirPlay (shairport-sync).
+            "airplay_karaoke": {
+    
+                // Optional, string, default: "/tmp/shairport-sync-metadata".
+                // Path to the shairport-sync metadata pipe.
+                "metadata_pipe": "/tmp/shairport-sync-metadata",
+    
+                // Optional, float, default: 0.05. How long to sleep between display updates.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 6000. Maximum ticks before ending screensaver.
+                "max_ticks": 6000,
+    
+                // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
+                // When false, lyrics display at a steady dimmer brightness.
+                "pulse_lyrics": true,
+            },
+    
+            // Configuration specific to Sonos Karaoke screensaver.
+            // Displays synced lyrics for music playing on Sonos speakers.
+            "sonos_karaoke": {
+    
+                // Optional, string, default: null. Name of Sonos speaker to use.
+                // If null, uses first discovered speaker.
+                // Example: "Living Room", "Kitchen"
+                "speaker_name": null,
+    
+                // Optional, float, default: 0.5. How often to poll Sonos for position (seconds).
+                "update_interval": 0.5,
+    
+                // Optional, float, default: 0.05. How long to sleep between display updates.
+                "tick_sleep": 0.05,
+    
+                // Optional, integer, default: 6000. Maximum ticks before ending screensaver.
+                "max_ticks": 6000,
+    
+                // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
+                // When false, lyrics display at a steady dimmer brightness.
+                "pulse_lyrics": true,
+            },
+        },
     },
 
-    // Configuration specific to the RGB Matrix driver (HUB75 panels).
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "rgbmatrix": {
-
-        // Optional, integer, default: 4. GPIO slowdown for Pi 3/4. Try 2-5 if you see issues.
-        "gpio_slowdown": 4,
-
-        // Optional, integer, default: 11. PWM bits for color depth (1-11). Lower = faster refresh.
-        "pwm_bits": 11,
-
-        // Optional, integer, default: 130. PWM timing in nanoseconds. Try 100-300.
-        "pwm_lsb_nanoseconds": 130,
-
-        // Optional, integer, default: 0. Limit refresh rate in Hz (0 = unlimited).
-        "limit_refresh_rate_hz": 0,
-
-        // Optional, boolean, default: false. Use software PWM instead of hardware.
-        // Enable if you have audio conflicts.
-        "disable_hardware_pulsing": false,
-    },
-
-    // Configuration specific to the game of life.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "game_of_life": {
-
-        // Optional, float in range: [0,1], default: 0.3333. How likely each pixel is to be alive (on)
-        // in the initial state.
-        "seed_liveness_probability": 0.3333,
-
-        // Optional, float, default: 0.07. How long to sleep between ticks, in seconds,
-        "tick_sleep": 0.07,
-
-        // Optional, integer, default: 16. How many frames are analyzed to determine if we are stuck in a loop
-        // and if we should to end the game.
-        "game_over_detection_lookback": 16,
-
-        // Optional, string, default: "random". The color mode for the game.
-        // Valid values: "random", "red", "green", "blue", "bw", "rainbow".
-        "game_color_mode": "random",
-
-        // Optional, string, default: "random". The variant for the game.
-        // Valid values: "normal", "immigration".
-        // See: https://cs.stanford.edu/people/eroberts/courses/soco/projects/2008-09/modeling-natural-systems/gameOfLife2.html
-        "variant": "random",
-
-        // Optional, boolean, default: false. Whether to do fade transitions between frames of the game.
-        "fade": false,
-
-        // Optional, boolean, default: false. Whether to invert the colors.
-        "invert": false,
-    },
-
-    // Configuration specific to cyclic automaton: https://en.wikipedia.org/wiki/Cyclic_cellular_automaton
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "cyclic_automaton": {
-
-        // Optional, float, default: 0.07. How long to sleep between ticks, in seconds,
-        "tick_sleep": 0.07,
-
-        // Optional, integer, default: 16. How many frames are analyzed to determine if we are stuck in a loop
-        // and if we should to end the game.
-        "game_over_detection_lookback": 16,
-
-        // Optional, boolean, default: false. Whether to do fade transitions between frames of the game.
-        "fade": false,
-    },
 
     // Configuration specific to playing snake.
     // Optional. This whole stanza is optional because none of the keys within it are required.
@@ -211,679 +868,6 @@
 
         // Optional, float, default: 1.5. Maximum ball speed.
         "max_ball_speed": 1.5,
-    },
-
-    // Configuration specific to boids flocking screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "boids": {
-
-        // Optional, integer, default: 15. Number of boids in the simulation.
-        "num_boids": 15,
-
-        // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 2000. Maximum number of ticks before ending.
-        "max_ticks": 2000,
-
-        // Optional, float, default: 1.5. Maximum speed of boids.
-        "max_speed": 1.5,
-
-        // Optional, float, default: 8.0. Perception radius for flocking behavior.
-        "perception_radius": 8.0,
-
-        // Optional, float, default: 2.0. Minimum distance for separation behavior.
-        "min_distance": 2.0,
-
-        // Optional, float, default: 1.5. Weight for separation steering.
-        "separation_weight": 1.5,
-
-        // Optional, float, default: 1.0. Weight for alignment steering.
-        "alignment_weight": 1.0,
-
-        // Optional, float, default: 1.0. Weight for cohesion steering.
-        "cohesion_weight": 1.0,
-    },
-
-    // Configuration specific to cosmic dream psychedelic screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "cosmic_dream": {
-
-        // Optional, integer, default: 20. Number of particles in the flow field.
-        "num_particles": 20,
-
-        // Optional, integer, default: 8. Length of particle trails.
-        "trail_length": 8,
-
-        // Optional, float, default: 0.5. Speed of particles.
-        "particle_speed": 0.5,
-
-        // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 3000. Maximum number of ticks before ending.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to mandelbrot zoom screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "mandelbrot": {
-
-        // Optional, integer, default: 100. Maximum iterations for escape calculation.
-        // Higher values show more detail but are slower.
-        "max_iterations": 100,
-
-        // Optional, float, default: 1.02. Zoom multiplier per tick.
-        // Values closer to 1.0 zoom slower.
-        "zoom_speed": 1.02,
-
-        // Optional, float, default: 0.02. How fast the view moves toward the target.
-        // Values closer to 0 move slower.
-        "lerp_factor": 0.02,
-
-        // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 1500. Maximum number of ticks before ending.
-        "max_ticks": 1500,
-    },
-
-    // Configuration specific to wave interference screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "wave_interference": {
-
-        // Optional, integer, default: 4. Number of wave sources.
-        "num_sources": 4,
-
-        // Optional, float, default: 0.5. Frequency of the waves (higher = tighter ripples).
-        "wave_frequency": 0.5,
-
-        // Optional, float, default: 0.15. How fast time advances (wave animation speed).
-        "time_speed": 0.15,
-
-        // Optional, float, default: 0.3. How fast sources drift around.
-        "drift_speed": 0.3,
-
-        // Optional, string, default: "rainbow". Color mode for the waves.
-        // Valid values: "rainbow", "monochrome", "plasma", "classic".
-        "color_mode": "rainbow",
-
-        // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 2000. Maximum number of ticks before ending.
-        "max_ticks": 2000,
-    },
-
-    // Configuration specific to spirograph screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "spirograph": {
-
-        // Optional, integer, default: 500. Number of points in the trail.
-        "trail_length": 500,
-
-        // Optional, boolean, default: true. Whether older trail points fade out.
-        "fade_trail": true,
-
-        // Optional, float, default: 1.0. Speed multiplier for pattern generation.
-        "time_speed": 1.0,
-
-        // Optional, float, default: 0.02. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.02,
-
-        // Optional, integer, default: 2000. Maximum number of ticks before ending.
-        "max_ticks": 2000,
-    },
-
-    // Configuration specific to lorenz attractor screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "lorenz": {
-
-        // Optional, float, default: 10.0. Lorenz sigma parameter.
-        "sigma": 10.0,
-
-        // Optional, float, default: 28.0. Lorenz rho parameter.
-        "rho": 28.0,
-
-        // Optional, float, default: 2.667. Lorenz beta parameter.
-        "beta": 2.667,
-
-        // Optional, float, default: 0.01. Time step for integration.
-        "dt": 0.01,
-
-        // Optional, integer, default: 5. Integration steps per frame.
-        "steps_per_frame": 5,
-
-        // Optional, integer, default: 800. Number of points in the trail.
-        "trail_length": 800,
-
-        // Optional, float, default: 0.005. Speed of view rotation.
-        "rotation_speed": 0.005,
-
-        // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 3000. Maximum number of ticks before ending.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to metaballs screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "metaballs": {
-
-        // Optional, integer, default: 5. Number of metaballs.
-        "num_balls": 5,
-
-        // Optional, float, default: 0.5. Movement speed of metaballs.
-        "speed": 0.5,
-
-        // Optional, float, default: 1.0. Threshold for blob surface (lower = larger blobs).
-        "threshold": 1.0,
-
-        // Optional, boolean, default: true. Whether to add glow effect at blob edges.
-        "glow": true,
-
-        // Optional, float, default: 0.04. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.04,
-
-        // Optional, integer, default: 2000. Maximum number of ticks before ending.
-        "max_ticks": 2000,
-    },
-
-    // Configuration specific to starfield screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "starfield": {
-
-        // Optional, integer, default: 80. Number of stars.
-        "num_stars": 80,
-
-        // Optional, float, default: 0.02. Speed of stars moving toward viewer.
-        "speed": 0.02,
-
-        // Optional, boolean, default: true. Whether to show motion trails on close stars.
-        "show_trails": true,
-
-        // Optional, integer, default: 3. Length of motion trails.
-        "trail_length": 3,
-
-        // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 3000. Maximum number of ticks before ending.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to matrix rain screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "matrix_rain": {
-
-        // Optional, float, default: 0.2. Minimum drop fall speed.
-        "min_speed": 0.2,
-
-        // Optional, float, default: 0.8. Maximum drop fall speed.
-        "max_speed": 0.8,
-
-        // Optional, integer, default: 4. Minimum trail length.
-        "min_length": 4,
-
-        // Optional, integer, default: 12. Maximum trail length.
-        "max_length": 12,
-
-        // Optional, float, default: 0.85. Trail fade rate per tick (0-1).
-        "fade_rate": 0.85,
-
-        // Optional, float, default: 0.08. Probability of spawning new drops.
-        "spawn_rate": 0.08,
-
-        // Optional, string, default: "green". Color mode for the rain.
-        // Valid values: "green", "blue", "rainbow", "white".
-        "color_mode": "green",
-
-        // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 3000. Maximum number of ticks before ending.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to melting clock screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "melting_clock": {
-
-        // Optional, boolean, default: false. Whether to show seconds (HH:MM:SS vs HH:MM).
-        "show_seconds": false,
-
-        // Optional, string, default: null (local time). Timezone to display time in.
-        // Examples: "America/New_York", "Europe/London", "Asia/Tokyo", "UTC".
-        // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-        "timezone": null,
-
-        // Optional, float, default: 0.15. Speed of melting/dripping animation.
-        "melt_speed": 0.15,
-
-        // Optional, float, default: 0.05. Speed of new digit forming.
-        "form_speed": 0.05,
-
-        // Optional, float, default: 0.85. Trail fade rate per tick (0-1).
-        "trail_fade": 0.85,
-
-        // Optional, float, default: 0.001. Speed of color hue cycling.
-        "hue_speed": 0.001,
-
-        // Optional, string, default: "rainbow". Color mode.
-        // Valid values: "rainbow", "green", "blue", "red", "white".
-        "color_mode": "rainbow",
-
-        // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 5000. Maximum number of ticks before ending.
-        "max_ticks": 5000,
-    },
-
-    // Configuration specific to aurora borealis screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "aurora": {
-
-        // Optional, integer, default: 4. Number of aurora curtains.
-        "num_curtains": 4,
-
-        // Optional, boolean, default: true. Whether to show twinkling background stars.
-        "show_stars": true,
-
-        // Optional, integer, default: 15. Number of background stars.
-        "num_stars": 15,
-
-        // Optional, float, default: 1.0. Overall animation speed multiplier.
-        "time_speed": 1.0,
-
-        // Optional, float, default: 0.04. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.04,
-
-        // Optional, integer, default: 3000. Maximum number of ticks before ending.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to shadebobs screensaver.
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "shadebobs": {
-
-        // Optional, integer, default: 5. Number of bobs (glowing circles).
-        "num_bobs": 5,
-
-        // Optional, float, default: 0.92. Fade rate per frame (lower = faster fade).
-        "fade": 0.92,
-
-        // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 2000. Maximum number of ticks before ending.
-        "max_ticks": 2000,
-    },
-
-    // Configuration specific to flow field screensaver.
-    "flowfield": {
-
-        // Optional, integer, default: 50. Number of particles.
-        "num_particles": 50,
-
-        // Optional, float, default: 0.95. Fade rate per frame.
-        "fade": 0.95,
-
-        // Optional, float, default: 0.5. Particle movement speed.
-        "speed": 0.5,
-
-        // Optional, float, default: 0.03. Tick sleep time.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 2500. Maximum ticks.
-        "max_ticks": 2500,
-    },
-
-    // Configuration specific to lava lamp screensaver.
-    "lavalamp": {
-
-        // Optional, integer, default: 10. Number of blobs.
-        "num_blobs": 10,
-
-        // Optional, float, default: 0.03. How fast blobs heat up.
-        "heat_rate": 0.03,
-
-        // Optional, float, default: 0.02. How fast blobs cool down.
-        "cool_rate": 0.02,
-
-        // Optional, float, default: 0.08. Buoyancy force strength.
-        "buoyancy": 0.08,
-
-        // Optional, float, default: 0.05. Tick sleep time.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 3000. Maximum ticks.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to reaction diffusion screensaver.
-    "reactiondiffusion": {
-
-        // Optional, integer, default: 8. Number of initial seed points.
-        "num_seeds": 8,
-
-        // Optional, integer, default: 10. Simulation steps per frame.
-        "steps_per_frame": 10,
-
-        // Optional, integer, default: 100. Frames between injecting new seeds.
-        "inject_interval": 100,
-
-        // Optional, float, default: 0.05. Tick sleep time.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 2000. Maximum ticks.
-        "max_ticks": 2000,
-    },
-
-    // Configuration specific to ink in water screensaver.
-    "inkinwater": {
-
-        // Optional, float, default: 0.06. Chance of new drop per frame.
-        "drop_chance": 0.06,
-
-        // Optional, float, default: 0.15. How fast ink diffuses.
-        "diffusion_rate": 0.15,
-
-        // Optional, float, default: 0.03. Upward flow strength (0 to disable).
-        "flow_strength": 0.03,
-
-        // Optional, float, default: 0.997. Slow fade rate.
-        "fade": 0.997,
-
-        // Optional, float, default: 0.04. Tick sleep time.
-        "tick_sleep": 0.04,
-
-        // Optional, integer, default: 2500. Maximum ticks.
-        "max_ticks": 2500,
-    },
-
-    // Configuration specific to perlin worms screensaver.
-    "perlinworms": {
-
-        // Optional, integer, default: 8. Number of worms.
-        "num_worms": 8,
-
-        // Optional, integer, default: 12. Length of each worm in segments.
-        "worm_length": 12,
-
-        // Optional, float, default: 0.8. Worm movement speed.
-        "speed": 0.8,
-
-        // Optional, float, default: 0.1. Scale of noise field.
-        "noise_scale": 0.1,
-
-        // Optional, float, default: 0.02. How fast noise field evolves.
-        "time_speed": 0.02,
-
-        // Optional, float, default: 0.92. Trail fade rate.
-        "fade": 0.92,
-
-        // Optional, float, default: 1.5. Glow radius around worm segments.
-        "glow_size": 1.5,
-
-        // Optional, float, default: 0.03. Tick sleep time.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 10000. Maximum ticks.
-        "max_ticks": 10000,
-    },
-
-    // Configuration specific to pendulum waves screensaver.
-    "pendulumwaves": {
-
-        // Optional, integer, default: 0. Number of pendulums (0 = auto based on width).
-        "num_pendulums": 0,
-
-        // Optional, float, default: 60.0. Base period in frames for longest pendulum.
-        "base_period": 60.0,
-
-        // Optional, integer, default: 600. Frames for full pattern cycle.
-        "cycle_time": 600,
-
-        // Optional, float, default: 1.5. Size of pendulum bob.
-        "bob_size": 1.5,
-
-        // Optional, float, default: 0.85. Trail fade rate.
-        "trail_fade": 0.85,
-
-        // Optional, string, default: rainbow. Color mode: rainbow, gradient, white.
-        "color_mode": "rainbow",
-
-        // Optional, float, default: 0.03. Tick sleep time.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 10000. Maximum ticks.
-        "max_ticks": 10000,
-    },
-
-    // Configuration specific to string art screensaver.
-    "stringart": {
-
-        // Optional, integer, default: 64. Number of points on the circle.
-        "num_points": 64,
-
-        // Optional, integer, default: 32. Number of strings to draw.
-        "num_strings": 32,
-
-        // Optional, float, default: 0.02. Speed of multiplier change.
-        "multiplier_speed": 0.02,
-
-        // Optional, float, default: 0.01. Rotation speed.
-        "rotation_speed": 0.01,
-
-        // Optional, float, default: 0.15. Fade rate per frame.
-        "fade": 0.15,
-
-        // Optional, float, default: 0.4. Line brightness.
-        "line_brightness": 0.4,
-
-        // Optional, float, default: 0.03. Tick sleep time.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 10000. Maximum ticks.
-        "max_ticks": 10000,
-    },
-
-    // Configuration specific to unknown pleasures screensaver.
-    "unknownpleasures": {
-
-        // Optional, integer, default: 0. Number of wave lines (0 = auto based on height).
-        "num_lines": 0,
-
-        // Optional, float, default: 0.05. Wave animation speed.
-        "wave_speed": 0.05,
-
-        // Optional, float, default: 0.15. Noise scale for wave generation.
-        "noise_scale": 0.15,
-
-        // Optional, float, default: 0.4. Wave amplitude.
-        "amplitude": 0.4,
-
-        // Optional, float, default: 1.0. Line brightness.
-        "line_brightness": 1.0,
-
-        // Optional, boolean, default: true. Fill below wave lines (solid mountain effect).
-        "fill_below": true,
-
-        // Optional, string, default: white. Color mode: white, blue, rainbow.
-        "color_mode": "white",
-
-        // Optional, float, default: 0.05. Tick sleep time.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 10000. Maximum ticks.
-        "max_ticks": 10000,
-    },
-
-    // Configuration specific to cloudscape screensaver.
-    "cloudscape": {
-
-        // Optional, integer, default: 3. Number of cloud layers.
-        "num_layers": 3,
-
-        // Optional, float, default: 0.2. Cloud drift speed.
-        "drift_speed": 0.2,
-
-        // Optional, string, default: pastel. Sky mode: pastel, day, dawn, sunset, night.
-        "sky_mode": "pastel",
-
-        // Optional, float, default: 0.7. Cloud density (0-1).
-        "cloud_density": 0.7,
-
-        // Optional, float, default: 0.04. Cloud scale (smaller = bigger clouds).
-        "cloud_scale": 0.04,
-
-        // Optional, float, default: 0.001. Sky color shift speed.
-        "sky_shift_speed": 0.001,
-
-        // Optional, float, default: 0.05. Tick sleep time.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 10000. Maximum ticks.
-        "max_ticks": 10000,
-    },
-
-    // Configuration specific to gradient test screensaver (for debugging flicker).
-    "gradient_test": {
-
-        // Optional, string, default: pastel_sky. Test pattern to display.
-        // Valid values: pastel_sky, white, half_white, dim_white, red, green, blue,
-        // horizontal_gradient, vertical_gradient, checkerboard, stripes, color_bars
-        "mode": "pastel_sky",
-
-        // Optional, float, default: 0.1. Tick sleep time (high = low CPU).
-        "tick_sleep": 0.1,
-
-        // Optional, integer, default: 3000. Maximum ticks.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to DVD bounce screensaver.
-    "dvd_bounce": {
-
-        // Optional, integer, default: 8. Width of the bouncing logo in pixels.
-        "logo_width": 8,
-
-        // Optional, integer, default: 4. Height of the bouncing logo in pixels.
-        "logo_height": 4,
-
-        // Optional, float, default: 0.5. Movement speed of the logo.
-        "speed": 0.5,
-
-        // Optional, string, default: random. Color mode for the logo.
-        // Valid values: "random", "rainbow", "pastel", "white".
-        "color_mode": "random",
-
-        // Optional, boolean, default: true. Whether to show a border around the logo.
-        "show_border": true,
-
-        // Optional, boolean, default: false. Whether to show "DVD" text in the logo.
-        "show_text": false,
-
-        // Optional, float, default: 0.03. Tick sleep time.
-        "tick_sleep": 0.03,
-
-        // Optional, integer, default: 10000. Maximum ticks.
-        "max_ticks": 10000,
-    },
-
-    // Configuration specific to NYC Subway arrival times screensaver.
-    // Requires nyct-gtfs library: pip install nyct-gtfs
-    "nyc_subway": {
-
-        // Optional, array of strings, default: ["127N", "127S"].
-        // Stop IDs to monitor. Format: stop_id + direction (N=uptown/north, S=downtown/south).
-        // Find stop IDs at: https://transitfeeds.com/p/mta/79/latest/stops
-        // Examples:
-        //   "127N"/"127S" = 34 St-Penn Station (1/2/3)
-        //   "A32N"/"A32S" = 34 St-Penn Station (A/C/E)
-        //   "R17N"/"R17S" = 34 St-Herald Sq (N/Q/R/W/B/D/F/M)
-        //   "L01N"/"L01S" = 8 Av (L)
-        //   "631N"/"631S" = Grand Central-42 St (4/5/6)
-        "stop_ids": ["D25N", "237N", "A44N"],
-
-        // Optional, array of strings, default: ["1", "2", "3"].
-        // Subway lines to display. Use line letters/numbers.
-        "lines": ["B", "Q", "2", "3", "4", "5", "A", "C"],
-
-        // Optional, integer, default: 30. How often to refresh data from MTA, in seconds.
-        "update_interval": 30,
-
-        // Optional, integer, default: 4. Maximum number of arrivals to show.
-        "max_arrivals": 4,
-
-        // Optional, float, default: 1.0. How long to sleep between display updates, in seconds.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 3000. Maximum ticks before ending screensaver.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to WFMU radio now-playing screensaver.
-    // Shows current track, artist, and show name from WFMU streams.
-    "wfmu": {
-
-        // Optional, string, default: "wfmu". Which WFMU stream to display.
-        // Valid values: "wfmu" (main 91.1), "gtd" (Give the Drummer Radio),
-        // "rock_n_soul" (Rock'n'Soul Radio).
-        "channel": "wfmu",
-
-        // Optional, integer, default: 15. How often to refresh data, in seconds.
-        "update_interval": 15,
-
-        // Optional, float, default: 0.05. How long to sleep between display updates.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 3000. Maximum ticks before ending screensaver.
-        "max_ticks": 3000,
-    },
-
-    // Configuration specific to AirPlay Karaoke screensaver.
-    // Displays synced lyrics for music playing via AirPlay (shairport-sync).
-    "airplay_karaoke": {
-
-        // Optional, string, default: "/tmp/shairport-sync-metadata".
-        // Path to the shairport-sync metadata pipe.
-        "metadata_pipe": "/tmp/shairport-sync-metadata",
-
-        // Optional, float, default: 0.05. How long to sleep between display updates.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 6000. Maximum ticks before ending screensaver.
-        "max_ticks": 6000,
-
-        // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
-        // When false, lyrics display at a steady dimmer brightness.
-        "pulse_lyrics": true,
-    },
-
-    // Configuration specific to Sonos Karaoke screensaver.
-    // Displays synced lyrics for music playing on Sonos speakers.
-    "sonos_karaoke": {
-
-        // Optional, string, default: null. Name of Sonos speaker to use.
-        // If null, uses first discovered speaker.
-        // Example: "Living Room", "Kitchen"
-        "speaker_name": null,
-
-        // Optional, float, default: 0.5. How often to poll Sonos for position (seconds).
-        "update_interval": 0.5,
-
-        // Optional, float, default: 0.05. How long to sleep between display updates.
-        "tick_sleep": 0.05,
-
-        // Optional, integer, default: 6000. Maximum ticks before ending screensaver.
-        "max_ticks": 6000,
-
-        // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
-        // When false, lyrics display at a steady dimmer brightness.
-        "pulse_lyrics": true,
     },
 
 }

--- a/default_config.json
+++ b/default_config.json
@@ -95,6 +95,20 @@
         "limited_max_vol_val": null,
     },
 
+    // Configuration for transitions between screensavers.
+    // Optional. This whole stanza is optional because none of the keys within it are required.
+    "transitions": {
+
+        // Optional, boolean, default: true. Whether to play animated transitions between screensavers.
+        "enabled": true,
+
+        // Optional, float, default: 1.0. Duration of the transition in seconds.
+        "duration": 1.0,
+
+        // Optional, integer, default: 30. Number of interpolation steps (~frames) per transition.
+        "num_steps": 30,
+    },
+
     // Configuration specific to the screensavers that play while nothing is in the playlist queue.
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "screensavers": {

--- a/default_config.json
+++ b/default_config.json
@@ -50,6 +50,27 @@
         // "gamma_enabled": false,
     },
 
+    // Configuration specific to the RGB Matrix driver (HUB75 panels).
+    // Optional. This whole stanza is optional because none of the keys within it are required.
+    "rgbmatrix": {
+
+        // Optional, integer, default: 4. GPIO slowdown for Pi 3/4. Try 2-5 if you see issues.
+        "gpio_slowdown": 4,
+
+        // Optional, integer, default: 11. PWM bits for color depth (1-11). Lower = faster refresh.
+        "pwm_bits": 11,
+
+        // Optional, integer, default: 130. PWM timing in nanoseconds. Try 100-300.
+        "pwm_lsb_nanoseconds": 130,
+
+        // Optional, integer, default: 0. Limit refresh rate in Hz (0 = unlimited).
+        "limit_refresh_rate_hz": 0,
+
+        // Optional, boolean, default: false. Use software PWM instead of hardware.
+        // Enable if you have audio conflicts.
+        "disable_hardware_pulsing": false,
+    },
+
     // Configuration specific to displaying videos.
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "video": {
@@ -110,6 +131,10 @@
         // A per-screensaver timeout of null falls back to this global value.
         "timeout": 120,
 
+        // Optional, float, default: 0.05. Seconds to sleep between ticks (frame rate).
+        // Can be overridden per-screensaver via screensavers.configs.<id>.tick_sleep.
+        "tick_sleep": 0.05,
+
         // Configuration for transitions between screensavers.
         // Optional. This whole stanza is optional because none of the keys within it are required.
         "transitions": {
@@ -123,10 +148,6 @@
             // Optional, float, default: 0.03. Seconds to sleep between transition frames.
             "tick_sleep": 0.03,
         },
-
-        // Optional, float, default: 0.05. Seconds to sleep between ticks (frame rate).
-        // Can be overridden per-screensaver via screensavers.configs.<id>.tick_sleep.
-        "tick_sleep": 0.05,
 
         // Per-screensaver configuration.
         // Each screensaver has its own stanza with configurable options.
@@ -788,27 +809,6 @@
         // Optional, string, default: "random". The color mode for the game.
         // Valid values: "random", "red", "green", "blue", "bw", "rainbow".
         "game_color_mode": "random",
-    },
-
-    // Configuration specific to the RGB Matrix driver (HUB75 panels).
-    // Optional. This whole stanza is optional because none of the keys within it are required.
-    "rgbmatrix": {
-
-        // Optional, integer, default: 4. GPIO slowdown for Pi 3/4. Try 2-5 if you see issues.
-        "gpio_slowdown": 4,
-
-        // Optional, integer, default: 11. PWM bits for color depth (1-11). Lower = faster refresh.
-        "pwm_bits": 11,
-
-        // Optional, integer, default: 130. PWM timing in nanoseconds. Try 100-300.
-        "pwm_lsb_nanoseconds": 130,
-
-        // Optional, integer, default: 0. Limit refresh rate in Hz (0 = unlimited).
-        "limit_refresh_rate_hz": 0,
-
-        // Optional, boolean, default: false. Use software PWM instead of hardware.
-        // Enable if you have audio conflicts.
-        "disable_hardware_pulsing": false,
     },
 
     // Configuration specific to playing pong.

--- a/default_config.json
+++ b/default_config.json
@@ -113,10 +113,10 @@
     // Optional. This whole stanza is optional because none of the keys within it are required.
     "screensavers": {
 
-        // Optional, ?float, default: null. Central dwell time in seconds for all screensavers.
+        // Optional, ?float, default: null. Screensaver timeout in seconds.
         // When set, each screensaver will end after this many seconds regardless of its own
         // max_ticks setting. When null (default), each screensaver uses its own max_ticks.
-        "dwell_time": null,
+        "screensaver_timeout": null,
 
         // Optional, array, default: []. Videos that may be cycled through as screensavers.
         // Add videos to the data/screensavers directory and update this value with those names.

--- a/default_config.json
+++ b/default_config.json
@@ -103,10 +103,11 @@
         // Which screensavers are included in the rotation. Use screensaver IDs.
         "enabled": ["game_of_life", "cyclic_automaton"],
 
-        // Optional, ?float, default: null. Screensaver timeout in seconds.
-        // When set, each screensaver will end after this many seconds regardless of its own
-        // max_ticks setting. Set to null or 0 to disable (each screensaver uses its own max_ticks).
-        "timeout": null,
+        // Optional, ?float, default: 120. Screensaver timeout in seconds.
+        // Each screensaver will end after this many seconds and rotate to the next one.
+        // Set to null or 0 to disable (screensavers run indefinitely).
+        // Can be overridden per-screensaver via screensavers.configs.<id>.timeout.
+        "timeout": 120,
 
         // Configuration for transitions between screensavers.
         // Optional. This whole stanza is optional because none of the keys within it are required.
@@ -121,6 +122,10 @@
             // Optional, integer, default: 30. Number of interpolation steps (~frames) per transition.
             "num_steps": 30,
         },
+
+        // Optional, float, default: 0.05. Seconds to sleep between ticks (frame rate).
+        // Can be overridden per-screensaver via screensavers.configs.<id>.tick_sleep.
+        "tick_sleep": 0.05,
 
         // Per-screensaver configuration.
         // Each screensaver has its own stanza with configurable options.
@@ -181,9 +186,6 @@
                 // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.05,
     
-                // Optional, integer, default: 2000. Maximum number of ticks before ending.
-                "max_ticks": 2000,
-    
                 // Optional, float, default: 1.5. Maximum speed of boids.
                 "max_speed": 1.5,
     
@@ -218,9 +220,6 @@
     
                 // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 3000. Maximum number of ticks before ending.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to mandelbrot zoom screensaver.
@@ -241,9 +240,6 @@
     
                 // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 1500. Maximum number of ticks before ending.
-                "max_ticks": 1500,
             },
     
             // Configuration specific to wave interference screensaver.
@@ -268,9 +264,6 @@
     
                 // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 2000. Maximum number of ticks before ending.
-                "max_ticks": 2000,
             },
     
             // Configuration specific to spirograph screensaver.
@@ -288,9 +281,6 @@
     
                 // Optional, float, default: 0.02. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.02,
-    
-                // Optional, integer, default: 2000. Maximum number of ticks before ending.
-                "max_ticks": 2000,
             },
     
             // Configuration specific to lorenz attractor screensaver.
@@ -320,9 +310,6 @@
     
                 // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 3000. Maximum number of ticks before ending.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to metaballs screensaver.
@@ -343,9 +330,6 @@
     
                 // Optional, float, default: 0.04. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.04,
-    
-                // Optional, integer, default: 2000. Maximum number of ticks before ending.
-                "max_ticks": 2000,
             },
     
             // Configuration specific to starfield screensaver.
@@ -366,9 +350,6 @@
     
                 // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 3000. Maximum number of ticks before ending.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to matrix rain screensaver.
@@ -399,9 +380,6 @@
     
                 // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 3000. Maximum number of ticks before ending.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to melting clock screensaver.
@@ -434,9 +412,6 @@
     
                 // Optional, float, default: 0.05. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 5000. Maximum number of ticks before ending.
-                "max_ticks": 5000,
             },
     
             // Configuration specific to aurora borealis screensaver.
@@ -457,9 +432,6 @@
     
                 // Optional, float, default: 0.04. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.04,
-    
-                // Optional, integer, default: 3000. Maximum number of ticks before ending.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to shadebobs screensaver.
@@ -474,9 +446,6 @@
     
                 // Optional, float, default: 0.03. How long to sleep between ticks, in seconds.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 2000. Maximum number of ticks before ending.
-                "max_ticks": 2000,
             },
     
             // Configuration specific to flow field screensaver.
@@ -493,9 +462,6 @@
     
                 // Optional, float, default: 0.03. Tick sleep time.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 2500. Maximum ticks.
-                "max_ticks": 2500,
             },
     
             // Configuration specific to lava lamp screensaver.
@@ -515,9 +481,6 @@
     
                 // Optional, float, default: 0.05. Tick sleep time.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 3000. Maximum ticks.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to reaction diffusion screensaver.
@@ -534,9 +497,6 @@
     
                 // Optional, float, default: 0.05. Tick sleep time.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 2000. Maximum ticks.
-                "max_ticks": 2000,
             },
     
             // Configuration specific to ink in water screensaver.
@@ -556,9 +516,6 @@
     
                 // Optional, float, default: 0.04. Tick sleep time.
                 "tick_sleep": 0.04,
-    
-                // Optional, integer, default: 2500. Maximum ticks.
-                "max_ticks": 2500,
             },
     
             // Configuration specific to perlin worms screensaver.
@@ -587,9 +544,6 @@
     
                 // Optional, float, default: 0.03. Tick sleep time.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 10000. Maximum ticks.
-                "max_ticks": 10000,
             },
     
             // Configuration specific to pendulum waves screensaver.
@@ -615,9 +569,6 @@
     
                 // Optional, float, default: 0.03. Tick sleep time.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 10000. Maximum ticks.
-                "max_ticks": 10000,
             },
     
             // Configuration specific to string art screensaver.
@@ -643,9 +594,6 @@
     
                 // Optional, float, default: 0.03. Tick sleep time.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 10000. Maximum ticks.
-                "max_ticks": 10000,
             },
     
             // Configuration specific to unknown pleasures screensaver.
@@ -674,9 +622,6 @@
     
                 // Optional, float, default: 0.05. Tick sleep time.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 10000. Maximum ticks.
-                "max_ticks": 10000,
             },
     
             // Configuration specific to cloudscape screensaver.
@@ -702,9 +647,6 @@
     
                 // Optional, float, default: 0.05. Tick sleep time.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 10000. Maximum ticks.
-                "max_ticks": 10000,
             },
     
             // Configuration specific to gradient test screensaver (for debugging flicker).
@@ -717,9 +659,6 @@
     
                 // Optional, float, default: 0.1. Tick sleep time (high = low CPU).
                 "tick_sleep": 0.1,
-    
-                // Optional, integer, default: 3000. Maximum ticks.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to DVD bounce screensaver.
@@ -746,9 +685,6 @@
     
                 // Optional, float, default: 0.03. Tick sleep time.
                 "tick_sleep": 0.03,
-    
-                // Optional, integer, default: 10000. Maximum ticks.
-                "max_ticks": 10000,
             },
     
             // Configuration specific to NYC Subway arrival times screensaver.
@@ -778,9 +714,6 @@
     
                 // Optional, float, default: 1.0. How long to sleep between display updates, in seconds.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 3000. Maximum ticks before ending screensaver.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to WFMU radio now-playing screensaver.
@@ -797,9 +730,6 @@
     
                 // Optional, float, default: 0.05. How long to sleep between display updates.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 3000. Maximum ticks before ending screensaver.
-                "max_ticks": 3000,
             },
     
             // Configuration specific to AirPlay Karaoke screensaver.
@@ -812,9 +742,6 @@
     
                 // Optional, float, default: 0.05. How long to sleep between display updates.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 6000. Maximum ticks before ending screensaver.
-                "max_ticks": 6000,
     
                 // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
                 // When false, lyrics display at a steady dimmer brightness.
@@ -835,9 +762,6 @@
     
                 // Optional, float, default: 0.05. How long to sleep between display updates.
                 "tick_sleep": 0.05,
-    
-                // Optional, integer, default: 6000. Maximum ticks before ending screensaver.
-                "max_ticks": 6000,
     
                 // Optional, boolean, default: true. Whether current lyrics pulse in brightness.
                 // When false, lyrics display at a steady dimmer brightness.

--- a/default_config.json
+++ b/default_config.json
@@ -107,6 +107,7 @@
         // Each screensaver will end after this many seconds and rotate to the next one.
         // Set to null or 0 to disable (screensavers run indefinitely).
         // Can be overridden per-screensaver via screensavers.configs.<id>.timeout.
+        // A per-screensaver timeout of null falls back to this global value.
         "timeout": 120,
 
         // Configuration for transitions between screensavers.

--- a/pifi/config.py
+++ b/pifi/config.py
@@ -149,10 +149,22 @@ class Config:
         """
         Reload config overrides from the database.
 
-        Reads JSON from the given SettingsDb keys and updates the stored
-        overrides for those keys. Then resets config to base values and
-        re-applies all known overrides. This supports partial reloads —
-        reloading one set of DB keys won't affect overrides from other keys.
+        Reads JSON from the given SettingsDb keys and deep-merges them into
+        the base config. Supports partial reloads — reloading one set of DB
+        keys won't affect overrides from other keys. Skips the rebuild if the
+        raw DB values haven't changed since the last call (string comparison).
+
+        Multi-process architecture:
+            The Server, Queue, and WebSocket Server run as separate processes
+            sharing a SQLite database as the source of truth for config overrides.
+
+            - Server process: Only the Server writes config overrides to the DB.
+              It calls reload_overrides() once at startup (to load overrides from
+              a previous session) and after each write, so reads always use a
+              fresh cache without needing reload_overrides() before every read.
+
+            - Queue process: Reads config that the Server may have changed. Must
+              call reload_overrides() before reads to pick up changes from the DB.
 
         Args:
             db_keys: list of SettingsDb key constants to read overrides from.

--- a/pifi/config.py
+++ b/pifi/config.py
@@ -133,18 +133,16 @@ class Config:
                 d1[k] = d2[k]
 
     @staticmethod
-    def reload_screensaver_overrides():
+    def reload_overrides(db_keys):
         """
-        Reload screensaver config overrides from the database.
+        Reload config overrides from the database.
 
-        This should be called before playing a screensaver to pick up
-        any changes made via the settings UI.
+        Reads JSON from the given SettingsDb keys and merges them into the
+        config tree. Previously applied overrides are restored to base
+        values before new ones are applied.
 
-        The database stores overrides in the format:
-        {screensaver_id: {key: value, ...}, ...}
-
-        These are merged into the config, so boids.num_boids in the
-        database override would be applied to Config['boids']['num_boids'].
+        Args:
+            db_keys: list of SettingsDb key constants to read overrides from.
         """
         Config.load_config_if_not_loaded()
 
@@ -153,58 +151,24 @@ class Config:
 
         settings_db = SettingsDb()
 
-        # Apply per-screensaver config overrides
-        overrides_json = settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
-
-        all_overrides = {}
-        if overrides_json:
-            try:
-                all_overrides = json.loads(overrides_json)
-            except (json.JSONDecodeError, TypeError):
-                Config.__logger.warning("Failed to parse screensaver config overrides")
-
         # Restore previously overridden sections to their base values
-        for sid in Config.__previously_overridden:
-            if sid in Config.__base_config:
-                Config.__config[sid] = copy.deepcopy(Config.__base_config[sid])
-            elif sid in Config.__config:
-                del Config.__config[sid]
+        for key in Config.__previously_overridden:
+            if key in Config.__base_config:
+                Config.__config[key] = copy.deepcopy(Config.__base_config[key])
+            elif key in Config.__config:
+                del Config.__config[key]
 
-        Config.__previously_overridden = set()
+        # Collect overrides from all sources
+        all_overrides = {}
+        for db_key in db_keys:
+            raw = settings_db.get(db_key)
+            if raw:
+                try:
+                    all_overrides.update(json.loads(raw))
+                except (json.JSONDecodeError, TypeError):
+                    Config.__logger.warning(f"Failed to parse {db_key} overrides")
 
-        # Apply each screensaver's overrides to the config
-        for screensaver_id, overrides in all_overrides.items():
-            if not isinstance(overrides, dict):
-                continue
-
-            if screensaver_id not in Config.__config:
-                Config.__config[screensaver_id] = {}
-            elif not isinstance(Config.__config[screensaver_id], dict):
-                Config.__config[screensaver_id] = {}
-
-            Config.__config[screensaver_id].update(overrides)
-            Config.__previously_overridden.add(screensaver_id)
-
-        Config.__logger.debug(f"Applied screensaver config overrides: {all_overrides}")
-
-        # Apply global settings overrides (screensavers.dwell_time, transitions.*)
-        global_json = settings_db.get(SettingsDb.GLOBAL_SETTINGS)
-        if global_json:
-            try:
-                global_overrides = json.loads(global_json)
-            except (json.JSONDecodeError, TypeError):
-                Config.__logger.warning("Failed to parse global settings overrides")
-                global_overrides = {}
-
-            for key, value in global_overrides.items():
-                if not isinstance(value, dict):
-                    continue
-
-                if key not in Config.__config:
-                    Config.__config[key] = {}
-                elif not isinstance(Config.__config[key], dict):
-                    Config.__config[key] = {}
-
-                Config.__config[key].update(value)
-
-            Config.__logger.debug(f"Applied global settings overrides: {global_overrides}")
+        # Apply and track
+        Config.__merge_dicts(Config.__config, all_overrides)
+        Config.__previously_overridden = set(all_overrides.keys())
+        Config.__logger.debug(f"Applied config overrides: {all_overrides}")

--- a/pifi/config.py
+++ b/pifi/config.py
@@ -13,7 +13,7 @@ class Config:
     __is_loaded = False
     __config = {}
     __base_config = {}
-    __previously_overridden = set()
+    __applied_overrides = {}  # {db_key: raw_json_string}
     __logger = Logger().set_namespace('Config')
     __PATH_SEP = '.'
 
@@ -137,9 +137,10 @@ class Config:
         """
         Reload config overrides from the database.
 
-        Reads JSON from the given SettingsDb keys and merges them into the
-        config tree. Previously applied overrides are restored to base
-        values before new ones are applied.
+        Reads JSON from the given SettingsDb keys and updates the stored
+        overrides for those keys. Then resets config to base values and
+        re-applies all known overrides. This supports partial reloads —
+        reloading one set of DB keys won't affect overrides from other keys.
 
         Args:
             db_keys: list of SettingsDb key constants to read overrides from.
@@ -151,24 +152,24 @@ class Config:
 
         settings_db = SettingsDb()
 
-        # Restore previously overridden sections to their base values
-        for key in Config.__previously_overridden:
-            if key in Config.__base_config:
-                Config.__config[key] = copy.deepcopy(Config.__base_config[key])
-            elif key in Config.__config:
-                del Config.__config[key]
-
-        # Collect overrides from all sources
-        all_overrides = {}
+        # Check if any DB values changed since last reload
+        changed = False
         for db_key in db_keys:
             raw = settings_db.get(db_key)
-            if raw:
-                try:
-                    all_overrides.update(json.loads(raw))
-                except (json.JSONDecodeError, TypeError):
-                    Config.__logger.warning(f"Failed to parse {db_key} overrides")
+            if raw != Config.__applied_overrides.get(db_key):
+                changed = True
+                if raw:
+                    Config.__applied_overrides[db_key] = raw
+                else:
+                    Config.__applied_overrides.pop(db_key, None)
 
-        # Apply and track
-        Config.__merge_dicts(Config.__config, all_overrides)
-        Config.__previously_overridden = set(all_overrides.keys())
-        Config.__logger.debug(f"Applied config overrides: {all_overrides}")
+        if not changed:
+            return
+
+        # Reset to base and re-apply all known overrides
+        Config.__config = copy.deepcopy(Config.__base_config)
+        for raw in Config.__applied_overrides.values():
+            try:
+                Config.__merge_dicts(Config.__config, json.loads(raw))
+            except (json.JSONDecodeError, TypeError):
+                Config.__logger.warning(f"Failed to parse overrides: {raw[:100]}")

--- a/pifi/config.py
+++ b/pifi/config.py
@@ -152,6 +152,8 @@ class Config:
         from pifi.settingsdb import SettingsDb
 
         settings_db = SettingsDb()
+
+        # Apply per-screensaver config overrides
         overrides_json = settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
 
         all_overrides = {}
@@ -175,14 +177,34 @@ class Config:
             if not isinstance(overrides, dict):
                 continue
 
-            # Get the existing screensaver config section
             if screensaver_id not in Config.__config:
                 Config.__config[screensaver_id] = {}
             elif not isinstance(Config.__config[screensaver_id], dict):
                 Config.__config[screensaver_id] = {}
 
-            # Merge overrides into the screensaver config
             Config.__config[screensaver_id].update(overrides)
             Config.__previously_overridden.add(screensaver_id)
 
         Config.__logger.debug(f"Applied screensaver config overrides: {all_overrides}")
+
+        # Apply global settings overrides (screensavers.dwell_time, transitions.*)
+        global_json = settings_db.get(SettingsDb.GLOBAL_SETTINGS)
+        if global_json:
+            try:
+                global_overrides = json.loads(global_json)
+            except (json.JSONDecodeError, TypeError):
+                Config.__logger.warning("Failed to parse global settings overrides")
+                global_overrides = {}
+
+            for key, value in global_overrides.items():
+                if not isinstance(value, dict):
+                    continue
+
+                if key not in Config.__config:
+                    Config.__config[key] = {}
+                elif not isinstance(Config.__config[key], dict):
+                    Config.__config[key] = {}
+
+                Config.__config[key].update(value)
+
+            Config.__logger.debug(f"Applied global settings overrides: {global_overrides}")

--- a/pifi/config.py
+++ b/pifi/config.py
@@ -60,6 +60,18 @@ class Config:
         Config.__is_loaded = True
 
     @staticmethod
+    def get_default(key, default = None):
+        """Get a key's value from the base config (before any runtime overrides)."""
+        Config.load_config_if_not_loaded()
+        config = Config.__base_config
+        for part in key.split(Config.__PATH_SEP):
+            if isinstance(config, dict) and part in config:
+                config = config[part]
+            else:
+                return default
+        return config
+
+    @staticmethod
     def __get(key, should_throw = False, default = None):
         Config.load_config_if_not_loaded()
 

--- a/pifi/config.py
+++ b/pifi/config.py
@@ -62,20 +62,13 @@ class Config:
     @staticmethod
     def get_default(key, default = None):
         """Get a key's value from the base config (before any runtime overrides)."""
-        Config.load_config_if_not_loaded()
-        config = Config.__base_config
-        for part in key.split(Config.__PATH_SEP):
-            if isinstance(config, dict) and part in config:
-                config = config[part]
-            else:
-                return default
-        return config
+        return Config.__get(key, default=default, config_dict=Config.__base_config)
 
     @staticmethod
-    def __get(key, should_throw = False, default = None):
+    def __get(key, should_throw = False, default = None, config_dict = None):
         Config.load_config_if_not_loaded()
 
-        config = Config.__config
+        config = config_dict if config_dict is not None else Config.__config
         for key in key.split(Config.__PATH_SEP):
             if key in config:
                 config = config[key]

--- a/pifi/led/ledframeplayer.py
+++ b/pifi/led/ledframeplayer.py
@@ -14,8 +14,7 @@ class LedFramePlayer:
     __FADE_STEPS = 5
 
     # clear_screen: whether to clear the screen when initializing
-    # video_color_mode: only applicable when playing videos
-    def __init__(self, clear_screen = True, video_color_mode = VideoColorMode.COLOR_MODE_COLOR):
+    def __init__(self, clear_screen = True):
         self.__current_frame = None
         self.__cached_brightness = max(0, min(100, Config.get('leds.brightness')))
         self.__last_driver_brightness = None
@@ -28,7 +27,26 @@ class LedFramePlayer:
         default_gamma = led_driver != LedDrivers.DRIVER_RGBMATRIX
         self.__gamma_enabled = Config.get('leds.gamma_enabled', default_gamma)
 
-        self.__gamma_controller = Gamma(video_color_mode = video_color_mode)
+        self.set_video_color_mode(VideoColorMode.COLOR_MODE_COLOR)
+        if led_driver == LedDrivers.DRIVER_APA102:
+            from pifi.led.drivers.driverapa102 import DriverApa102
+            self.__driver = DriverApa102(clear_screen)
+        elif led_driver == LedDrivers.DRIVER_RGBMATRIX:
+            from pifi.led.drivers.driverrgbmatrix import DriverRgbMatrix
+            self.__driver = DriverRgbMatrix(clear_screen)
+        elif led_driver == LedDrivers.DRIVER_WS2812B:
+            from pifi.led.drivers.driverws2812b import DriverWs2812b
+            self.__driver = DriverWs2812b(clear_screen)
+        else:
+            raise Exception(f'Unsupported driver: {led_driver}.')
+
+        initial_brightness = self.__get_brightness()
+        self.__driver.set_brightness(initial_brightness)
+        self.__last_driver_brightness = initial_brightness
+
+    def set_video_color_mode(self, video_color_mode):
+        self.__gamma_controller = Gamma(video_color_mode=video_color_mode)
+        self.__video_color_mode = video_color_mode
 
         # static gamma curve
         self.__scale_red_gamma_curve = None
@@ -52,23 +70,6 @@ class LedFramePlayer:
             self.__scale_red_gamma_curves = self.__gamma_controller.scale_red_curves
             self.__scale_green_gamma_curves = self.__gamma_controller.scale_green_curves
             self.__scale_blue_gamma_curves = self.__gamma_controller.scale_blue_curves
-        if led_driver == LedDrivers.DRIVER_APA102:
-            from pifi.led.drivers.driverapa102 import DriverApa102
-            self.__driver = DriverApa102(clear_screen)
-        elif led_driver == LedDrivers.DRIVER_RGBMATRIX:
-            from pifi.led.drivers.driverrgbmatrix import DriverRgbMatrix
-            self.__driver = DriverRgbMatrix(clear_screen)
-        elif led_driver == LedDrivers.DRIVER_WS2812B:
-            from pifi.led.drivers.driverws2812b import DriverWs2812b
-            self.__driver = DriverWs2812b(clear_screen)
-        else:
-            raise Exception(f'Unsupported driver: {led_driver}.')
-
-        initial_brightness = self.__get_brightness()
-        self.__driver.set_brightness(initial_brightness)
-        self.__last_driver_brightness = initial_brightness
-
-        self.__video_color_mode = video_color_mode
 
     def clear_screen(self):
         self.__driver.clear_screen()

--- a/pifi/led/ledframeplayer.py
+++ b/pifi/led/ledframeplayer.py
@@ -74,7 +74,13 @@ class LedFramePlayer:
         self.__driver.clear_screen()
 
     def play_frame(self, frame):
+        self.__current_frame = frame
         self.__set_frame_pixels(frame)
+
+    def get_current_frame(self):
+        if self.__current_frame is None:
+            return None
+        return self.__current_frame.copy()
 
     def fade_to_frame(self, frame):
         if (self.__current_frame is None):

--- a/pifi/queue.py
+++ b/pifi/queue.py
@@ -230,7 +230,7 @@ class Queue:
 
     def __maybe_respond_to_settings_changes(self):
         old_is_enabled = self.__is_screensaver_enabled
-        setting = self.__settings_db.get_row(SettingsDb.SCREENSAVER_SETTING)
+        setting = self.__settings_db.get_row(SettingsDb.IS_SCREENSAVER_ENABLED)
         if (setting is None or setting['value'] == '1'):
             self.__is_screensaver_enabled = True
         else:

--- a/pifi/screensaver/airplaykaraoke.py
+++ b/pifi/screensaver/airplaykaraoke.py
@@ -24,7 +24,7 @@ class AirPlayKaraoke(KaraokeBase):
 
         # AirPlay-specific configuration
         self.__metadata_pipe = Config.get(
-            'airplay_karaoke.metadata_pipe', '/tmp/shairport-sync-metadata'
+            'screensavers.configs.airplay_karaoke.metadata_pipe', '/tmp/shairport-sync-metadata'
         )
         self._max_ticks = Config.get('screensavers.configs.airplay_karaoke.max_ticks', 6000)
         self._tick_sleep = Config.get('screensavers.configs.airplay_karaoke.tick_sleep', 0.05)

--- a/pifi/screensaver/airplaykaraoke.py
+++ b/pifi/screensaver/airplaykaraoke.py
@@ -26,8 +26,6 @@ class AirPlayKaraoke(KaraokeBase):
         self.__metadata_pipe = Config.get(
             'screensavers.configs.airplay_karaoke.metadata_pipe', '/tmp/shairport-sync-metadata'
         )
-        self._max_ticks = Config.get('screensavers.configs.airplay_karaoke.max_ticks', 6000)
-        self._tick_sleep = Config.get('screensavers.configs.airplay_karaoke.tick_sleep', 0.05)
         self._pulse_lyrics = Config.get('screensavers.configs.airplay_karaoke.pulse_lyrics', True)
 
         # Pending album art — PICT arrives before mden, so we stage it
@@ -152,7 +150,7 @@ class AirPlayKaraoke(KaraokeBase):
                 return
             elif item_code == 'mden':
                 # Metadata batch complete — write to class-level state so it
-                # survives max_ticks instance restarts.
+                # survives instance restarts.
                 with self._poll_lock:
                     if 'title' in pending_metadata:
                         new_title = pending_metadata['title']

--- a/pifi/screensaver/airplaykaraoke.py
+++ b/pifi/screensaver/airplaykaraoke.py
@@ -26,9 +26,9 @@ class AirPlayKaraoke(KaraokeBase):
         self.__metadata_pipe = Config.get(
             'airplay_karaoke.metadata_pipe', '/tmp/shairport-sync-metadata'
         )
-        self._max_ticks = Config.get('airplay_karaoke.max_ticks', 6000)
-        self._tick_sleep = Config.get('airplay_karaoke.tick_sleep', 0.05)
-        self._pulse_lyrics = Config.get('airplay_karaoke.pulse_lyrics', True)
+        self._max_ticks = Config.get('screensavers.configs.airplay_karaoke.max_ticks', 6000)
+        self._tick_sleep = Config.get('screensavers.configs.airplay_karaoke.tick_sleep', 0.05)
+        self._pulse_lyrics = Config.get('screensavers.configs.airplay_karaoke.pulse_lyrics', True)
 
         # Pending album art — PICT arrives before mden, so we stage it
         # here and apply (or clear) in the mden handler on title change.

--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -23,7 +21,6 @@ class Aurora(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -46,19 +43,31 @@ class Aurora(Screensaver):
         self.__activity = 1.0
         self.__target_activity = 1.0
 
-    def play(self):
-        self.__logger.info("Starting Aurora screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.aurora.max_ticks', 3000)
-        tick = 0
+    def _tick(self, tick):
+        time_speed = Config.get('screensavers.configs.aurora.time_speed', 1.0)
+        self.__time += 0.05 * time_speed
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Occasionally change activity level (bursts)
+        if random.random() < 0.005:
+            self.__target_activity = random.uniform(0.5, 2.0)
 
-        self.__logger.info("Aurora screensaver ended")
+        # Smooth activity transitions
+        self.__activity += (self.__target_activity - self.__activity) * 0.02
+
+        # Update curtain drift
+        for curtain in self.__curtains:
+            curtain['base_x'] += curtain['drift_speed']
+
+            # Wrap around or bounce
+            if curtain['base_x'] < -0.2:
+                curtain['base_x'] = 1.2
+            elif curtain['base_x'] > 1.2:
+                curtain['base_x'] = -0.2
+
+        self.__render()
 
     def __reset(self):
         self.__time = 0.0
@@ -119,29 +128,6 @@ class Aurora(Screensaver):
             # Shimmer properties
             'shimmer_speed': random.uniform(2.0, 5.0),
         }
-
-    def __tick(self):
-        time_speed = Config.get('screensavers.configs.aurora.time_speed', 1.0)
-        self.__time += 0.05 * time_speed
-
-        # Occasionally change activity level (bursts)
-        if random.random() < 0.005:
-            self.__target_activity = random.uniform(0.5, 2.0)
-
-        # Smooth activity transitions
-        self.__activity += (self.__target_activity - self.__activity) * 0.02
-
-        # Update curtain drift
-        for curtain in self.__curtains:
-            curtain['base_x'] += curtain['drift_speed']
-
-            # Wrap around or bounce
-            if curtain['base_x'] < -0.2:
-                curtain['base_x'] = 1.2
-            elif curtain['base_x'] > 1.2:
-                curtain['base_x'] = -0.2
-
-        self.__render()
 
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], dtype=np.float32)
@@ -245,9 +231,6 @@ class Aurora(Screensaver):
                         frame[y, x, 0] = min(255, frame[y, x, 0] + r * brightness * 255)
                         frame[y, x, 1] = min(255, frame[y, x, 1] + g * brightness * 255)
                         frame[y, x, 2] = min(255, frame[y, x, 2] + b * brightness * 255)
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.aurora.tick_sleep', 0.04)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -53,7 +53,7 @@ class Aurora(Screensaver):
         max_ticks = Config.get('aurora.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -21,11 +20,6 @@ class Aurora(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -154,7 +148,7 @@ class Aurora(Screensaver):
 
         # Convert to uint8
         frame = np.clip(frame, 0, 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __draw_curtain(self, frame, curtain):
         """Draw a single aurora curtain onto the frame."""

--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -50,7 +50,7 @@ class Aurora(Screensaver):
         self.__logger.info("Starting Aurora screensaver")
         self.__reset()
 
-        max_ticks = Config.get('aurora.max_ticks', 3000)
+        max_ticks = Config.get('screensavers.configs.aurora.max_ticks', 3000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -66,15 +66,15 @@ class Aurora(Screensaver):
         self.__target_activity = 1.0
 
         # Create curtains
-        num_curtains = Config.get('aurora.num_curtains', 4)
+        num_curtains = Config.get('screensavers.configs.aurora.num_curtains', 4)
         self.__curtains = []
 
         for i in range(num_curtains):
             self.__curtains.append(self.__create_curtain(i, num_curtains))
 
         # Create background stars
-        if Config.get('aurora.show_stars', True):
-            num_stars = Config.get('aurora.num_stars', 15)
+        if Config.get('screensavers.configs.aurora.show_stars', True):
+            num_stars = Config.get('screensavers.configs.aurora.num_stars', 15)
             self.__stars = []
             for _ in range(num_stars):
                 self.__stars.append({
@@ -121,7 +121,7 @@ class Aurora(Screensaver):
         }
 
     def __tick(self):
-        time_speed = Config.get('aurora.time_speed', 1.0)
+        time_speed = Config.get('screensavers.configs.aurora.time_speed', 1.0)
         self.__time += 0.05 * time_speed
 
         # Occasionally change activity level (bursts)
@@ -147,7 +147,7 @@ class Aurora(Screensaver):
         frame = np.zeros([self.__height, self.__width, 3], dtype=np.float32)
 
         # Draw background stars first
-        if Config.get('aurora.show_stars', True):
+        if Config.get('screensavers.configs.aurora.show_stars', True):
             for star in self.__stars:
                 # Twinkle
                 twinkle = 0.5 + 0.5 * math.sin(self.__time * star['twinkle_speed'] * 10 + star['twinkle_phase'])
@@ -247,7 +247,7 @@ class Aurora(Screensaver):
                         frame[y, x, 2] = min(255, frame[y, x, 2] + b * brightness * 255)
 
     def __get_tick_sleep(self):
-        return Config.get('aurora.tick_sleep', 0.04)
+        return Config.get('screensavers.configs.aurora.tick_sleep', 0.04)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -53,7 +53,7 @@ class Aurora(Screensaver):
         max_ticks = Config.get('aurora.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -1,9 +1,7 @@
 import math
 import numpy as np
-import time
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,7 +18,6 @@ class Boids(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -33,19 +30,13 @@ class Boids(Screensaver):
         self.__positions = None
         self.__velocities = None
 
-    def play(self):
-        self.__logger.info("Starting Boids screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.boids.max_ticks', 2000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Boids screensaver ended")
+    def _tick(self, tick):
+        self.__update_velocities()
+        self.__update_positions()
+        self.__render()
 
     def __reset(self):
         num_boids = Config.get('screensavers.configs.boids.num_boids', 15)
@@ -63,11 +54,6 @@ class Boids(Screensaver):
             np.cos(angles) * speeds,
             np.sin(angles) * speeds
         ])
-
-    def __tick(self):
-        self.__update_velocities()
-        self.__update_positions()
-        self.__render()
 
     def __update_velocities(self):
         separation = self.__calculate_separation()
@@ -204,9 +190,6 @@ class Boids(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.boids.tick_sleep', 0.05)
 
     def __get_max_speed(self):
         return Config.get('screensavers.configs.boids.max_speed', 1.5)

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -40,7 +40,7 @@ class Boids(Screensaver):
         max_ticks = Config.get('boids.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -40,7 +40,7 @@ class Boids(Screensaver):
         max_ticks = Config.get('boids.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -2,7 +2,6 @@ import math
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,11 +17,6 @@ class Boids(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -162,7 +156,7 @@ class Boids(Screensaver):
             rgb = self.__hsv_to_rgb(hue, 1.0, 1.0)
             frame[y, x] = rgb
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV color to RGB."""

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -37,7 +37,7 @@ class Boids(Screensaver):
         self.__logger.info("Starting Boids screensaver")
         self.__reset()
 
-        max_ticks = Config.get('boids.max_ticks', 2000)
+        max_ticks = Config.get('screensavers.configs.boids.max_ticks', 2000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -48,7 +48,7 @@ class Boids(Screensaver):
         self.__logger.info("Boids screensaver ended")
 
     def __reset(self):
-        num_boids = Config.get('boids.num_boids', 15)
+        num_boids = Config.get('screensavers.configs.boids.num_boids', 15)
 
         # Initialize random positions across the display
         self.__positions = np.random.rand(num_boids, 2)
@@ -74,9 +74,9 @@ class Boids(Screensaver):
         alignment = self.__calculate_alignment()
         cohesion = self.__calculate_cohesion()
 
-        sep_weight = Config.get('boids.separation_weight', 1.5)
-        align_weight = Config.get('boids.alignment_weight', 1.0)
-        coh_weight = Config.get('boids.cohesion_weight', 1.0)
+        sep_weight = Config.get('screensavers.configs.boids.separation_weight', 1.5)
+        align_weight = Config.get('screensavers.configs.boids.alignment_weight', 1.0)
+        coh_weight = Config.get('screensavers.configs.boids.cohesion_weight', 1.0)
 
         self.__velocities += (
             separation * sep_weight +
@@ -96,7 +96,7 @@ class Boids(Screensaver):
         num_boids = len(self.__positions)
         separation = np.zeros_like(self.__velocities)
 
-        min_distance = Config.get('boids.min_distance', 2.0)
+        min_distance = Config.get('screensavers.configs.boids.min_distance', 2.0)
 
         for i in range(num_boids):
             diff = self.__positions[i] - self.__positions
@@ -206,13 +206,13 @@ class Boids(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('boids.tick_sleep', 0.05)
+        return Config.get('screensavers.configs.boids.tick_sleep', 0.05)
 
     def __get_max_speed(self):
-        return Config.get('boids.max_speed', 1.5)
+        return Config.get('screensavers.configs.boids.max_speed', 1.5)
 
     def __get_perception_radius(self):
-        return Config.get('boids.perception_radius', 8.0)
+        return Config.get('screensavers.configs.boids.perception_radius', 8.0)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -22,42 +22,15 @@ class CellularAutomaton(Screensaver, ABC):
         else:
             self.__led_frame_player = led_frame_player
 
-    def play(self, should_loop = False):
-        if should_loop:
-            while True:
-                self.tick(should_loop = should_loop)
-        else:
-            self.__reset()
-            while True:
-                if not self.tick():
-                    break
-
-    # return False when the game is over, True otherwise.
-    def tick(self, should_loop = False, force_reset = False):
-        is_game_in_progress = True
-        if self._board is None or force_reset:
-            # start the game
-            self.__reset()
-        else:
-            self.__tick_internal()
-
-        self.__do_tick_bookkeeping()
-
-        if self.__is_game_over():
-            if should_loop:
-                self.__reset()
-                self.__do_tick_bookkeeping()
-                is_game_in_progress = True
-            else:
-                is_game_in_progress = False
-
-        time.sleep(self._get_tick_sleep_seconds())
-
-        return is_game_in_progress
-
-    def __tick_internal(self):
-        self._update_board()
-        self.__show_board()
+    def play(self):
+        self.__reset()
+        while True:
+            self._update_board()
+            self.__show_board()
+            self.__do_tick_bookkeeping()
+            if self.__is_game_over():
+                break
+            time.sleep(self._get_tick_sleep_seconds())
 
     def __do_tick_bookkeeping(self):
         self._num_ticks += 1

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -79,8 +79,8 @@ class CellularAutomaton(Screensaver, ABC):
         return hashlib.md5(self._board).hexdigest()
 
     def __is_game_over(self):
-        if self._is_past_dwell_time():
-            self._logger.info("Game over due to dwell time exceeded.")
+        if self._is_past_screensaver_timeout():
+            self._logger.info("Game over due to screensaver timeout exceeded.")
             return True
 
         if self._get_max_game_length_seconds() > 0 and (time.time() - self.__start_time) > self._get_max_game_length_seconds():

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -3,7 +3,6 @@ import hashlib
 import time
 
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.datastructure.limitedsizedict import LimitedSizeDict
 from pifi.screensaver.screensaver import Screensaver
 
@@ -17,10 +16,6 @@ class CellularAutomaton(Screensaver, ABC):
         super().__init__(led_frame_player)
         self._logger = Logger().set_namespace(self.__class__.__name__)
         self._board = None
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
     def _setup(self):
         self.__reset()
@@ -44,9 +39,9 @@ class CellularAutomaton(Screensaver, ABC):
         frame = self._board_to_frame()
 
         if self._should_fade_to_frame():
-            self.__led_frame_player.fade_to_frame(frame)
+            self._led_frame_player.fade_to_frame(frame)
         else:
-            self.__led_frame_player.play_frame(frame)
+            self._led_frame_player.play_frame(frame)
 
     def __get_board_hash(self):
         return hashlib.md5(self._board).hexdigest()

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -79,6 +79,10 @@ class CellularAutomaton(Screensaver, ABC):
         return hashlib.md5(self._board).hexdigest()
 
     def __is_game_over(self):
+        if self._is_past_dwell_time():
+            self._logger.info("Game over due to dwell time exceeded.")
+            return True
+
         if self._get_max_game_length_seconds() > 0 and (time.time() - self.__start_time) > self._get_max_game_length_seconds():
             self._logger.info("Game over due to timeout expiration.")
             return True

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -22,15 +22,15 @@ class CellularAutomaton(Screensaver, ABC):
         else:
             self.__led_frame_player = led_frame_player
 
-    def play(self):
+    def _setup(self):
         self.__reset()
-        while True:
-            self._update_board()
-            self.__show_board()
-            self.__do_tick_bookkeeping()
-            if self.__is_game_over():
-                break
-            time.sleep(self._get_tick_sleep_seconds())
+
+    def _tick(self, tick):
+        self._update_board()
+        self.__show_board()
+        self.__do_tick_bookkeeping()
+        if self.__should_reset_game():
+            self.__reset()
 
     def __do_tick_bookkeeping(self):
         self._num_ticks += 1
@@ -51,24 +51,20 @@ class CellularAutomaton(Screensaver, ABC):
     def __get_board_hash(self):
         return hashlib.md5(self._board).hexdigest()
 
-    def __is_game_over(self):
-        if self._is_past_screensaver_timeout():
-            self._logger.info("Game over due to screensaver timeout exceeded.")
-            return True
-
-        if self._get_max_game_length_seconds() > 0 and (time.time() - self.__start_time) > self._get_max_game_length_seconds():
-            self._logger.info("Game over due to timeout expiration.")
+    def __should_reset_game(self):
+        if self._get_max_game_length_seconds() > 0 and (time.time() - self.__game_start_time) > self._get_max_game_length_seconds():
+            self._logger.info("Resetting game due to per-game time limit.")
             return True
 
         if self.__prev_board_state_counts[self.__get_board_hash()] > self._get_max_state_repetitions_for_game_over():
-            self._logger.info("Game over detected. Current board state has repeated at least " +
+            self._logger.info("Resetting game. Current board state has repeated at least " +
                 f"{self._get_max_state_repetitions_for_game_over()} times.")
             return True
         return False
 
     def __reset(self):
         self._logger.info("Starting new game.")
-        self.__start_time = time.time()
+        self.__game_start_time = time.time()
         self._num_ticks = 0
         self.__prev_board_state_counts = LimitedSizeDict(capacity = self._get_game_over_detection_lookback_amount())
 
@@ -94,10 +90,6 @@ class CellularAutomaton(Screensaver, ABC):
 
     @abstractmethod
     def _update_board(self):
-        pass
-
-    @abstractmethod
-    def _get_tick_sleep_seconds(self):
         pass
 
     @abstractmethod

--- a/pifi/screensaver/cellularautomata/cyclicautomaton.py
+++ b/pifi/screensaver/cellularautomata/cyclicautomaton.py
@@ -9,13 +9,13 @@ from pifi.screensaver.cellularautomata.cellularautomaton import CellularAutomato
 class CyclicAutomaton(CellularAutomaton):
 
     def _get_tick_sleep_seconds(self):
-        return Config.get('cyclic_automaton.tick_sleep')
+        return Config.get('screensavers.configs.cyclic_automaton.tick_sleep')
 
     def _get_game_over_detection_lookback_amount(self):
-        return Config.get('cyclic_automaton.game_over_detection_lookback')
+        return Config.get('screensavers.configs.cyclic_automaton.game_over_detection_lookback')
 
     def _should_fade_to_frame(self):
-        return Config.get('cyclic_automaton.fade')
+        return Config.get('screensavers.configs.cyclic_automaton.fade')
 
     def _get_max_game_length_seconds(self):
         return 60

--- a/pifi/screensaver/cellularautomata/cyclicautomaton.py
+++ b/pifi/screensaver/cellularautomata/cyclicautomaton.py
@@ -8,9 +8,6 @@ from pifi.screensaver.cellularautomata.cellularautomaton import CellularAutomato
 # https://en.wikipedia.org/wiki/Cyclic_cellular_automaton
 class CyclicAutomaton(CellularAutomaton):
 
-    def _get_tick_sleep_seconds(self):
-        return Config.get('screensavers.configs.cyclic_automaton.tick_sleep')
-
     def _get_game_over_detection_lookback_amount(self):
         return Config.get('screensavers.configs.cyclic_automaton.game_over_detection_lookback')
 

--- a/pifi/screensaver/cellularautomata/gameoflife.py
+++ b/pifi/screensaver/cellularautomata/gameoflife.py
@@ -21,19 +21,19 @@ class GameOfLife(CellularAutomaton):
         self.__game_color_helper = GameColorHelper()
 
     def _get_tick_sleep_seconds(self):
-        return Config.get('game_of_life.tick_sleep')
+        return Config.get('screensavers.configs.game_of_life.tick_sleep')
 
     def _get_game_over_detection_lookback_amount(self):
-        return Config.get('game_of_life.game_over_detection_lookback')
+        return Config.get('screensavers.configs.game_of_life.game_over_detection_lookback')
 
     def _should_fade_to_frame(self):
-        return Config.get('game_of_life.fade')
+        return Config.get('screensavers.configs.game_of_life.fade')
 
     def _reset_hook(self):
         self.__game_color_helper.reset()
-        self.__game_color_mode = GameColorHelper.determine_game_color_mode(Config.get('game_of_life.game_color_mode'))
+        self.__game_color_mode = GameColorHelper.determine_game_color_mode(Config.get('screensavers.configs.game_of_life.game_color_mode'))
 
-        variant = Config.get('game_of_life.variant')
+        variant = Config.get('screensavers.configs.game_of_life.variant')
         if variant in self.VARIANTS:
             self.__variant = variant
         else:
@@ -45,7 +45,7 @@ class GameOfLife(CellularAutomaton):
         # neighborhood calculation and avoid edge checks.
         shape = [Config.get_or_throw('leds.display_height') + 2, Config.get_or_throw('leds.display_width') + 2]
         self._board = np.zeros(shape, np.uint8)
-        probability = Config.get('game_of_life.seed_liveness_probability')
+        probability = Config.get('screensavers.configs.game_of_life.seed_liveness_probability')
         if self.__variant == self.__VARIANT_IMMIGRATION:
             seed = np.random.random_sample([x - 2 for x in shape]) < (probability / 2)
             seed2 = np.random.random_sample([x - 2 for x in shape]) < (probability / 2)

--- a/pifi/screensaver/cellularautomata/gameoflife.py
+++ b/pifi/screensaver/cellularautomata/gameoflife.py
@@ -20,9 +20,6 @@ class GameOfLife(CellularAutomaton):
         super().__init__(**kwargs)
         self.__game_color_helper = GameColorHelper()
 
-    def _get_tick_sleep_seconds(self):
-        return Config.get('screensavers.configs.game_of_life.tick_sleep')
-
     def _get_game_over_detection_lookback_amount(self):
         return Config.get('screensavers.configs.game_of_life.game_over_detection_lookback')
 

--- a/pifi/screensaver/cloudscape.py
+++ b/pifi/screensaver/cloudscape.py
@@ -10,7 +10,6 @@ Optimized for low-power devices with buffer reuse and caching.
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,10 +18,6 @@ class Cloudscape(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -239,7 +234,7 @@ class Cloudscape(Screensaver):
         # Convert to uint8 output
         np.clip(self.__frame, 0, 255, out=self.__frame)
         np.copyto(self.__output_frame, self.__frame.astype(np.uint8))
-        self.__led_frame_player.play_frame(self.__output_frame)
+        self._led_frame_player.play_frame(self.__output_frame)
 
     def _setup(self):
         """Initialize noise and reset state."""

--- a/pifi/screensaver/cloudscape.py
+++ b/pifi/screensaver/cloudscape.py
@@ -31,14 +31,14 @@ class Cloudscape(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Config
-        self.__num_layers = Config.get('cloudscape.num_layers', 3)
-        self.__drift_speed = Config.get('cloudscape.drift_speed', 0.2)
-        self.__sky_mode = Config.get('cloudscape.sky_mode', 'pastel')
-        self.__cloud_density = Config.get('cloudscape.cloud_density', 0.7)
-        self.__cloud_scale = Config.get('cloudscape.cloud_scale', 0.04)
-        self.__sky_shift_speed = Config.get('cloudscape.sky_shift_speed', 0.001)
-        self.__tick_sleep = Config.get('cloudscape.tick_sleep', 0.05)
-        self.__max_ticks = Config.get('cloudscape.max_ticks', 10000)
+        self.__num_layers = Config.get('screensavers.configs.cloudscape.num_layers', 3)
+        self.__drift_speed = Config.get('screensavers.configs.cloudscape.drift_speed', 0.2)
+        self.__sky_mode = Config.get('screensavers.configs.cloudscape.sky_mode', 'pastel')
+        self.__cloud_density = Config.get('screensavers.configs.cloudscape.cloud_density', 0.7)
+        self.__cloud_scale = Config.get('screensavers.configs.cloudscape.cloud_scale', 0.04)
+        self.__sky_shift_speed = Config.get('screensavers.configs.cloudscape.sky_shift_speed', 0.001)
+        self.__tick_sleep = Config.get('screensavers.configs.cloudscape.tick_sleep', 0.05)
+        self.__max_ticks = Config.get('screensavers.configs.cloudscape.max_ticks', 10000)
 
         # Pre-compute coordinate grids (reused every frame)
         self.__x_grid, self.__y_grid = np.meshgrid(

--- a/pifi/screensaver/cloudscape.py
+++ b/pifi/screensaver/cloudscape.py
@@ -8,11 +8,9 @@ Optimized for low-power devices with buffer reuse and caching.
 """
 
 import numpy as np
-import time
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -21,7 +19,6 @@ class Cloudscape(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -37,8 +34,6 @@ class Cloudscape(Screensaver):
         self.__cloud_density = Config.get('screensavers.configs.cloudscape.cloud_density', 0.7)
         self.__cloud_scale = Config.get('screensavers.configs.cloudscape.cloud_scale', 0.04)
         self.__sky_shift_speed = Config.get('screensavers.configs.cloudscape.sky_shift_speed', 0.001)
-        self.__tick_sleep = Config.get('screensavers.configs.cloudscape.tick_sleep', 0.05)
-        self.__max_ticks = Config.get('screensavers.configs.cloudscape.max_ticks', 10000)
 
         # Pre-compute coordinate grids (reused every frame)
         self.__x_grid, self.__y_grid = np.meshgrid(
@@ -246,23 +241,16 @@ class Cloudscape(Screensaver):
         np.copyto(self.__output_frame, self.__frame.astype(np.uint8))
         self.__led_frame_player.play_frame(self.__output_frame)
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting Cloudscape screensaver")
-
-        # Initialize
+    def _setup(self):
+        """Initialize noise and reset state."""
         self.__perm = self.__generate_permutation()
         self.__time = 0.0
         self.__sky_cache_tick = -1
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            self.__time += 1
-            self.__render(tick)
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("Cloudscape screensaver ended")
+    def _tick(self, tick):
+        """Advance time and render one frame."""
+        self.__time += 1
+        self.__render(tick)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/cloudscape.py
+++ b/pifi/screensaver/cloudscape.py
@@ -256,6 +256,8 @@ class Cloudscape(Screensaver):
         self.__sky_cache_tick = -1
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             self.__time += 1
             self.__render(tick)
             time.sleep(self.__tick_sleep)

--- a/pifi/screensaver/cloudscape.py
+++ b/pifi/screensaver/cloudscape.py
@@ -256,7 +256,7 @@ class Cloudscape(Screensaver):
         self.__sky_cache_tick = -1
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             self.__time += 1
             self.__render(tick)

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -59,7 +59,7 @@ class CosmicDream(Screensaver):
         max_ticks = Config.get('cosmic_dream.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -3,7 +3,6 @@ import numpy as np
 import time
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -22,11 +21,6 @@ class CosmicDream(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -65,7 +59,7 @@ class CosmicDream(Screensaver):
         # Apply global color cycling / hue shift
         frame = self.__apply_color_cycle(frame, t)
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __reset(self):
         self.__start_time = time.time()

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -56,7 +56,7 @@ class CosmicDream(Screensaver):
         self.__logger.info("Starting CosmicDream screensaver")
         self.__reset()
 
-        max_ticks = Config.get('cosmic_dream.max_ticks', 3000)
+        max_ticks = Config.get('screensavers.configs.cosmic_dream.max_ticks', 3000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -71,13 +71,13 @@ class CosmicDream(Screensaver):
         self.__frame_count = 0
 
         # Initialize particles for flow field
-        num_particles = Config.get('cosmic_dream.num_particles', 20)
+        num_particles = Config.get('screensavers.configs.cosmic_dream.num_particles', 20)
         self.__particles = np.random.rand(num_particles, 2)
         self.__particles[:, 0] *= self.__width
         self.__particles[:, 1] *= self.__height
 
         # Trail buffer: stores previous positions for motion blur
-        trail_length = Config.get('cosmic_dream.trail_length', 8)
+        trail_length = Config.get('screensavers.configs.cosmic_dream.trail_length', 8)
         self.__particle_trails = np.zeros((num_particles, trail_length, 2))
         for i in range(trail_length):
             self.__particle_trails[:, i, :] = self.__particles
@@ -201,7 +201,7 @@ class CosmicDream(Screensaver):
             angle = noise_val * math.pi * 2
 
             # Move particle
-            speed = Config.get('cosmic_dream.particle_speed', 0.5)
+            speed = Config.get('screensavers.configs.cosmic_dream.particle_speed', 0.5)
             self.__particles[i, 0] += math.cos(angle) * speed
             self.__particles[i, 1] += math.sin(angle) * speed
 
@@ -358,7 +358,7 @@ class CosmicDream(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('cosmic_dream.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.cosmic_dream.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -3,7 +3,6 @@ import numpy as np
 import time
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -23,7 +22,6 @@ class CosmicDream(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -52,19 +50,22 @@ class CosmicDream(Screensaver):
         self.__start_time = None
         self.__frame_count = 0
 
-    def play(self):
-        self.__logger.info("Starting CosmicDream screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.cosmic_dream.max_ticks', 3000)
-        tick = 0
+    def _tick(self, tick):
+        t = time.time() - self.__start_time
+        self.__frame_count += 1
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Create the layered frame
+        frame = self.__render_plasma_layer(t)
+        frame = self.__blend_geometry_layer(frame, t)
+        frame = self.__blend_particle_layer(frame, t)
 
-        self.__logger.info("CosmicDream screensaver ended")
+        # Apply global color cycling / hue shift
+        frame = self.__apply_color_cycle(frame, t)
+
+        self.__led_frame_player.play_frame(frame)
 
     def __reset(self):
         self.__start_time = time.time()
@@ -84,20 +85,6 @@ class CosmicDream(Screensaver):
 
         # Random offsets for multi-octave noise
         self.__noise_offsets = np.random.rand(6) * 1000
-
-    def __tick(self):
-        t = time.time() - self.__start_time
-        self.__frame_count += 1
-
-        # Create the layered frame
-        frame = self.__render_plasma_layer(t)
-        frame = self.__blend_geometry_layer(frame, t)
-        frame = self.__blend_particle_layer(frame, t)
-
-        # Apply global color cycling / hue shift
-        frame = self.__apply_color_cycle(frame, t)
-
-        self.__led_frame_player.play_frame(frame)
 
     def __render_plasma_layer(self, t):
         """
@@ -356,9 +343,6 @@ class CosmicDream(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.cosmic_dream.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -59,7 +59,7 @@ class CosmicDream(Screensaver):
         max_ticks = Config.get('cosmic_dream.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -3,7 +3,6 @@ import random
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,11 +18,6 @@ class DvdBounce(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -184,7 +178,7 @@ class DvdBounce(Screensaver):
         if show_text and self.__logo_width >= 12 and self.__logo_height >= 3:
             self.__draw_dvd_text(frame, x_start, y_start)
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __draw_dvd_text(self, frame, x_offset, y_offset):
         """Draw simple 'DVD' text pattern in the logo."""

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -63,7 +63,7 @@ class DvdBounce(Screensaver):
         max_ticks = Config.get('dvd_bounce.max_ticks', 10000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -63,7 +63,7 @@ class DvdBounce(Screensaver):
         max_ticks = Config.get('dvd_bounce.max_ticks', 10000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -1,5 +1,4 @@
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
@@ -56,43 +55,10 @@ class DvdBounce(Screensaver):
         # Corner hit counter (for fun!)
         self.__corner_hits = 0
 
-    def play(self):
-        self.__logger.info("Starting DVD Bounce screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.dvd_bounce.max_ticks', 10000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info(f"DVD Bounce ended. Corner hits: {self.__corner_hits}")
-
-    def __reset(self):
-        """Initialize the bouncing logo."""
-        # Start at a random position
-        self.__x = random.uniform(0, self.__width - self.__logo_width)
-        self.__y = random.uniform(0, self.__height - self.__logo_height)
-
-        # Random initial velocity
-        speed = Config.get('screensavers.configs.dvd_bounce.speed', 0.5)
-        angle = random.uniform(0, 2 * np.pi)
-        self.__vx = speed * np.cos(angle)
-        self.__vy = speed * np.sin(angle)
-
-        # Ensure we're actually moving
-        if abs(self.__vx) < 0.1:
-            self.__vx = 0.3 if self.__vx >= 0 else -0.3
-        if abs(self.__vy) < 0.1:
-            self.__vy = 0.3 if self.__vy >= 0 else -0.3
-
-        # Random initial color
-        self.__color = self.__random_color()
-        self.__corner_hits = 0
-
-    def __tick(self):
+    def _tick(self, tick):
         """Update position and check for bounces."""
         # Update position
         self.__x += self.__vx
@@ -129,9 +95,31 @@ class DvdBounce(Screensaver):
             # Check for corner hit!
             if bounced_x and bounced_y:
                 self.__corner_hits += 1
-                self.__logger.info(f"🎯 CORNER HIT! Total: {self.__corner_hits}")
+                self.__logger.info(f"CORNER HIT! Total: {self.__corner_hits}")
 
         self.__render()
+
+    def __reset(self):
+        """Initialize the bouncing logo."""
+        # Start at a random position
+        self.__x = random.uniform(0, self.__width - self.__logo_width)
+        self.__y = random.uniform(0, self.__height - self.__logo_height)
+
+        # Random initial velocity
+        speed = Config.get('screensavers.configs.dvd_bounce.speed', 0.5)
+        angle = random.uniform(0, 2 * np.pi)
+        self.__vx = speed * np.cos(angle)
+        self.__vy = speed * np.sin(angle)
+
+        # Ensure we're actually moving
+        if abs(self.__vx) < 0.1:
+            self.__vx = 0.3 if self.__vx >= 0 else -0.3
+        if abs(self.__vy) < 0.1:
+            self.__vy = 0.3 if self.__vy >= 0 else -0.3
+
+        # Random initial color
+        self.__color = self.__random_color()
+        self.__corner_hits = 0
 
     def __random_color(self):
         """Generate a random bright color."""
@@ -275,9 +263,6 @@ class DvdBounce(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.dvd_bounce.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -30,8 +30,8 @@ class DvdBounce(Screensaver):
         self.__height = Config.get_or_throw('leds.display_height')
 
         # Logo dimensions (clamp to display size)
-        requested_width = Config.get('dvd_bounce.logo_width', 8)
-        requested_height = Config.get('dvd_bounce.logo_height', 4)
+        requested_width = Config.get('screensavers.configs.dvd_bounce.logo_width', 8)
+        requested_height = Config.get('screensavers.configs.dvd_bounce.logo_height', 4)
 
         self.__logo_width = min(requested_width, self.__width - 1)
         self.__logo_height = min(requested_height, self.__height - 1)
@@ -60,7 +60,7 @@ class DvdBounce(Screensaver):
         self.__logger.info("Starting DVD Bounce screensaver")
         self.__reset()
 
-        max_ticks = Config.get('dvd_bounce.max_ticks', 10000)
+        max_ticks = Config.get('screensavers.configs.dvd_bounce.max_ticks', 10000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -77,7 +77,7 @@ class DvdBounce(Screensaver):
         self.__y = random.uniform(0, self.__height - self.__logo_height)
 
         # Random initial velocity
-        speed = Config.get('dvd_bounce.speed', 0.5)
+        speed = Config.get('screensavers.configs.dvd_bounce.speed', 0.5)
         angle = random.uniform(0, 2 * np.pi)
         self.__vx = speed * np.cos(angle)
         self.__vy = speed * np.sin(angle)
@@ -135,7 +135,7 @@ class DvdBounce(Screensaver):
 
     def __random_color(self):
         """Generate a random bright color."""
-        color_mode = Config.get('dvd_bounce.color_mode', 'random')
+        color_mode = Config.get('screensavers.configs.dvd_bounce.color_mode', 'random')
 
         if color_mode == 'random':
             # Random bright color
@@ -174,7 +174,7 @@ class DvdBounce(Screensaver):
         y_end = min(y_start + self.__logo_height, self.__height)
 
         # Fill the rectangle
-        show_border = Config.get('dvd_bounce.show_border', True)
+        show_border = Config.get('screensavers.configs.dvd_bounce.show_border', True)
 
         if show_border:
             # Draw filled logo with border
@@ -192,7 +192,7 @@ class DvdBounce(Screensaver):
             frame[y_start:y_end, x_start:x_end] = self.__color
 
         # Optional: Draw "DVD" text if logo is big enough
-        show_text = Config.get('dvd_bounce.show_text', False)
+        show_text = Config.get('screensavers.configs.dvd_bounce.show_text', False)
         if show_text and self.__logo_width >= 12 and self.__logo_height >= 3:
             self.__draw_dvd_text(frame, x_start, y_start)
 
@@ -277,7 +277,7 @@ class DvdBounce(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('dvd_bounce.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.dvd_bounce.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -47,7 +47,7 @@ class FlowField(Screensaver):
         self.__logger.info("Starting Flow Field screensaver")
         self.__reset()
 
-        max_ticks = Config.get('flowfield.max_ticks', 2500)
+        max_ticks = Config.get('screensavers.configs.flowfield.max_ticks', 2500)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -63,7 +63,7 @@ class FlowField(Screensaver):
         self.__noise_z = random.random() * 100
 
         # Create particles
-        num_particles = Config.get('flowfield.num_particles', 50)
+        num_particles = Config.get('screensavers.configs.flowfield.num_particles', 50)
         self.__particles = []
         for _ in range(num_particles):
             self.__particles.append(self.__create_particle())
@@ -81,7 +81,7 @@ class FlowField(Screensaver):
 
     def __tick(self):
         # Fade buffer
-        fade = Config.get('flowfield.fade', 0.95)
+        fade = Config.get('screensavers.configs.flowfield.fade', 0.95)
         self.__buffer *= fade
 
         # Slowly evolve the flow field
@@ -97,7 +97,7 @@ class FlowField(Screensaver):
             ) * math.pi * 4  # Map to full rotation
 
             # Move particle
-            speed = Config.get('flowfield.speed', 0.5)
+            speed = Config.get('screensavers.configs.flowfield.speed', 0.5)
             particle['x'] += math.cos(angle) * speed
             particle['y'] += math.sin(angle) * speed
 
@@ -210,7 +210,7 @@ class FlowField(Screensaver):
         return [r * 255, g * 255, b * 255]
 
     def __get_tick_sleep(self):
-        return Config.get('flowfield.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.flowfield.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,11 +16,6 @@ class FlowField(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -115,7 +109,7 @@ class FlowField(Screensaver):
 
     def __render(self):
         frame = np.clip(self.__buffer, 0, 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __noise(self, x, y, z):
         """Simple Perlin-like noise implementation."""

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,7 +17,6 @@ class FlowField(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -43,43 +40,10 @@ class FlowField(Screensaver):
         random.shuffle(self.__perm)
         self.__perm += self.__perm  # Double it for overflow
 
-    def play(self):
-        self.__logger.info("Starting Flow Field screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.flowfield.max_ticks', 2500)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Flow Field screensaver ended")
-
-    def __reset(self):
-        self.__buffer = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
-        self.__time = 0
-        self.__noise_z = random.random() * 100
-
-        # Create particles
-        num_particles = Config.get('screensavers.configs.flowfield.num_particles', 50)
-        self.__particles = []
-        for _ in range(num_particles):
-            self.__particles.append(self.__create_particle())
-
-        # Random color palette for this session
-        self.__hue_base = random.random()
-        self.__hue_range = random.uniform(0.1, 0.3)
-
-    def __create_particle(self):
-        return {
-            'x': random.random() * self.__width,
-            'y': random.random() * self.__height,
-            'hue': random.random(),
-        }
-
-    def __tick(self):
+    def _tick(self, tick):
         # Fade buffer
         fade = Config.get('screensavers.configs.flowfield.fade', 0.95)
         self.__buffer *= fade
@@ -126,6 +90,28 @@ class FlowField(Screensaver):
 
         self.__render()
         self.__time += 1
+
+    def __reset(self):
+        self.__buffer = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__time = 0
+        self.__noise_z = random.random() * 100
+
+        # Create particles
+        num_particles = Config.get('screensavers.configs.flowfield.num_particles', 50)
+        self.__particles = []
+        for _ in range(num_particles):
+            self.__particles.append(self.__create_particle())
+
+        # Random color palette for this session
+        self.__hue_base = random.random()
+        self.__hue_range = random.uniform(0.1, 0.3)
+
+    def __create_particle(self):
+        return {
+            'x': random.random() * self.__width,
+            'y': random.random() * self.__height,
+            'hue': random.random(),
+        }
 
     def __render(self):
         frame = np.clip(self.__buffer, 0, 255).astype(np.uint8)
@@ -208,9 +194,6 @@ class FlowField(Screensaver):
             r, g, b = v, p, q
 
         return [r * 255, g * 255, b * 255]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.flowfield.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -50,7 +50,7 @@ class FlowField(Screensaver):
         max_ticks = Config.get('flowfield.max_ticks', 2500)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -50,7 +50,7 @@ class FlowField(Screensaver):
         max_ticks = Config.get('flowfield.max_ticks', 2500)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/gradienttest.py
+++ b/pifi/screensaver/gradienttest.py
@@ -8,7 +8,6 @@ Tests whether flicker is caused by colors/PWM rather than CPU load.
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,10 +16,6 @@ class GradientTest(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -166,7 +161,7 @@ class GradientTest(Screensaver):
 
     def _tick(self, tick):
         """Display the pre-generated static frame."""
-        self.__led_frame_player.play_frame(self.__frame)
+        self._led_frame_player.play_frame(self.__frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/gradienttest.py
+++ b/pifi/screensaver/gradienttest.py
@@ -29,9 +29,9 @@ class GradientTest(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Config
-        self.__mode = Config.get('gradient_test.mode', 'pastel_sky')
-        self.__tick_sleep = Config.get('gradient_test.tick_sleep', 0.1)
-        self.__max_ticks = Config.get('gradient_test.max_ticks', 3000)
+        self.__mode = Config.get('screensavers.configs.gradient_test.mode', 'pastel_sky')
+        self.__tick_sleep = Config.get('screensavers.configs.gradient_test.tick_sleep', 0.1)
+        self.__max_ticks = Config.get('screensavers.configs.gradient_test.max_ticks', 3000)
 
         # Pre-generate the static frame ONCE
         self.__frame = self.__generate_frame()

--- a/pifi/screensaver/gradienttest.py
+++ b/pifi/screensaver/gradienttest.py
@@ -6,11 +6,9 @@ Tests whether flicker is caused by colors/PWM rather than CPU load.
 """
 
 import numpy as np
-import time
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,7 +17,6 @@ class GradientTest(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -30,8 +27,6 @@ class GradientTest(Screensaver):
 
         # Config
         self.__mode = Config.get('screensavers.configs.gradient_test.mode', 'pastel_sky')
-        self.__tick_sleep = Config.get('screensavers.configs.gradient_test.tick_sleep', 0.1)
-        self.__max_ticks = Config.get('screensavers.configs.gradient_test.max_ticks', 3000)
 
         # Pre-generate the static frame ONCE
         self.__frame = self.__generate_frame()
@@ -169,19 +164,9 @@ class GradientTest(Screensaver):
         self.__mode = old_mode
         return frame
 
-    def play(self):
-        """Run the screensaver - just display the same frame repeatedly."""
-        self.__logger.info(f"Starting GradientTest screensaver (mode={self.__mode})")
-
-        # Display the pre-generated static frame
-        # This loop does almost NO CPU work - just sleep and display
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            self.__led_frame_player.play_frame(self.__frame)
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("GradientTest screensaver ended")
+    def _tick(self, tick):
+        """Display the pre-generated static frame."""
+        self.__led_frame_player.play_frame(self.__frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/gradienttest.py
+++ b/pifi/screensaver/gradienttest.py
@@ -176,6 +176,8 @@ class GradientTest(Screensaver):
         # Display the pre-generated static frame
         # This loop does almost NO CPU work - just sleep and display
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             self.__led_frame_player.play_frame(self.__frame)
             time.sleep(self.__tick_sleep)
 

--- a/pifi/screensaver/gradienttest.py
+++ b/pifi/screensaver/gradienttest.py
@@ -176,7 +176,7 @@ class GradientTest(Screensaver):
         # Display the pre-generated static frame
         # This loop does almost NO CPU work - just sleep and display
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             self.__led_frame_player.play_frame(self.__frame)
             time.sleep(self.__tick_sleep)

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -3,7 +3,6 @@ import random
 import math
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,11 +16,6 @@ class InkInWater(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -117,7 +111,7 @@ class InkInWater(Screensaver):
     def __render(self):
         # Clamp and convert to uint8
         frame = np.clip(self.__buffer * 255, 0, 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         if s == 0.0:

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -1,10 +1,8 @@
 import numpy as np
-import time
 import random
 import math
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,7 +17,6 @@ class InkInWater(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -33,19 +30,27 @@ class InkInWater(Screensaver):
         self.__buffer = None
         self.__time = 0
 
-    def play(self):
-        self.__logger.info("Starting Ink in Water screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.inkinwater.max_ticks', 2500)
-        tick = 0
+    def _tick(self, tick):
+        # Add new drops more frequently for more activity
+        drop_chance = Config.get('screensavers.configs.inkinwater.drop_chance', 0.06)
+        if random.random() < drop_chance:
+            self.__add_drop()
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Add subtle flow/movement to make it more dynamic
+        self.__apply_flow()
 
-        self.__logger.info("Ink in Water screensaver ended")
+        # Diffuse the ink
+        self.__diffuse()
+
+        # Very slow fade to prevent eternal buildup
+        fade = Config.get('screensavers.configs.inkinwater.fade', 0.997)
+        self.__buffer *= fade
+
+        self.__render()
+        self.__time += 1
 
     def __reset(self):
         self.__time = 0
@@ -79,25 +84,6 @@ class InkInWater(Screensaver):
                         self.__buffer[ny, nx, 0] += color[0] * falloff * intensity / 255
                         self.__buffer[ny, nx, 1] += color[1] * falloff * intensity / 255
                         self.__buffer[ny, nx, 2] += color[2] * falloff * intensity / 255
-
-    def __tick(self):
-        # Add new drops more frequently for more activity
-        drop_chance = Config.get('screensavers.configs.inkinwater.drop_chance', 0.06)
-        if random.random() < drop_chance:
-            self.__add_drop()
-
-        # Add subtle flow/movement to make it more dynamic
-        self.__apply_flow()
-
-        # Diffuse the ink
-        self.__diffuse()
-
-        # Very slow fade to prevent eternal buildup
-        fade = Config.get('screensavers.configs.inkinwater.fade', 0.997)
-        self.__buffer *= fade
-
-        self.__render()
-        self.__time += 1
 
     def __apply_flow(self):
         """Apply subtle upward flow like ink rising in water."""
@@ -158,9 +144,6 @@ class InkInWater(Screensaver):
             r, g, b = v, p, q
 
         return [r, g, b]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.inkinwater.tick_sleep', 0.04)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -40,7 +40,7 @@ class InkInWater(Screensaver):
         max_ticks = Config.get('inkinwater.max_ticks', 2500)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -37,7 +37,7 @@ class InkInWater(Screensaver):
         self.__logger.info("Starting Ink in Water screensaver")
         self.__reset()
 
-        max_ticks = Config.get('inkinwater.max_ticks', 2500)
+        max_ticks = Config.get('screensavers.configs.inkinwater.max_ticks', 2500)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -82,7 +82,7 @@ class InkInWater(Screensaver):
 
     def __tick(self):
         # Add new drops more frequently for more activity
-        drop_chance = Config.get('inkinwater.drop_chance', 0.06)
+        drop_chance = Config.get('screensavers.configs.inkinwater.drop_chance', 0.06)
         if random.random() < drop_chance:
             self.__add_drop()
 
@@ -93,7 +93,7 @@ class InkInWater(Screensaver):
         self.__diffuse()
 
         # Very slow fade to prevent eternal buildup
-        fade = Config.get('inkinwater.fade', 0.997)
+        fade = Config.get('screensavers.configs.inkinwater.fade', 0.997)
         self.__buffer *= fade
 
         self.__render()
@@ -101,7 +101,7 @@ class InkInWater(Screensaver):
 
     def __apply_flow(self):
         """Apply subtle upward flow like ink rising in water."""
-        flow_strength = Config.get('inkinwater.flow_strength', 0.03)
+        flow_strength = Config.get('screensavers.configs.inkinwater.flow_strength', 0.03)
         if flow_strength <= 0:
             return
 
@@ -112,7 +112,7 @@ class InkInWater(Screensaver):
 
     def __diffuse(self):
         """Simple diffusion - each pixel shares with neighbors."""
-        diffusion_rate = Config.get('inkinwater.diffusion_rate', 0.15)
+        diffusion_rate = Config.get('screensavers.configs.inkinwater.diffusion_rate', 0.15)
 
         # Pad for edge handling
         padded = np.pad(self.__buffer, ((1, 1), (1, 1), (0, 0)), mode='edge')
@@ -160,7 +160,7 @@ class InkInWater(Screensaver):
         return [r, g, b]
 
     def __get_tick_sleep(self):
-        return Config.get('inkinwater.tick_sleep', 0.04)
+        return Config.get('screensavers.configs.inkinwater.tick_sleep', 0.04)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -40,7 +40,7 @@ class InkInWater(Screensaver):
         max_ticks = Config.get('inkinwater.max_ticks', 2500)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -131,7 +131,7 @@ class KaraokeBase(Screensaver):
 
         try:
             for tick in range(self._max_ticks):
-                if self._is_past_dwell_time():
+                if self._is_past_screensaver_timeout():
                     break
                 self.__render()
                 self.__tick_count += 1

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -131,6 +131,8 @@ class KaraokeBase(Screensaver):
 
         try:
             for tick in range(self._max_ticks):
+                if self._is_past_dwell_time():
+                    break
                 self.__render()
                 self.__tick_count += 1
                 time.sleep(self._tick_sleep)

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -79,7 +79,6 @@ class KaraokeBase(Screensaver):
         # Private state - lyrics
         self.__lyrics = []  # List of (timestamp_seconds, line_text, word_timings)
         self.__lyrics_available = False
-        self.__lyrics_quality = None  # 'synced', 'enhanced', or None
         self.__lyrics_track = None   # Track name lyrics were fetched for
         self.__lyrics_artist = None  # Artist name lyrics were fetched for
         self.__fetch_in_progress = False
@@ -89,7 +88,6 @@ class KaraokeBase(Screensaver):
         self.__tick_count = 0
         self.__scroll_offset = 0
         self.__current_line_index = -1
-        self.__line_scroll_offset = 0
         self.__line_start_time = 0
         self.__line_duration = 5.0
         self.__line_transition_progress = 1.0
@@ -110,12 +108,6 @@ class KaraokeBase(Screensaver):
     def _setup(self):
         if not self._connect():
             self._logger.error(f"Could not connect to {self._get_source_display_name()}")
-            frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
-            for _ in range(100):
-                frame.fill(0)
-                self._render_connection_error(frame)
-                self._led_frame_player.play_frame(frame)
-                time.sleep(0.1)
             self.__connection_failed = True
             return
 
@@ -128,7 +120,10 @@ class KaraokeBase(Screensaver):
 
     def _tick(self, tick):
         if self.__connection_failed:
-            return False
+            frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
+            self._render_connection_error(frame)
+            self._led_frame_player.play_frame(frame)
+            return
         self.__render()
         self.__tick_count += 1
 
@@ -195,7 +190,6 @@ class KaraokeBase(Screensaver):
 
             self.__lyrics = []
             self.__lyrics_available = False
-            self.__lyrics_quality = None
             self.__current_line_index = -1
             self.__max_position = 0
             self.__max_intro_progress = 0
@@ -295,7 +289,6 @@ class KaraokeBase(Screensaver):
                     if self._current_track == title and self._current_artist == artist:
                         self.__lyrics = lyrics
                         self.__lyrics_available = len(lyrics) > 0
-                        self.__lyrics_quality = quality if lyrics else None
                         self.__lyrics_track = title
                         self.__lyrics_artist = artist
                         if lyrics:
@@ -308,7 +301,6 @@ class KaraokeBase(Screensaver):
                 with self.__fetch_lock:
                     self.__lyrics = []
                     self.__lyrics_available = False
-                    self.__lyrics_quality = None
         except Exception as e:
             self._logger.error(f"Error fetching lyrics: {e}")
             import traceback
@@ -743,7 +735,6 @@ class KaraokeBase(Screensaver):
         if current_idx != self.__current_line_index:
             self.__current_line_index = current_idx
             self.__line_transition_progress = 0.0
-            self.__line_scroll_offset = 0
             self.__line_start_time = time.time()
             self.__word_start_times = {}
 

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -12,7 +12,6 @@ import time
 from abc import abstractmethod
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver import textutils
@@ -61,10 +60,6 @@ class KaraokeBase(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self._logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self._led_frame_player = led_frame_player
 
         self._width = Config.get('leds.display_width', 64)
         self._height = Config.get('leds.display_height', 32)

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -69,7 +69,7 @@ class KaraokeBase(Screensaver):
         self._poll_lock = threading.Lock()
         self._polling_active = False
         self.__poll_thread = None
-        self.__connection_failed = False
+        self.__connection_failed_time = None
 
         # Private state - lyrics
         self.__lyrics = []  # List of (timestamp_seconds, line_text, word_timings)
@@ -103,7 +103,7 @@ class KaraokeBase(Screensaver):
     def _setup(self):
         if not self._connect():
             self._logger.error(f"Could not connect to {self._get_source_display_name()}")
-            self.__connection_failed = True
+            self.__connection_failed_time = time.time()
             return
 
         self._logger.info(f"Connected to {self._get_source_display_name()}")
@@ -114,7 +114,9 @@ class KaraokeBase(Screensaver):
         self.__poll_thread.start()
 
     def _tick(self, tick):
-        if self.__connection_failed:
+        if self.__connection_failed_time is not None:
+            if (time.time() - self.__connection_failed_time) > 10:
+                return False
             self.__frame_buffer.fill(0)
             self._render_connection_error(self.__frame_buffer)
             self._led_frame_player.play_frame(self.__frame_buffer)

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -21,7 +21,7 @@ from pifi.screensaver import textutils
 class KaraokeBase(Screensaver):
     """Base class for karaoke lyrics display screensavers."""
 
-    # Persisted state — class-level so it survives max_ticks instance restarts.
+    # Persisted state — class-level so it survives instance restarts.
     # Use KaraokeBase._field = value for writes (self._field = creates instance vars).
     _current_track = None
     _current_artist = None
@@ -69,13 +69,12 @@ class KaraokeBase(Screensaver):
         self._width = Config.get('leds.display_width', 64)
         self._height = Config.get('leds.display_height', 32)
 
-        # Subclasses should override these in their __init__
-        self._tick_sleep = 0.05
-        self._max_ticks = 6000
         self._pulse_lyrics = True
 
         self._poll_lock = threading.Lock()
         self._polling_active = False
+        self.__poll_thread = None
+        self.__connection_failed = False
 
         # Private state - lyrics
         self.__lyrics = []  # List of (timestamp_seconds, line_text, word_timings)
@@ -108,10 +107,7 @@ class KaraokeBase(Screensaver):
         # Pre-allocated frame buffer
         self.__frame_buffer = np.zeros((self._height, self._width, 3), dtype=np.uint8)
 
-    def play(self):
-        """Run the screensaver."""
-        self._logger.info(f"Starting {self.get_name()} screensaver")
-
+    def _setup(self):
         if not self._connect():
             self._logger.error(f"Could not connect to {self._get_source_display_name()}")
             frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
@@ -120,27 +116,26 @@ class KaraokeBase(Screensaver):
                 self._render_connection_error(frame)
                 self._led_frame_player.play_frame(frame)
                 time.sleep(0.1)
+            self.__connection_failed = True
             return
 
         self._logger.info(f"Connected to {self._get_source_display_name()}")
 
         # Start background polling thread
         self._polling_active = True
-        poll_thread = threading.Thread(target=self._polling_loop, daemon=True)
-        poll_thread.start()
+        self.__poll_thread = threading.Thread(target=self._polling_loop, daemon=True)
+        self.__poll_thread.start()
 
-        try:
-            for tick in range(self._max_ticks):
-                if self._is_past_screensaver_timeout():
-                    break
-                self.__render()
-                self.__tick_count += 1
-                time.sleep(self._tick_sleep)
-        finally:
+    def _tick(self, tick):
+        if self.__connection_failed:
+            return False
+        self.__render()
+        self.__tick_count += 1
+
+    def _teardown(self):
+        if self.__poll_thread is not None:
             self._polling_active = False
-            poll_thread.join(timeout=1.0)
-
-        self._logger.info(f"{self.get_name()} screensaver ended")
+            self.__poll_thread.join(timeout=1.0)
 
     # --- Abstract methods for subclasses ---
 

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -120,9 +120,9 @@ class KaraokeBase(Screensaver):
 
     def _tick(self, tick):
         if self.__connection_failed:
-            frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
-            self._render_connection_error(frame)
-            self._led_frame_player.play_frame(frame)
+            self.__frame_buffer.fill(0)
+            self._render_connection_error(self.__frame_buffer)
+            self._led_frame_player.play_frame(self.__frame_buffer)
             return
         self.__render()
         self.__tick_count += 1

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,11 +16,6 @@ class LavaLamp(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -163,7 +157,7 @@ class LavaLamp(Screensaver):
                     color = self.__hsv_to_rgb(hue, 0.9, glow * 0.3)
                     frame[y, x] = color
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         if s == 0.0:

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -39,7 +39,7 @@ class LavaLamp(Screensaver):
         max_ticks = Config.get('lavalamp.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,7 +17,6 @@ class LavaLamp(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -32,19 +29,13 @@ class LavaLamp(Screensaver):
         self.__blobs = []
         self.__time = 0
 
-    def play(self):
-        self.__logger.info("Starting Lava Lamp screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.lavalamp.max_ticks', 3000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Lava Lamp screensaver ended")
+    def _tick(self, tick):
+        self.__update_blobs()
+        self.__render()
+        self.__time += 1
 
     def __reset(self):
         self.__time = 0
@@ -73,11 +64,6 @@ class LavaLamp(Screensaver):
 
         # Color palette - warm colors like real lava lamp
         self.__base_hue = random.choice([0.0, 0.05, 0.08, 0.55, 0.75])  # Red, orange, yellow, blue, purple
-
-    def __tick(self):
-        self.__update_blobs()
-        self.__render()
-        self.__time += 1
 
     def __update_blobs(self):
         heat_rate = Config.get('screensavers.configs.lavalamp.heat_rate', 0.03)
@@ -205,9 +191,6 @@ class LavaLamp(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.lavalamp.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -36,7 +36,7 @@ class LavaLamp(Screensaver):
         self.__logger.info("Starting Lava Lamp screensaver")
         self.__reset()
 
-        max_ticks = Config.get('lavalamp.max_ticks', 3000)
+        max_ticks = Config.get('screensavers.configs.lavalamp.max_ticks', 3000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -50,7 +50,7 @@ class LavaLamp(Screensaver):
         self.__time = 0
 
         # Create blobs - more blobs for more activity
-        num_blobs = Config.get('lavalamp.num_blobs', 10)
+        num_blobs = Config.get('screensavers.configs.lavalamp.num_blobs', 10)
         self.__blobs = []
 
         for i in range(num_blobs):
@@ -80,9 +80,9 @@ class LavaLamp(Screensaver):
         self.__time += 1
 
     def __update_blobs(self):
-        heat_rate = Config.get('lavalamp.heat_rate', 0.03)
-        cool_rate = Config.get('lavalamp.cool_rate', 0.02)
-        buoyancy = Config.get('lavalamp.buoyancy', 0.08)
+        heat_rate = Config.get('screensavers.configs.lavalamp.heat_rate', 0.03)
+        cool_rate = Config.get('screensavers.configs.lavalamp.cool_rate', 0.02)
+        buoyancy = Config.get('screensavers.configs.lavalamp.buoyancy', 0.08)
         damping = 0.96
 
         for blob in self.__blobs:
@@ -207,7 +207,7 @@ class LavaLamp(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('lavalamp.tick_sleep', 0.05)
+        return Config.get('screensavers.configs.lavalamp.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -39,7 +39,7 @@ class LavaLamp(Screensaver):
         max_ticks = Config.get('lavalamp.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -48,7 +48,7 @@ class Lorenz(Screensaver):
         max_ticks = Config.get('lorenz.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -48,7 +48,7 @@ class Lorenz(Screensaver):
         max_ticks = Config.get('lorenz.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,7 +18,6 @@ class Lorenz(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -41,30 +38,10 @@ class Lorenz(Screensaver):
         # Rotation angle for 3D projection
         self.__rotation = 0.0
 
-    def play(self):
-        self.__logger.info("Starting Lorenz attractor screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.lorenz.max_ticks', 3000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Lorenz attractor screensaver ended")
-
-    def __reset(self):
-        # Start near the attractor with small random offset
-        self.__x = 1.0 + random.uniform(-0.1, 0.1)
-        self.__y = 1.0 + random.uniform(-0.1, 0.1)
-        self.__z = 1.0 + random.uniform(-0.1, 0.1)
-
-        self.__trail = []
-        self.__rotation = random.uniform(0, 2 * math.pi)
-
-    def __tick(self):
+    def _tick(self, tick):
         # Lorenz system parameters (classic values)
         sigma = Config.get('screensavers.configs.lorenz.sigma', 10.0)
         rho = Config.get('screensavers.configs.lorenz.rho', 28.0)
@@ -99,6 +76,15 @@ class Lorenz(Screensaver):
         self.__rotation += rotation_speed
 
         self.__render()
+
+    def __reset(self):
+        # Start near the attractor with small random offset
+        self.__x = 1.0 + random.uniform(-0.1, 0.1)
+        self.__y = 1.0 + random.uniform(-0.1, 0.1)
+        self.__z = 1.0 + random.uniform(-0.1, 0.1)
+
+        self.__trail = []
+        self.__rotation = random.uniform(0, 2 * math.pi)
 
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
@@ -183,9 +169,6 @@ class Lorenz(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.lorenz.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,11 +17,6 @@ class Lorenz(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -90,7 +84,7 @@ class Lorenz(Screensaver):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
 
         if not self.__trail:
-            self.__led_frame_player.play_frame(frame)
+            self._led_frame_player.play_frame(frame)
             return
 
         # Find bounds for scaling
@@ -140,7 +134,7 @@ class Lorenz(Screensaver):
                 new_color = np.minimum(255, current + np.array(rgb, dtype=np.int16))
                 frame[screen_y, screen_x] = new_color.astype(np.uint8)
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV color to RGB."""

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -45,7 +45,7 @@ class Lorenz(Screensaver):
         self.__logger.info("Starting Lorenz attractor screensaver")
         self.__reset()
 
-        max_ticks = Config.get('lorenz.max_ticks', 3000)
+        max_ticks = Config.get('screensavers.configs.lorenz.max_ticks', 3000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -66,15 +66,15 @@ class Lorenz(Screensaver):
 
     def __tick(self):
         # Lorenz system parameters (classic values)
-        sigma = Config.get('lorenz.sigma', 10.0)
-        rho = Config.get('lorenz.rho', 28.0)
-        beta = Config.get('lorenz.beta', 8.0 / 3.0)
+        sigma = Config.get('screensavers.configs.lorenz.sigma', 10.0)
+        rho = Config.get('screensavers.configs.lorenz.rho', 28.0)
+        beta = Config.get('screensavers.configs.lorenz.beta', 8.0 / 3.0)
 
         # Time step for integration
-        dt = Config.get('lorenz.dt', 0.01)
+        dt = Config.get('screensavers.configs.lorenz.dt', 0.01)
 
         # Number of integration steps per frame
-        steps_per_frame = Config.get('lorenz.steps_per_frame', 5)
+        steps_per_frame = Config.get('screensavers.configs.lorenz.steps_per_frame', 5)
 
         for _ in range(steps_per_frame):
             # Lorenz equations (Euler integration)
@@ -90,12 +90,12 @@ class Lorenz(Screensaver):
             self.__trail.append((self.__x, self.__y, self.__z))
 
         # Limit trail length
-        max_trail = Config.get('lorenz.trail_length', 800)
+        max_trail = Config.get('screensavers.configs.lorenz.trail_length', 800)
         if len(self.__trail) > max_trail:
             self.__trail = self.__trail[-max_trail:]
 
         # Slowly rotate view
-        rotation_speed = Config.get('lorenz.rotation_speed', 0.005)
+        rotation_speed = Config.get('screensavers.configs.lorenz.rotation_speed', 0.005)
         self.__rotation += rotation_speed
 
         self.__render()
@@ -185,7 +185,7 @@ class Lorenz(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('lorenz.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.lorenz.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -1,6 +1,5 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
@@ -64,19 +63,29 @@ class Mandelbrot(Screensaver):
         # Track consecutive black frames for reset detection
         self.__black_frame_count = 0
 
-    def play(self):
-        self.__logger.info("Starting Mandelbrot screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.mandelbrot.max_ticks', 1500)
-        tick = 0
+    def _tick(self, tick):
+        # Smoothly move center towards target
+        lerp_factor = Config.get('screensavers.configs.mandelbrot.lerp_factor', 0.02)
+        self.__center_x += (self.__target_x - self.__center_x) * lerp_factor
+        self.__center_y += (self.__target_y - self.__center_y) * lerp_factor
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Exponential zoom
+        zoom_speed = Config.get('screensavers.configs.mandelbrot.zoom_speed', 1.02)
+        self.__zoom *= zoom_speed
 
-        self.__logger.info("Mandelbrot screensaver ended")
+        black_ratio = self.__render()
+
+        # If frame is all black, we've zoomed into the set interior
+        if black_ratio == 1.0:
+            self.__black_frame_count += 1
+            if self.__black_frame_count >= 5:
+                self.__logger.info("Zoomed into black region, picking new target")
+                self.__reset()
+        else:
+            self.__black_frame_count = 0
 
     def __reset(self):
         # Start with full view of the set
@@ -115,27 +124,6 @@ class Mandelbrot(Screensaver):
             palette[i] = self.__hsv_to_rgb(hue, sat, val)
 
         return palette
-
-    def __tick(self):
-        # Smoothly move center towards target
-        lerp_factor = Config.get('screensavers.configs.mandelbrot.lerp_factor', 0.02)
-        self.__center_x += (self.__target_x - self.__center_x) * lerp_factor
-        self.__center_y += (self.__target_y - self.__center_y) * lerp_factor
-
-        # Exponential zoom
-        zoom_speed = Config.get('screensavers.configs.mandelbrot.zoom_speed', 1.02)
-        self.__zoom *= zoom_speed
-
-        black_ratio = self.__render()
-
-        # If frame is all black, we've zoomed into the set interior
-        if black_ratio == 1.0:
-            self.__black_frame_count += 1
-            if self.__black_frame_count >= 5:
-                self.__logger.info("Zoomed into black region, picking new target")
-                self.__reset()
-        else:
-            self.__black_frame_count = 0
 
     def __render(self):
         max_iter = Config.get('screensavers.configs.mandelbrot.max_iterations', 50)
@@ -217,9 +205,6 @@ class Mandelbrot(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.mandelbrot.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -68,7 +68,7 @@ class Mandelbrot(Screensaver):
         self.__logger.info("Starting Mandelbrot screensaver")
         self.__reset()
 
-        max_ticks = Config.get('mandelbrot.max_ticks', 1500)
+        max_ticks = Config.get('screensavers.configs.mandelbrot.max_ticks', 1500)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -118,12 +118,12 @@ class Mandelbrot(Screensaver):
 
     def __tick(self):
         # Smoothly move center towards target
-        lerp_factor = Config.get('mandelbrot.lerp_factor', 0.02)
+        lerp_factor = Config.get('screensavers.configs.mandelbrot.lerp_factor', 0.02)
         self.__center_x += (self.__target_x - self.__center_x) * lerp_factor
         self.__center_y += (self.__target_y - self.__center_y) * lerp_factor
 
         # Exponential zoom
-        zoom_speed = Config.get('mandelbrot.zoom_speed', 1.02)
+        zoom_speed = Config.get('screensavers.configs.mandelbrot.zoom_speed', 1.02)
         self.__zoom *= zoom_speed
 
         black_ratio = self.__render()
@@ -138,7 +138,7 @@ class Mandelbrot(Screensaver):
             self.__black_frame_count = 0
 
     def __render(self):
-        max_iter = Config.get('mandelbrot.max_iterations', 50)
+        max_iter = Config.get('screensavers.configs.mandelbrot.max_iterations', 50)
 
         # Calculate view bounds
         aspect = self.__width / self.__height
@@ -219,7 +219,7 @@ class Mandelbrot(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('mandelbrot.tick_sleep', 0.05)
+        return Config.get('screensavers.configs.mandelbrot.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -71,7 +71,7 @@ class Mandelbrot(Screensaver):
         max_ticks = Config.get('mandelbrot.max_ticks', 1500)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -4,7 +4,6 @@ import random
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -39,11 +38,6 @@ class Mandelbrot(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -172,7 +166,7 @@ class Mandelbrot(Screensaver):
         interior_mask = (M == 0)
         frame[interior_mask] = 0
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
         # Return ratio of black (interior) pixels
         total_pixels = self.__width * self.__height

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -71,7 +71,7 @@ class Mandelbrot(Screensaver):
         max_ticks = Config.get('mandelbrot.max_ticks', 1500)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -45,7 +45,7 @@ class MatrixRain(Screensaver):
         max_ticks = Config.get('matrix_rain.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -45,7 +45,7 @@ class MatrixRain(Screensaver):
         max_ticks = Config.get('matrix_rain.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -42,7 +42,7 @@ class MatrixRain(Screensaver):
         self.__logger.info("Starting Matrix Rain screensaver")
         self.__reset()
 
-        max_ticks = Config.get('matrix_rain.max_ticks', 3000)
+        max_ticks = Config.get('screensavers.configs.matrix_rain.max_ticks', 3000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -63,10 +63,10 @@ class MatrixRain(Screensaver):
 
     def __add_drop(self, x, from_top=True):
         """Add a new raindrop in column x."""
-        min_speed = Config.get('matrix_rain.min_speed', 0.2)
-        max_speed = Config.get('matrix_rain.max_speed', 0.8)
-        min_length = Config.get('matrix_rain.min_length', 4)
-        max_length = Config.get('matrix_rain.max_length', 12)
+        min_speed = Config.get('screensavers.configs.matrix_rain.min_speed', 0.2)
+        max_speed = Config.get('screensavers.configs.matrix_rain.max_speed', 0.8)
+        min_length = Config.get('screensavers.configs.matrix_rain.min_length', 4)
+        max_length = Config.get('screensavers.configs.matrix_rain.max_length', 12)
 
         speed = random.uniform(min_speed, max_speed)
         length = random.randint(min_length, min(max_length, self.__height))
@@ -85,8 +85,8 @@ class MatrixRain(Screensaver):
         })
 
     def __tick(self):
-        fade_rate = Config.get('matrix_rain.fade_rate', 0.85)
-        spawn_rate = Config.get('matrix_rain.spawn_rate', 0.08)
+        fade_rate = Config.get('screensavers.configs.matrix_rain.fade_rate', 0.85)
+        spawn_rate = Config.get('screensavers.configs.matrix_rain.spawn_rate', 0.08)
 
         # Fade existing trails
         self.__trail_buffer *= fade_rate
@@ -134,7 +134,7 @@ class MatrixRain(Screensaver):
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
 
-        color_mode = Config.get('matrix_rain.color_mode', 'green')
+        color_mode = Config.get('screensavers.configs.matrix_rain.color_mode', 'green')
 
         if color_mode == 'green':
             # Classic green matrix
@@ -221,7 +221,7 @@ class MatrixRain(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('matrix_rain.tick_sleep', 0.05)
+        return Config.get('screensavers.configs.matrix_rain.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -20,11 +19,6 @@ class MatrixRain(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -177,7 +171,7 @@ class MatrixRain(Screensaver):
                         intensity = int(b * 255)
                         frame[y, x] = [intensity, intensity, intensity]
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV color to RGB."""

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -1,9 +1,7 @@
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -22,7 +20,6 @@ class MatrixRain(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -38,53 +35,10 @@ class MatrixRain(Screensaver):
         # The frame buffer for trails (stores brightness values)
         self.__trail_buffer = None
 
-    def play(self):
-        self.__logger.info("Starting Matrix Rain screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.matrix_rain.max_ticks', 3000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Matrix Rain screensaver ended")
-
-    def __reset(self):
-        self.__drops = []
-        self.__trail_buffer = np.zeros((self.__height, self.__width), dtype=np.float32)
-
-        # Initialize some drops
-        for x in range(self.__width):
-            if random.random() < 0.3:
-                self.__add_drop(x)
-
-    def __add_drop(self, x, from_top=True):
-        """Add a new raindrop in column x."""
-        min_speed = Config.get('screensavers.configs.matrix_rain.min_speed', 0.2)
-        max_speed = Config.get('screensavers.configs.matrix_rain.max_speed', 0.8)
-        min_length = Config.get('screensavers.configs.matrix_rain.min_length', 4)
-        max_length = Config.get('screensavers.configs.matrix_rain.max_length', 12)
-
-        speed = random.uniform(min_speed, max_speed)
-        length = random.randint(min_length, min(max_length, self.__height))
-
-        if from_top:
-            y = random.uniform(-length, 0)
-        else:
-            y = random.uniform(-length, self.__height)
-
-        self.__drops.append({
-            'x': x,
-            'y': y,
-            'speed': speed,
-            'length': length,
-            'active': True
-        })
-
-    def __tick(self):
+    def _tick(self, tick):
         fade_rate = Config.get('screensavers.configs.matrix_rain.fade_rate', 0.85)
         spawn_rate = Config.get('screensavers.configs.matrix_rain.spawn_rate', 0.08)
 
@@ -130,6 +84,38 @@ class MatrixRain(Screensaver):
                 self.__add_drop(x)
 
         self.__render()
+
+    def __reset(self):
+        self.__drops = []
+        self.__trail_buffer = np.zeros((self.__height, self.__width), dtype=np.float32)
+
+        # Initialize some drops
+        for x in range(self.__width):
+            if random.random() < 0.3:
+                self.__add_drop(x)
+
+    def __add_drop(self, x, from_top=True):
+        """Add a new raindrop in column x."""
+        min_speed = Config.get('screensavers.configs.matrix_rain.min_speed', 0.2)
+        max_speed = Config.get('screensavers.configs.matrix_rain.max_speed', 0.8)
+        min_length = Config.get('screensavers.configs.matrix_rain.min_length', 4)
+        max_length = Config.get('screensavers.configs.matrix_rain.max_length', 12)
+
+        speed = random.uniform(min_speed, max_speed)
+        length = random.randint(min_length, min(max_length, self.__height))
+
+        if from_top:
+            y = random.uniform(-length, 0)
+        else:
+            y = random.uniform(-length, self.__height)
+
+        self.__drops.append({
+            'x': x,
+            'y': y,
+            'speed': speed,
+            'length': length,
+            'active': True
+        })
 
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
@@ -219,9 +205,6 @@ class MatrixRain(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.matrix_rain.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -117,7 +117,7 @@ class MeltingClock(Screensaver):
         self.__height = Config.get_or_throw('leds.display_height')
 
         # Get timezone configuration
-        timezone_str = Config.get('melting_clock.timezone', None)
+        timezone_str = Config.get('screensavers.configs.melting_clock.timezone', None)
         if timezone_str:
             try:
                 self.__timezone = ZoneInfo(timezone_str)
@@ -145,7 +145,7 @@ class MeltingClock(Screensaver):
         self.__logger.info("Starting Melting Clock screensaver")
         self.__reset()
 
-        max_ticks = Config.get('melting_clock.max_ticks', 5000)
+        max_ticks = Config.get('screensavers.configs.melting_clock.max_ticks', 5000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -168,7 +168,7 @@ class MeltingClock(Screensaver):
         else:
             current_datetime = datetime.now()
 
-        show_seconds = Config.get('melting_clock.show_seconds', False)
+        show_seconds = Config.get('screensavers.configs.melting_clock.show_seconds', False)
         if show_seconds:
             new_time = current_datetime.strftime("%H:%M:%S")
         else:
@@ -183,7 +183,7 @@ class MeltingClock(Screensaver):
         self.__update_animations()
 
         # Slowly cycle hue
-        hue_speed = Config.get('melting_clock.hue_speed', 0.001)
+        hue_speed = Config.get('screensavers.configs.melting_clock.hue_speed', 0.001)
         self.__hue = (self.__hue + hue_speed) % 1.0
 
         self.__render()
@@ -251,8 +251,8 @@ class MeltingClock(Screensaver):
 
     def __update_animations(self):
         """Update all melting and forming animations."""
-        melt_speed = Config.get('melting_clock.melt_speed', 0.15)
-        form_speed = Config.get('melting_clock.form_speed', 0.05)
+        melt_speed = Config.get('screensavers.configs.melting_clock.melt_speed', 0.15)
+        form_speed = Config.get('screensavers.configs.melting_clock.form_speed', 0.05)
 
         for state in self.__char_states:
             # Update drops (melting)
@@ -279,7 +279,7 @@ class MeltingClock(Screensaver):
     def __get_char_x(self, char_index):
         """Get x position for a character."""
         # Calculate total width of time string
-        show_seconds = Config.get('melting_clock.show_seconds', False)
+        show_seconds = Config.get('screensavers.configs.melting_clock.show_seconds', False)
         if show_seconds:
             # HH:MM:SS = 8 chars, but colons are narrower
             total_width = 6 * self.DIGIT_WIDTH + 2 * 3 + 7  # 6 digits + 2 colons + spacing
@@ -302,7 +302,7 @@ class MeltingClock(Screensaver):
 
     def __render(self):
         # Fade existing buffer (creates trails)
-        fade = Config.get('melting_clock.trail_fade', 0.85)
+        fade = Config.get('screensavers.configs.melting_clock.trail_fade', 0.85)
         self.__buffer *= fade
 
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
@@ -341,7 +341,7 @@ class MeltingClock(Screensaver):
                     self.__buffer[trail_y, px] = max(self.__buffer[trail_y, px], drop['brightness'] * 0.5)
 
         # Convert buffer to colored frame
-        color_mode = Config.get('melting_clock.color_mode', 'rainbow')
+        color_mode = Config.get('screensavers.configs.melting_clock.color_mode', 'rainbow')
 
         for y in range(self.__height):
             for x in range(self.__width):
@@ -390,7 +390,7 @@ class MeltingClock(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('melting_clock.tick_sleep', 0.05)
+        return Config.get('screensavers.configs.melting_clock.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -148,7 +148,7 @@ class MeltingClock(Screensaver):
         max_ticks = Config.get('melting_clock.max_ticks', 5000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -148,7 +148,7 @@ class MeltingClock(Screensaver):
         max_ticks = Config.get('melting_clock.max_ticks', 5000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -5,7 +5,6 @@ from zoneinfo import ZoneInfo
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -106,11 +105,6 @@ class MeltingClock(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -348,7 +342,7 @@ class MeltingClock(Screensaver):
                         rgb = [v, v, v]
                     frame[y, x] = rgb
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV color to RGB."""

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -1,5 +1,4 @@
 import numpy as np
-import time
 import random
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -141,27 +140,10 @@ class MeltingClock(Screensaver):
         # Color hue (slowly cycles)
         self.__hue = 0.0
 
-    def play(self):
-        self.__logger.info("Starting Melting Clock screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.melting_clock.max_ticks', 5000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Melting Clock screensaver ended")
-
-    def __reset(self):
-        self.__current_time = ""
-        self.__char_states = []
-        self.__buffer = np.zeros((self.__height, self.__width), dtype=np.float32)
-        self.__hue = random.random()
-
-    def __tick(self):
+    def _tick(self, tick):
         # Get current time in configured timezone
         if self.__timezone:
             current_datetime = datetime.now(self.__timezone)
@@ -187,6 +169,12 @@ class MeltingClock(Screensaver):
         self.__hue = (self.__hue + hue_speed) % 1.0
 
         self.__render()
+
+    def __reset(self):
+        self.__current_time = ""
+        self.__char_states = []
+        self.__buffer = np.zeros((self.__height, self.__width), dtype=np.float32)
+        self.__hue = random.random()
 
     def __handle_time_change(self, new_time):
         """Handle transition from old time to new time."""
@@ -388,9 +376,6 @@ class MeltingClock(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.melting_clock.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -43,7 +43,7 @@ class Metaballs(Screensaver):
         self.__logger.info("Starting Metaballs screensaver")
         self.__reset()
 
-        max_ticks = Config.get('metaballs.max_ticks', 2000)
+        max_ticks = Config.get('screensavers.configs.metaballs.max_ticks', 2000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -54,7 +54,7 @@ class Metaballs(Screensaver):
         self.__logger.info("Metaballs screensaver ended")
 
     def __reset(self):
-        num_balls = Config.get('metaballs.num_balls', 5)
+        num_balls = Config.get('screensavers.configs.metaballs.num_balls', 5)
         self.__balls = []
 
         for i in range(num_balls):
@@ -73,7 +73,7 @@ class Metaballs(Screensaver):
         radius = random.uniform(min_radius, max_radius)
 
         # Random velocity
-        speed = Config.get('metaballs.speed', 0.5)
+        speed = Config.get('screensavers.configs.metaballs.speed', 0.5)
         angle = random.uniform(0, 2 * math.pi)
         vx = math.cos(angle) * speed
         vy = math.sin(angle) * speed
@@ -136,7 +136,7 @@ class Metaballs(Screensaver):
                 color_field[:, :, c] += contribution * rgb[c]
 
         # Threshold the field to create blob shapes
-        threshold = Config.get('metaballs.threshold', 1.0)
+        threshold = Config.get('screensavers.configs.metaballs.threshold', 1.0)
 
         # Normalize colors by field strength
         field_safe = np.maximum(field, 0.001)
@@ -154,7 +154,7 @@ class Metaballs(Screensaver):
             frame[:, :, c] = (color_field[:, :, c] * intensity * 255).astype(np.uint8)
 
         # Add glow effect at the edges
-        glow = Config.get('metaballs.glow', True)
+        glow = Config.get('screensavers.configs.metaballs.glow', True)
         if glow:
             edge_intensity = np.clip((field - threshold * 0.3) / (threshold * 0.3), 0, 1)
             edge_intensity = edge_intensity * (1 - intensity) * 0.5
@@ -192,7 +192,7 @@ class Metaballs(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('metaballs.tick_sleep', 0.04)
+        return Config.get('screensavers.configs.metaballs.tick_sleep', 0.04)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,11 +17,6 @@ class Metaballs(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -148,7 +142,7 @@ class Metaballs(Screensaver):
                 glow_add = (color_field[:, :, c] * edge_intensity * 128).astype(np.uint8)
                 frame[:, :, c] = np.minimum(255, frame[:, :, c].astype(np.int16) + glow_add).astype(np.uint8)
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV color to RGB."""

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -46,7 +46,7 @@ class Metaballs(Screensaver):
         max_ticks = Config.get('metaballs.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -46,7 +46,7 @@ class Metaballs(Screensaver):
         max_ticks = Config.get('metaballs.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,7 +18,6 @@ class Metaballs(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -39,19 +36,13 @@ class Metaballs(Screensaver):
         y = np.arange(self.__height)
         self.__grid_x, self.__grid_y = np.meshgrid(x, y)
 
-    def play(self):
-        self.__logger.info("Starting Metaballs screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.metaballs.max_ticks', 2000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Metaballs screensaver ended")
+    def _tick(self, tick):
+        self.__update_balls()
+        self.__render()
+        self.__time += 0.1
 
     def __reset(self):
         num_balls = Config.get('screensavers.configs.metaballs.num_balls', 5)
@@ -82,11 +73,6 @@ class Metaballs(Screensaver):
         hue = (index / total + random.uniform(-0.1, 0.1)) % 1.0
 
         return [x, y, radius, vx, vy, hue]
-
-    def __tick(self):
-        self.__update_balls()
-        self.__render()
-        self.__time += 0.1
 
     def __update_balls(self):
         """Update ball positions with smooth movement."""
@@ -190,9 +176,6 @@ class Metaballs(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.metaballs.tick_sleep', 0.04)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -80,12 +80,12 @@ class NycSubway(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Configuration
-        self.__stop_ids = Config.get('nyc_subway.stop_ids', ['127N', '127S'])
-        self.__lines = Config.get('nyc_subway.lines', ['1', '2', '3'])
-        self.__update_interval = Config.get('nyc_subway.update_interval', 30)
-        self.__max_arrivals = Config.get('nyc_subway.max_arrivals', 4)
-        self.__max_ticks = Config.get('nyc_subway.max_ticks', 3000)
-        self.__tick_sleep = Config.get('nyc_subway.tick_sleep', 0.05)
+        self.__stop_ids = Config.get('screensavers.configs.nyc_subway.stop_ids', ['127N', '127S'])
+        self.__lines = Config.get('screensavers.configs.nyc_subway.lines', ['1', '2', '3'])
+        self.__update_interval = Config.get('screensavers.configs.nyc_subway.update_interval', 30)
+        self.__max_arrivals = Config.get('screensavers.configs.nyc_subway.max_arrivals', 4)
+        self.__max_ticks = Config.get('screensavers.configs.nyc_subway.max_ticks', 3000)
+        self.__tick_sleep = Config.get('screensavers.configs.nyc_subway.tick_sleep', 0.05)
 
         # State
         self.__arrivals = []

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -319,7 +319,7 @@ class NycSubway(Screensaver):
         self.__start_background_fetch()
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             # Start background fetch if needed (non-blocking)
             current_time = time.time()

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -319,6 +319,8 @@ class NycSubway(Screensaver):
         self.__start_background_fetch()
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             # Start background fetch if needed (non-blocking)
             current_time = time.time()
             if current_time - self.__last_update > self.__update_interval:

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -17,7 +17,6 @@ import threading
 from datetime import datetime, timezone
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver import textutils
@@ -71,10 +70,6 @@ class NycSubway(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -364,7 +359,7 @@ class NycSubway(Screensaver):
         # Advance animation tick
         self.__tick_count += 1
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __update_display_rows(self, new_arrivals):
         """Update display rows, triggering animations for changes."""

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -84,8 +84,6 @@ class NycSubway(Screensaver):
         self.__lines = Config.get('screensavers.configs.nyc_subway.lines', ['1', '2', '3'])
         self.__update_interval = Config.get('screensavers.configs.nyc_subway.update_interval', 30)
         self.__max_arrivals = Config.get('screensavers.configs.nyc_subway.max_arrivals', 4)
-        self.__max_ticks = Config.get('screensavers.configs.nyc_subway.max_ticks', 3000)
-        self.__tick_sleep = Config.get('screensavers.configs.nyc_subway.tick_sleep', 0.05)
 
         # State
         self.__arrivals = []
@@ -311,26 +309,18 @@ class NycSubway(Screensaver):
         with self.__fetch_lock:
             self.__grouped_arrivals = grouped[:self.__max_arrivals]
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting NYC Subway screensaver")
-
-        # Start initial fetch in background
+    def _setup(self):
+        """Start initial data fetch."""
         self.__start_background_fetch()
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            # Start background fetch if needed (non-blocking)
-            current_time = time.time()
-            if current_time - self.__last_update > self.__update_interval:
-                self.__start_background_fetch()
-                self.__last_update = current_time
+    def _tick(self, tick):
+        """Fetch new data if needed and render one frame."""
+        current_time = time.time()
+        if current_time - self.__last_update > self.__update_interval:
+            self.__start_background_fetch()
+            self.__last_update = current_time
 
-            self.__render()
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("NYC Subway screensaver ended")
+        self.__render()
 
     def __start_background_fetch(self):
         """Start a background thread to fetch arrivals."""

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -169,7 +169,7 @@ class PendulumWaves(Screensaver):
         self.__init_pendulums()
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             self.__update()
 

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -7,11 +7,9 @@ mesmerizing wave patterns as they go in and out of sync.
 
 import math
 import numpy as np
-import time
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -20,7 +18,6 @@ class PendulumWaves(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -36,8 +33,6 @@ class PendulumWaves(Screensaver):
         self.__bob_size = Config.get('screensavers.configs.pendulumwaves.bob_size', 1.5)
         self.__trail_fade = Config.get('screensavers.configs.pendulumwaves.trail_fade', 0.85)
         self.__color_mode = Config.get('screensavers.configs.pendulumwaves.color_mode', 'rainbow')  # rainbow, gradient, white
-        self.__tick_sleep = Config.get('screensavers.configs.pendulumwaves.tick_sleep', 0.03)
-        self.__max_ticks = Config.get('screensavers.configs.pendulumwaves.max_ticks', 10000)
 
         # Auto-calculate pendulum count if not specified
         if self.__num_pendulums <= 0:
@@ -163,23 +158,16 @@ class PendulumWaves(Screensaver):
 
         self.__tick += 1
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting Pendulum Waves screensaver")
+    def _setup(self):
+        """Initialize pendulums."""
         self.__init_pendulums()
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            self.__update()
+    def _tick(self, tick):
+        """Update pendulums and render one frame."""
+        self.__update()
 
-            # Convert to uint8 frame
-            frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
-
-            self.__led_frame_player.play_frame(frame)
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("Pendulum Waves screensaver ended")
+        frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
+        self.__led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -30,14 +30,14 @@ class PendulumWaves(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Config
-        self.__num_pendulums = Config.get('pendulumwaves.num_pendulums', 0)  # 0 = auto
-        self.__base_period = Config.get('pendulumwaves.base_period', 60.0)  # frames for longest pendulum
-        self.__cycle_time = Config.get('pendulumwaves.cycle_time', 600)  # frames for full pattern cycle
-        self.__bob_size = Config.get('pendulumwaves.bob_size', 1.5)
-        self.__trail_fade = Config.get('pendulumwaves.trail_fade', 0.85)
-        self.__color_mode = Config.get('pendulumwaves.color_mode', 'rainbow')  # rainbow, gradient, white
-        self.__tick_sleep = Config.get('pendulumwaves.tick_sleep', 0.03)
-        self.__max_ticks = Config.get('pendulumwaves.max_ticks', 10000)
+        self.__num_pendulums = Config.get('screensavers.configs.pendulumwaves.num_pendulums', 0)  # 0 = auto
+        self.__base_period = Config.get('screensavers.configs.pendulumwaves.base_period', 60.0)  # frames for longest pendulum
+        self.__cycle_time = Config.get('screensavers.configs.pendulumwaves.cycle_time', 600)  # frames for full pattern cycle
+        self.__bob_size = Config.get('screensavers.configs.pendulumwaves.bob_size', 1.5)
+        self.__trail_fade = Config.get('screensavers.configs.pendulumwaves.trail_fade', 0.85)
+        self.__color_mode = Config.get('screensavers.configs.pendulumwaves.color_mode', 'rainbow')  # rainbow, gradient, white
+        self.__tick_sleep = Config.get('screensavers.configs.pendulumwaves.tick_sleep', 0.03)
+        self.__max_ticks = Config.get('screensavers.configs.pendulumwaves.max_ticks', 10000)
 
         # Auto-calculate pendulum count if not specified
         if self.__num_pendulums <= 0:

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -169,6 +169,8 @@ class PendulumWaves(Screensaver):
         self.__init_pendulums()
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             self.__update()
 
             # Convert to uint8 frame

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -9,7 +9,6 @@ import math
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,10 +17,6 @@ class PendulumWaves(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -167,7 +162,7 @@ class PendulumWaves(Screensaver):
         self.__update()
 
         frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -30,15 +30,15 @@ class PerlinWorms(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Config
-        self.__num_worms = Config.get('perlinworms.num_worms', 8)
-        self.__worm_length = Config.get('perlinworms.worm_length', 12)
-        self.__speed = Config.get('perlinworms.speed', 0.8)
-        self.__noise_scale = Config.get('perlinworms.noise_scale', 0.1)
-        self.__time_speed = Config.get('perlinworms.time_speed', 0.02)
-        self.__fade = Config.get('perlinworms.fade', 0.92)
-        self.__glow_size = Config.get('perlinworms.glow_size', 1.5)
-        self.__tick_sleep = Config.get('perlinworms.tick_sleep', 0.03)
-        self.__max_ticks = Config.get('perlinworms.max_ticks', 10000)
+        self.__num_worms = Config.get('screensavers.configs.perlinworms.num_worms', 8)
+        self.__worm_length = Config.get('screensavers.configs.perlinworms.worm_length', 12)
+        self.__speed = Config.get('screensavers.configs.perlinworms.speed', 0.8)
+        self.__noise_scale = Config.get('screensavers.configs.perlinworms.noise_scale', 0.1)
+        self.__time_speed = Config.get('screensavers.configs.perlinworms.time_speed', 0.02)
+        self.__fade = Config.get('screensavers.configs.perlinworms.fade', 0.92)
+        self.__glow_size = Config.get('screensavers.configs.perlinworms.glow_size', 1.5)
+        self.__tick_sleep = Config.get('screensavers.configs.perlinworms.tick_sleep', 0.03)
+        self.__max_ticks = Config.get('screensavers.configs.perlinworms.max_ticks', 10000)
 
         # Initialize Perlin noise
         self.__perm = self.__generate_permutation()

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -9,7 +9,6 @@ import math
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,10 +17,6 @@ class PerlinWorms(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -224,7 +219,7 @@ class PerlinWorms(Screensaver):
         self.__draw_worms()
 
         frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -7,11 +7,9 @@ leaving glowing trails that fade over time.
 
 import math
 import numpy as np
-import time
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -20,7 +18,6 @@ class PerlinWorms(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -37,8 +34,6 @@ class PerlinWorms(Screensaver):
         self.__time_speed = Config.get('screensavers.configs.perlinworms.time_speed', 0.02)
         self.__fade = Config.get('screensavers.configs.perlinworms.fade', 0.92)
         self.__glow_size = Config.get('screensavers.configs.perlinworms.glow_size', 1.5)
-        self.__tick_sleep = Config.get('screensavers.configs.perlinworms.tick_sleep', 0.03)
-        self.__max_ticks = Config.get('screensavers.configs.perlinworms.max_ticks', 10000)
 
         # Initialize Perlin noise
         self.__perm = self.__generate_permutation()
@@ -218,30 +213,18 @@ class PerlinWorms(Screensaver):
                     self.__canvas[py, px, 1] = min(1.0, self.__canvas[py, px, 1] + g * intensity * 0.3)
                     self.__canvas[py, px, 2] = min(1.0, self.__canvas[py, px, 2] + b * intensity * 0.3)
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting Perlin Worms screensaver")
+    def _setup(self):
+        """Initialize worms."""
         self.__init_worms()
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            # Update time
-            self.__time += self.__time_speed
+    def _tick(self, tick):
+        """Update worms and render one frame."""
+        self.__time += self.__time_speed
+        self.__update_worms()
+        self.__draw_worms()
 
-            # Update worm positions
-            self.__update_worms()
-
-            # Draw worms
-            self.__draw_worms()
-
-            # Convert to uint8 frame
-            frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
-
-            self.__led_frame_player.play_frame(frame)
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("Perlin Worms screensaver ended")
+        frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
+        self.__led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -224,6 +224,8 @@ class PerlinWorms(Screensaver):
         self.__init_worms()
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             # Update time
             self.__time += self.__time_speed
 

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -224,7 +224,7 @@ class PerlinWorms(Screensaver):
         self.__init_worms()
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             # Update time
             self.__time += self.__time_speed

--- a/pifi/screensaver/reactiondiffusion.py
+++ b/pifi/screensaver/reactiondiffusion.py
@@ -1,5 +1,4 @@
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
@@ -35,19 +34,22 @@ class ReactionDiffusion(Screensaver):
 
         self.__time = 0
 
-    def play(self):
-        self.__logger.info("Starting Reaction Diffusion screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.reactiondiffusion.max_ticks', 2000)
-        tick = 0
+    def _tick(self, tick):
+        # Run multiple simulation steps per frame for faster evolution
+        steps_per_frame = Config.get('screensavers.configs.reactiondiffusion.steps_per_frame', 10)
+        for _ in range(steps_per_frame):
+            self.__simulate_step()
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Periodically inject new seeds to keep evolution going
+        inject_interval = Config.get('screensavers.configs.reactiondiffusion.inject_interval', 100)
+        if self.__time > 0 and self.__time % inject_interval == 0:
+            self.__inject_seed()
 
-        self.__logger.info("Reaction Diffusion screensaver ended")
+        self.__render()
+        self.__time += 1
 
     def __reset(self):
         self.__time = 0
@@ -86,20 +88,6 @@ class ReactionDiffusion(Screensaver):
         self.__hue = random.random()
 
         self.__logger.info(f"Reaction Diffusion params: f={self.__params['f']}, k={self.__params['k']}")
-
-    def __tick(self):
-        # Run multiple simulation steps per frame for faster evolution
-        steps_per_frame = Config.get('screensavers.configs.reactiondiffusion.steps_per_frame', 10)
-        for _ in range(steps_per_frame):
-            self.__simulate_step()
-
-        # Periodically inject new seeds to keep evolution going
-        inject_interval = Config.get('screensavers.configs.reactiondiffusion.inject_interval', 100)
-        if self.__time > 0 and self.__time % inject_interval == 0:
-            self.__inject_seed()
-
-        self.__render()
-        self.__time += 1
 
     def __inject_seed(self):
         """Inject a new seed to keep the pattern evolving."""
@@ -198,9 +186,6 @@ class ReactionDiffusion(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.reactiondiffusion.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/reactiondiffusion.py
+++ b/pifi/screensaver/reactiondiffusion.py
@@ -39,7 +39,7 @@ class ReactionDiffusion(Screensaver):
         self.__logger.info("Starting Reaction Diffusion screensaver")
         self.__reset()
 
-        max_ticks = Config.get('reactiondiffusion.max_ticks', 2000)
+        max_ticks = Config.get('screensavers.configs.reactiondiffusion.max_ticks', 2000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -57,7 +57,7 @@ class ReactionDiffusion(Screensaver):
         self.__B = np.zeros((self.__height, self.__width), dtype=np.float32)
 
         # Seed some B in random spots - more seeds for faster start
-        num_seeds = Config.get('reactiondiffusion.num_seeds', 8)
+        num_seeds = Config.get('screensavers.configs.reactiondiffusion.num_seeds', 8)
         for _ in range(num_seeds):
             cx = random.randint(2, self.__width - 3)
             cy = random.randint(2, self.__height - 3)
@@ -89,12 +89,12 @@ class ReactionDiffusion(Screensaver):
 
     def __tick(self):
         # Run multiple simulation steps per frame for faster evolution
-        steps_per_frame = Config.get('reactiondiffusion.steps_per_frame', 10)
+        steps_per_frame = Config.get('screensavers.configs.reactiondiffusion.steps_per_frame', 10)
         for _ in range(steps_per_frame):
             self.__simulate_step()
 
         # Periodically inject new seeds to keep evolution going
-        inject_interval = Config.get('reactiondiffusion.inject_interval', 100)
+        inject_interval = Config.get('screensavers.configs.reactiondiffusion.inject_interval', 100)
         if self.__time > 0 and self.__time % inject_interval == 0:
             self.__inject_seed()
 
@@ -200,7 +200,7 @@ class ReactionDiffusion(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('reactiondiffusion.tick_sleep', 0.05)
+        return Config.get('screensavers.configs.reactiondiffusion.tick_sleep', 0.05)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/reactiondiffusion.py
+++ b/pifi/screensaver/reactiondiffusion.py
@@ -3,7 +3,6 @@ import random
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,11 +18,6 @@ class ReactionDiffusion(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -158,7 +152,7 @@ class ReactionDiffusion(Screensaver):
                     val = (1 - a) * 0.15
                     frame[y, x] = self.__hsv_to_rgb(self.__hue, 0.3, val)
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         if s == 0.0:

--- a/pifi/screensaver/reactiondiffusion.py
+++ b/pifi/screensaver/reactiondiffusion.py
@@ -42,7 +42,7 @@ class ReactionDiffusion(Screensaver):
         max_ticks = Config.get('reactiondiffusion.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/reactiondiffusion.py
+++ b/pifi/screensaver/reactiondiffusion.py
@@ -42,7 +42,7 @@ class ReactionDiffusion(Screensaver):
         max_ticks = Config.get('reactiondiffusion.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -2,10 +2,22 @@ import time
 from abc import ABC, abstractmethod
 
 from pifi.config import Config
+from pifi.logger import Logger
 
 
 class Screensaver(ABC):
-    """Abstract base class for all screensavers."""
+    """Abstract base class for all screensavers.
+
+    Provides a template play() method that runs a tick loop with timeout
+    enforcement. Subclasses implement _tick(), and optionally override
+    _setup() / _teardown().
+
+    The tick loop exits when any of these occur:
+    - The timeout is exceeded (per-screensaver or global)
+    - _tick() returns False (for subclass-specific stop conditions)
+    """
+
+    _screensaver_logger = Logger().set_namespace('Screensaver')
 
     def __init__(self, led_frame_player=None):
         """
@@ -22,21 +34,64 @@ class Screensaver(ABC):
         self._screensaver_base_init_called = True
         self._start_time = time.time()
 
-    def _is_past_screensaver_timeout(self):
+        # Per-screensaver config overrides global defaults. To revert a
+        # per-screensaver override, remove the key (set to null via the API)
+        # so it falls back to the global value.
+        # e.g. screensavers.configs.boids.tick_sleep overrides screensavers.tick_sleep
+        sid = self.get_id()
+        self._tick_sleep = Config.get(
+            f'screensavers.configs.{sid}.tick_sleep',
+            Config.get('screensavers.tick_sleep', 0.05)
+        )
+        self._timeout = Config.get(
+            f'screensavers.configs.{sid}.timeout',
+            Config.get('screensavers.timeout', 120)
+        )
+
+    def _is_past_timeout(self):
         """Check if the screensaver timeout has been exceeded.
 
-        Returns True if screensavers.timeout is set (> 0) and the elapsed
-        time since play started exceeds it. Returns False if timeout is
-        not set (None/0), deferring to per-screensaver max_ticks.
+        A timeout of 0 or None means unlimited (never times out).
         """
-        screensaver_timeout = Config.get('screensavers.timeout', None)
-        if not screensaver_timeout:
+        if not self._timeout:
             return False
-        return (time.time() - self._start_time) > screensaver_timeout
+        return (time.time() - self._start_time) > self._timeout
+
+    def play(self) -> None:
+        """Run the screensaver tick loop.
+
+        Calls _setup(), then runs _tick() in a loop until timeout or
+        _tick() returns False. Calls _teardown() in a finally block
+        to ensure cleanup.
+        """
+        self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
+        self._setup()
+        try:
+            tick = 0
+            while not self._is_past_timeout():
+                if self._tick(tick) is False:
+                    break
+                time.sleep(self._tick_sleep)
+                tick += 1
+        finally:
+            self._teardown()
+        self._screensaver_logger.info(f"{self.get_name()} screensaver ended")
+
+    def _setup(self):
+        """Called once before the tick loop. Override for initialization."""
+        pass
+
+    def _teardown(self):
+        """Called after the tick loop (in finally block). Override for cleanup."""
+        pass
 
     @abstractmethod
-    def play(self) -> None:
-        """Play the screensaver until completion."""
+    def _tick(self, tick) -> None:
+        """Called each iteration of the tick loop.
+
+        Return False to stop the loop early. Any other return value
+        (including None) continues the loop.
+        """
         pass
 
     @classmethod

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -1,4 +1,8 @@
+import time
 from abc import ABC, abstractmethod
+
+from pifi.config import Config
+
 
 class Screensaver(ABC):
     """Abstract base class for all screensavers."""
@@ -16,6 +20,19 @@ class Screensaver(ABC):
         """
         # Flag to verify subclasses call super().__init__()
         self._screensaver_base_init_called = True
+        self._start_time = time.time()
+
+    def _is_past_dwell_time(self):
+        """Check if the central dwell time has been exceeded.
+
+        Returns True if screensavers.dwell_time is set (> 0) and the elapsed
+        time since play started exceeds it. Returns False if dwell_time is
+        not set (None/0), deferring to per-screensaver max_ticks.
+        """
+        dwell_time = Config.get('screensavers.dwell_time', None)
+        if not dwell_time:
+            return False
+        return (time.time() - self._start_time) > dwell_time
 
     @abstractmethod
     def play(self) -> None:

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -22,17 +22,17 @@ class Screensaver(ABC):
         self._screensaver_base_init_called = True
         self._start_time = time.time()
 
-    def _is_past_dwell_time(self):
-        """Check if the central dwell time has been exceeded.
+    def _is_past_screensaver_timeout(self):
+        """Check if the screensaver timeout has been exceeded.
 
-        Returns True if screensavers.dwell_time is set (> 0) and the elapsed
-        time since play started exceeds it. Returns False if dwell_time is
+        Returns True if screensavers.screensaver_timeout is set (> 0) and the elapsed
+        time since play started exceeds it. Returns False if screensaver_timeout is
         not set (None/0), deferring to per-screensaver max_ticks.
         """
-        dwell_time = Config.get('screensavers.dwell_time', None)
-        if not dwell_time:
+        screensaver_timeout = Config.get('screensavers.screensaver_timeout', None)
+        if not screensaver_timeout:
             return False
-        return (time.time() - self._start_time) > dwell_time
+        return (time.time() - self._start_time) > screensaver_timeout
 
     @abstractmethod
     def play(self) -> None:

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -25,11 +25,11 @@ class Screensaver(ABC):
     def _is_past_screensaver_timeout(self):
         """Check if the screensaver timeout has been exceeded.
 
-        Returns True if screensavers.screensaver_timeout is set (> 0) and the elapsed
-        time since play started exceeds it. Returns False if screensaver_timeout is
+        Returns True if screensavers.timeout is set (> 0) and the elapsed
+        time since play started exceeds it. Returns False if timeout is
         not set (None/0), deferring to per-screensaver max_ticks.
         """
-        screensaver_timeout = Config.get('screensavers.screensaver_timeout', None)
+        screensaver_timeout = Config.get('screensavers.timeout', None)
         if not screensaver_timeout:
             return False
         return (time.time() - self._start_time) > screensaver_timeout

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -2,6 +2,7 @@ import time
 from abc import ABC, abstractmethod
 
 from pifi.config import Config
+from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
 
 
@@ -24,8 +25,8 @@ class Screensaver(ABC):
         Standard constructor signature for all screensavers.
 
         Args:
-            led_frame_player: Optional LedFramePlayer instance. If None, subclasses
-                            typically create their own instance.
+            led_frame_player: Optional LedFramePlayer instance. If None, a new
+                            instance is created. Stored as self._led_frame_player.
 
         Note: Subclasses must call super().__init__(led_frame_player) as the first
               line of their __init__ method.
@@ -33,19 +34,29 @@ class Screensaver(ABC):
         # Flag to verify subclasses call super().__init__()
         self._screensaver_base_init_called = True
 
-        # Per-screensaver config overrides global defaults. To revert a
-        # per-screensaver override, remove the key (set to null via the API)
-        # so it falls back to the global value.
+        if led_frame_player is None:
+            led_frame_player = LedFramePlayer()
+        self._led_frame_player = led_frame_player
+
+        # Per-screensaver config overrides global defaults. A per-screensaver
+        # value of None (null in JSON) falls back to the global value — this is
+        # how the API reverts per-screensaver overrides.
         # e.g. screensavers.configs.boids.tick_sleep overrides screensavers.tick_sleep
         sid = self.get_id()
-        self._tick_sleep = Config.get(
-            f'screensavers.configs.{sid}.tick_sleep',
-            Config.get('screensavers.tick_sleep', 0.05)
-        )
-        self._timeout = Config.get(
-            f'screensavers.configs.{sid}.timeout',
-            Config.get('screensavers.timeout', 120)
-        )
+
+        self._tick_sleep = Config.get(f'screensavers.configs.{sid}.tick_sleep')
+        if self._tick_sleep is None:
+            self._tick_sleep = Config.get('screensavers.tick_sleep')
+        if self._tick_sleep is None:
+            self._tick_sleep = 0
+
+        # For timeout, null means unlimited at the global level (0 also means
+        # unlimited). At the per-screensaver level, null falls back to global.
+        self._timeout = Config.get(f'screensavers.configs.{sid}.timeout')
+        if self._timeout is None:
+            self._timeout = Config.get('screensavers.timeout')
+        if self._timeout is None:
+            self._timeout = 0
 
     def _is_past_timeout(self):
         """Check if the screensaver timeout has been exceeded.

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -32,7 +32,6 @@ class Screensaver(ABC):
         """
         # Flag to verify subclasses call super().__init__()
         self._screensaver_base_init_called = True
-        self._start_time = time.time()
 
         # Per-screensaver config overrides global defaults. To revert a
         # per-screensaver override, remove the key (set to null via the API)
@@ -65,6 +64,7 @@ class Screensaver(ABC):
         to ensure cleanup.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
+        self._start_time = time.time()
         self._setup()
         try:
             tick = 0

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -32,7 +32,7 @@ from pifi.screensaver.cellularautomata.cyclicautomaton import CyclicAutomaton
 from pifi.screensaver.cellularautomata.gameoflife import GameOfLife
 from pifi.screensaver.videoscreensaver import VideoScreensaver
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.screensaver.transition import TransitionPlayer
+from pifi.screensaver.transitionplayer import TransitionPlayer
 from pifi.settingsdb import SettingsDb
 from pifi.logger import Logger
 

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -140,7 +140,7 @@ class ScreensaverManager:
 
             # Reload config overrides from database before playing
             # This picks up any changes made via the settings UI
-            Config.reload_screensaver_overrides()
+            Config.reload_overrides([SettingsDb.SCREENSAVER_CONFIGS, SettingsDb.GLOBAL_SCREENSAVER_SETTINGS])
 
             # Build list of available screensaver IDs
             available_ids = []
@@ -160,7 +160,4 @@ class ScreensaverManager:
             screensaver.play()
 
             if Config.get('transitions.enabled', True):
-                try:
-                    self.__transition_player.play_transition()
-                except Exception as e:
-                    self.__logger.warning(f"Transition failed: {e}")
+                self.__transition_player.play_transition()

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -123,7 +123,7 @@ class ScreensaverManager:
     def get_enabled_screensavers():
         """Get list of enabled screensaver IDs."""
         Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-        return Config.get('screensavers.enabled', ['game_of_life', 'cyclic_automaton'])
+        return Config.get('screensavers.enabled')
 
     def run(self):
         while True:
@@ -131,7 +131,7 @@ class ScreensaverManager:
             # This picks up any changes made via the settings UI
             Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
-            enabled = Config.get('screensavers.enabled', ['game_of_life', 'cyclic_automaton'])
+            enabled = Config.get('screensavers.enabled')
 
             # Build list of available screensaver IDs
             available_ids = []

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -159,5 +159,5 @@ class ScreensaverManager:
             screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
             screensaver.play()
 
-            if Config.get('transitions.enabled', True):
+            if Config.get('screensavers.transitions.enabled', True):
                 self.__transition_player.play_transition()

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -1,4 +1,3 @@
-import json
 import random
 
 from pifi.config import Config
@@ -122,25 +121,17 @@ class ScreensaverManager:
 
     @staticmethod
     def get_enabled_screensavers():
-        """Get list of enabled screensaver IDs from database."""
-        settings_db = SettingsDb()
-        enabled_json = settings_db.get(SettingsDb.ENABLED_SCREENSAVERS)
-        if enabled_json:
-            return json.loads(enabled_json)
-        return ['game_of_life', 'cyclic_automaton']
-
-    def __get_enabled_screensavers(self):
-        """Get list of enabled screensaver IDs from SettingsDb."""
-        return ScreensaverManager.get_enabled_screensavers()
+        """Get list of enabled screensaver IDs."""
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
+        return Config.get('screensavers.enabled', ['game_of_life', 'cyclic_automaton'])
 
     def run(self):
         while True:
-            # Re-read enabled screensavers each iteration so changes take effect
-            enabled = self.__get_enabled_screensavers()
-
             # Reload config overrides from database before playing
             # This picks up any changes made via the settings UI
-            Config.reload_overrides([SettingsDb.SCREENSAVER_CONFIGS, SettingsDb.GLOBAL_SCREENSAVER_SETTINGS])
+            Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
+
+            enabled = Config.get('screensavers.enabled', ['game_of_life', 'cyclic_automaton'])
 
             # Build list of available screensaver IDs
             available_ids = []

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -33,6 +33,7 @@ from pifi.screensaver.cellularautomata.cyclicautomaton import CyclicAutomaton
 from pifi.screensaver.cellularautomata.gameoflife import GameOfLife
 from pifi.screensaver.videoscreensaver import VideoScreensaver
 from pifi.led.ledframeplayer import LedFramePlayer
+from pifi.screensaver.transition import TransitionPlayer
 from pifi.settingsdb import SettingsDb
 from pifi.logger import Logger
 
@@ -101,6 +102,8 @@ class ScreensaverManager:
                 raise
         self.__logger.info("All screensavers validated successfully")
 
+        self.__transition_player = TransitionPlayer(self.__led_frame_player)
+
     @staticmethod
     def get_all_screensavers():
         """Get metadata for all available screensavers."""
@@ -155,3 +158,9 @@ class ScreensaverManager:
             screensaver_cls = self.SCREENSAVER_CLASSES[screensaver_id]
             screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
             screensaver.play()
+
+            if Config.get('transitions.enabled', True):
+                try:
+                    self.__transition_player.play_transition()
+                except Exception as e:
+                    self.__logger.warning(f"Transition failed: {e}")

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -119,12 +119,6 @@ class ScreensaverManager:
 
         return ScreensaverManager._all_screensavers_cache
 
-    @staticmethod
-    def get_enabled_screensavers():
-        """Get list of enabled screensaver IDs."""
-        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-        return Config.get('screensavers.enabled')
-
     def run(self):
         while True:
             # Reload config overrides from database before playing

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -43,7 +43,7 @@ class Shadebobs(Screensaver):
         max_ticks = Config.get('shadebobs.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -1,6 +1,5 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
@@ -36,19 +35,34 @@ class Shadebobs(Screensaver):
         self.__bobs = []
         self.__time = 0
 
-    def play(self):
-        self.__logger.info("Starting Shadebobs screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.shadebobs.max_ticks', 2000)
-        tick = 0
+    def _tick(self, tick):
+        # Fade the buffer
+        fade = Config.get('screensavers.configs.shadebobs.fade', 0.92)
+        self.__buffer *= fade
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Update and draw each bob
+        for bob in self.__bobs:
+            # Update hue
+            bob['hue'] = (bob['hue'] + bob['hue_speed']) % 1.0
 
-        self.__logger.info("Shadebobs screensaver ended")
+            # Calculate position using Lissajous curves
+            t = self.__time * bob['speed'] * 0.05
+            x = math.sin(bob['freq_x'] * t + bob['phase_x'])
+            y = math.sin(bob['freq_y'] * t + bob['phase_y'])
+
+            # Map from [-1, 1] to screen coordinates
+            screen_x = (x + 1) / 2 * (self.__width - 1)
+            screen_y = (y + 1) / 2 * (self.__height - 1)
+
+            # Draw the bob with additive blending
+            self.__draw_bob(screen_x, screen_y, bob)
+
+        # Render to display
+        self.__render()
+        self.__time += 1
 
     def __reset(self):
         # Float buffer for smooth color accumulation
@@ -79,32 +93,6 @@ class Shadebobs(Screensaver):
             self.__bobs.append(bob)
 
         self.__logger.info(f"Created {num_bobs} shadebobs")
-
-    def __tick(self):
-        # Fade the buffer
-        fade = Config.get('screensavers.configs.shadebobs.fade', 0.92)
-        self.__buffer *= fade
-
-        # Update and draw each bob
-        for bob in self.__bobs:
-            # Update hue
-            bob['hue'] = (bob['hue'] + bob['hue_speed']) % 1.0
-
-            # Calculate position using Lissajous curves
-            t = self.__time * bob['speed'] * 0.05
-            x = math.sin(bob['freq_x'] * t + bob['phase_x'])
-            y = math.sin(bob['freq_y'] * t + bob['phase_y'])
-
-            # Map from [-1, 1] to screen coordinates
-            screen_x = (x + 1) / 2 * (self.__width - 1)
-            screen_y = (y + 1) / 2 * (self.__height - 1)
-
-            # Draw the bob with additive blending
-            self.__draw_bob(screen_x, screen_y, bob)
-
-        # Render to display
-        self.__render()
-        self.__time += 1
 
     def __draw_bob(self, cx, cy, bob):
         """Draw a glowing bob at the given position with additive blending."""
@@ -169,9 +157,6 @@ class Shadebobs(Screensaver):
             r, g, b = v, p, q
 
         return [r * 255, g * 255, b * 255]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.shadebobs.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -43,7 +43,7 @@ class Shadebobs(Screensaver):
         max_ticks = Config.get('shadebobs.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -40,7 +40,7 @@ class Shadebobs(Screensaver):
         self.__logger.info("Starting Shadebobs screensaver")
         self.__reset()
 
-        max_ticks = Config.get('shadebobs.max_ticks', 2000)
+        max_ticks = Config.get('screensavers.configs.shadebobs.max_ticks', 2000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -56,7 +56,7 @@ class Shadebobs(Screensaver):
         self.__time = 0
 
         # Create bobs with different Lissajous parameters
-        num_bobs = Config.get('shadebobs.num_bobs', 5)
+        num_bobs = Config.get('screensavers.configs.shadebobs.num_bobs', 5)
         self.__bobs = []
 
         for i in range(num_bobs):
@@ -82,7 +82,7 @@ class Shadebobs(Screensaver):
 
     def __tick(self):
         # Fade the buffer
-        fade = Config.get('shadebobs.fade', 0.92)
+        fade = Config.get('screensavers.configs.shadebobs.fade', 0.92)
         self.__buffer *= fade
 
         # Update and draw each bob
@@ -171,7 +171,7 @@ class Shadebobs(Screensaver):
         return [r * 255, g * 255, b * 255]
 
     def __get_tick_sleep(self):
-        return Config.get('shadebobs.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.shadebobs.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -4,7 +4,6 @@ import random
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,11 +18,6 @@ class Shadebobs(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -128,7 +122,7 @@ class Shadebobs(Screensaver):
         """Convert float buffer to uint8 and display."""
         # Clamp to 255 and convert
         frame = np.clip(self.__buffer, 0, 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV to RGB, returns values in 0-255 range."""

--- a/pifi/screensaver/sonoskaraoke.py
+++ b/pifi/screensaver/sonoskaraoke.py
@@ -20,11 +20,11 @@ class SonosKaraoke(KaraokeBase):
         super().__init__(led_frame_player)
 
         # Sonos-specific configuration
-        self.__speaker_name = Config.get('sonos_karaoke.speaker_name', None)
-        self.__update_interval = Config.get('sonos_karaoke.update_interval', 0.5)
-        self._max_ticks = Config.get('sonos_karaoke.max_ticks', 6000)
-        self._tick_sleep = Config.get('sonos_karaoke.tick_sleep', 0.05)
-        self._pulse_lyrics = Config.get('sonos_karaoke.pulse_lyrics', True)
+        self.__speaker_name = Config.get('screensavers.configs.sonos_karaoke.speaker_name', None)
+        self.__update_interval = Config.get('screensavers.configs.sonos_karaoke.update_interval', 0.5)
+        self._max_ticks = Config.get('screensavers.configs.sonos_karaoke.max_ticks', 6000)
+        self._tick_sleep = Config.get('screensavers.configs.sonos_karaoke.tick_sleep', 0.05)
+        self._pulse_lyrics = Config.get('screensavers.configs.sonos_karaoke.pulse_lyrics', True)
 
         # Sonos speaker reference
         self.__speaker = None

--- a/pifi/screensaver/sonoskaraoke.py
+++ b/pifi/screensaver/sonoskaraoke.py
@@ -22,8 +22,6 @@ class SonosKaraoke(KaraokeBase):
         # Sonos-specific configuration
         self.__speaker_name = Config.get('screensavers.configs.sonos_karaoke.speaker_name', None)
         self.__update_interval = Config.get('screensavers.configs.sonos_karaoke.update_interval', 0.5)
-        self._max_ticks = Config.get('screensavers.configs.sonos_karaoke.max_ticks', 6000)
-        self._tick_sleep = Config.get('screensavers.configs.sonos_karaoke.tick_sleep', 0.05)
         self._pulse_lyrics = Config.get('screensavers.configs.sonos_karaoke.pulse_lyrics', True)
 
         # Sonos speaker reference

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -4,7 +4,6 @@ import random
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -20,11 +19,6 @@ class Spirograph(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -121,7 +115,7 @@ class Spirograph(Screensaver):
                 # Additive blending for overlapping points
                 frame[iy, ix] = np.minimum(255, frame[iy, ix] + np.array(rgb, dtype=np.uint8))
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV color to RGB."""

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -42,7 +42,7 @@ class Spirograph(Screensaver):
         max_ticks = Config.get('spirograph.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -1,6 +1,5 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
@@ -35,43 +34,10 @@ class Spirograph(Screensaver):
         self.__trail = []  # List of (x, y, hue) points
         self.__params = {}
 
-    def play(self):
-        self.__logger.info("Starting Spirograph screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.spirograph.max_ticks', 2000)
-        tick = 0
-
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Spirograph screensaver ended")
-
-    def __reset(self):
-        self.__time = 0.0
-        self.__trail = []
-
-        # Randomize spirograph parameters for variety
-        # R = radius of fixed circle, r = radius of rolling circle, d = drawing point offset
-        self.__params = {
-            'R': random.uniform(0.3, 0.5),  # Outer radius (fraction of display)
-            'r': random.uniform(0.08, 0.25),  # Inner radius
-            'd': random.uniform(0.05, 0.2),   # Pen offset
-            'speed1': random.uniform(0.02, 0.05),  # Primary rotation speed
-            'speed2': random.uniform(0.03, 0.08),  # Secondary rotation speed
-            'hue_speed': random.uniform(0.001, 0.003),  # Color cycling speed
-        }
-
-        # Ensure interesting ratio (non-repeating patterns)
-        ratio = self.__params['R'] / self.__params['r']
-        if abs(ratio - round(ratio)) < 0.1:
-            self.__params['r'] *= 1.1
-
-        self.__logger.info(f"Spirograph params: R={self.__params['R']:.3f}, r={self.__params['r']:.3f}")
-
-    def __tick(self):
+    def _tick(self, tick):
         time_speed = Config.get('screensavers.configs.spirograph.time_speed', 1.0)
         self.__time += time_speed
 
@@ -112,6 +78,28 @@ class Spirograph(Screensaver):
             self.__trail.pop(0)
 
         self.__render()
+
+    def __reset(self):
+        self.__time = 0.0
+        self.__trail = []
+
+        # Randomize spirograph parameters for variety
+        # R = radius of fixed circle, r = radius of rolling circle, d = drawing point offset
+        self.__params = {
+            'R': random.uniform(0.3, 0.5),  # Outer radius (fraction of display)
+            'r': random.uniform(0.08, 0.25),  # Inner radius
+            'd': random.uniform(0.05, 0.2),   # Pen offset
+            'speed1': random.uniform(0.02, 0.05),  # Primary rotation speed
+            'speed2': random.uniform(0.03, 0.08),  # Secondary rotation speed
+            'hue_speed': random.uniform(0.001, 0.003),  # Color cycling speed
+        }
+
+        # Ensure interesting ratio (non-repeating patterns)
+        ratio = self.__params['R'] / self.__params['r']
+        if abs(ratio - round(ratio)) < 0.1:
+            self.__params['r'] *= 1.1
+
+        self.__logger.info(f"Spirograph params: R={self.__params['R']:.3f}, r={self.__params['r']:.3f}")
 
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
@@ -161,9 +149,6 @@ class Spirograph(Screensaver):
             r, g, b = v, p, q
 
         return [int(r * 255), int(g * 255), int(b * 255)]
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.spirograph.tick_sleep', 0.02)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -42,7 +42,7 @@ class Spirograph(Screensaver):
         max_ticks = Config.get('spirograph.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -39,7 +39,7 @@ class Spirograph(Screensaver):
         self.__logger.info("Starting Spirograph screensaver")
         self.__reset()
 
-        max_ticks = Config.get('spirograph.max_ticks', 2000)
+        max_ticks = Config.get('screensavers.configs.spirograph.max_ticks', 2000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -72,7 +72,7 @@ class Spirograph(Screensaver):
         self.__logger.info(f"Spirograph params: R={self.__params['R']:.3f}, r={self.__params['r']:.3f}")
 
     def __tick(self):
-        time_speed = Config.get('spirograph.time_speed', 1.0)
+        time_speed = Config.get('screensavers.configs.spirograph.time_speed', 1.0)
         self.__time += time_speed
 
         # Calculate current point using epitrochoid formula
@@ -106,7 +106,7 @@ class Spirograph(Screensaver):
         hue = (self.__time * self.__params['hue_speed']) % 1.0
 
         # Add to trail
-        max_trail = Config.get('spirograph.trail_length', 500)
+        max_trail = Config.get('screensavers.configs.spirograph.trail_length', 500)
         self.__trail.append((screen_x, screen_y, hue))
         if len(self.__trail) > max_trail:
             self.__trail.pop(0)
@@ -115,7 +115,7 @@ class Spirograph(Screensaver):
 
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
-        fade_trail = Config.get('spirograph.fade_trail', True)
+        fade_trail = Config.get('screensavers.configs.spirograph.fade_trail', True)
 
         for i, (x, y, hue) in enumerate(self.__trail):
             ix = int(x) % self.__width
@@ -163,7 +163,7 @@ class Spirograph(Screensaver):
         return [int(r * 255), int(g * 255), int(b * 255)]
 
     def __get_tick_sleep(self):
-        return Config.get('spirograph.tick_sleep', 0.02)
+        return Config.get('screensavers.configs.spirograph.tick_sleep', 0.02)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -37,7 +37,7 @@ class Starfield(Screensaver):
         self.__logger.info("Starting Starfield screensaver")
         self.__reset()
 
-        max_ticks = Config.get('starfield.max_ticks', 3000)
+        max_ticks = Config.get('screensavers.configs.starfield.max_ticks', 3000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -48,7 +48,7 @@ class Starfield(Screensaver):
         self.__logger.info("Starfield screensaver ended")
 
     def __reset(self):
-        num_stars = Config.get('starfield.num_stars', 80)
+        num_stars = Config.get('screensavers.configs.starfield.num_stars', 80)
         self.__stars = []
 
         for _ in range(num_stars):
@@ -73,7 +73,7 @@ class Starfield(Screensaver):
         self.__stars.append([x, y, z])
 
     def __tick(self):
-        speed = Config.get('starfield.speed', 0.02)
+        speed = Config.get('screensavers.configs.starfield.speed', 0.02)
 
         # Move stars toward viewer (decrease z)
         new_stars = []
@@ -89,7 +89,7 @@ class Starfield(Screensaver):
         self.__stars = new_stars
 
         # Maintain star count
-        num_stars = Config.get('starfield.num_stars', 80)
+        num_stars = Config.get('screensavers.configs.starfield.num_stars', 80)
         while len(self.__stars) < num_stars:
             self.__add_star(random_z=False)
 
@@ -101,8 +101,8 @@ class Starfield(Screensaver):
         cx = self.__width / 2
         cy = self.__height / 2
 
-        show_trails = Config.get('starfield.show_trails', True)
-        trail_length = Config.get('starfield.trail_length', 3)
+        show_trails = Config.get('screensavers.configs.starfield.show_trails', True)
+        trail_length = Config.get('screensavers.configs.starfield.trail_length', 3)
 
         for star in self.__stars:
             x, y, z = star
@@ -159,7 +159,7 @@ class Starfield(Screensaver):
         self.__led_frame_player.play_frame(frame)
 
     def __get_tick_sleep(self):
-        return Config.get('starfield.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.starfield.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -40,7 +40,7 @@ class Starfield(Screensaver):
         max_ticks = Config.get('starfield.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,11 +17,6 @@ class Starfield(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -142,7 +136,7 @@ class Starfield(Screensaver):
                             trail_color = [trail_int, trail_int, trail_int]
                             frame[tiy, tix] = np.maximum(frame[tiy, tix], trail_color)
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -40,7 +40,7 @@ class Starfield(Screensaver):
         max_ticks = Config.get('starfield.max_ticks', 3000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,7 +18,6 @@ class Starfield(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -33,19 +30,31 @@ class Starfield(Screensaver):
         # Stars: each is [x, y, z] where z is depth (0 = closest, 1 = farthest)
         self.__stars = []
 
-    def play(self):
-        self.__logger.info("Starting Starfield screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.starfield.max_ticks', 3000)
-        tick = 0
+    def _tick(self, tick):
+        speed = Config.get('screensavers.configs.starfield.speed', 0.02)
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
+        # Move stars toward viewer (decrease z)
+        new_stars = []
+        for star in self.__stars:
+            star[2] -= speed
 
-        self.__logger.info("Starfield screensaver ended")
+            # If star passed the viewer, respawn it far away
+            if star[2] <= 0.01:
+                self.__add_star(random_z=False)
+            else:
+                new_stars.append(star)
+
+        self.__stars = new_stars
+
+        # Maintain star count
+        num_stars = Config.get('screensavers.configs.starfield.num_stars', 80)
+        while len(self.__stars) < num_stars:
+            self.__add_star(random_z=False)
+
+        self.__render()
 
     def __reset(self):
         num_stars = Config.get('screensavers.configs.starfield.num_stars', 80)
@@ -71,29 +80,6 @@ class Starfield(Screensaver):
             z = 1.0
 
         self.__stars.append([x, y, z])
-
-    def __tick(self):
-        speed = Config.get('screensavers.configs.starfield.speed', 0.02)
-
-        # Move stars toward viewer (decrease z)
-        new_stars = []
-        for star in self.__stars:
-            star[2] -= speed
-
-            # If star passed the viewer, respawn it far away
-            if star[2] <= 0.01:
-                self.__add_star(random_z=False)
-            else:
-                new_stars.append(star)
-
-        self.__stars = new_stars
-
-        # Maintain star count
-        num_stars = Config.get('screensavers.configs.starfield.num_stars', 80)
-        while len(self.__stars) < num_stars:
-            self.__add_star(random_z=False)
-
-        self.__render()
 
     def __render(self):
         frame = np.zeros([self.__height, self.__width, 3], np.uint8)
@@ -157,9 +143,6 @@ class Starfield(Screensaver):
                             frame[tiy, tix] = np.maximum(frame[tiy, tix], trail_color)
 
         self.__led_frame_player.play_frame(frame)
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.starfield.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -7,11 +7,9 @@ curved envelope patterns through straight lines alone.
 
 import math
 import numpy as np
-import time
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -20,7 +18,6 @@ class StringArt(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -36,8 +33,6 @@ class StringArt(Screensaver):
         self.__rotation_speed = Config.get('screensavers.configs.stringart.rotation_speed', 0.01)
         self.__fade = Config.get('screensavers.configs.stringart.fade', 0.15)
         self.__line_brightness = Config.get('screensavers.configs.stringart.line_brightness', 0.4)
-        self.__tick_sleep = Config.get('screensavers.configs.stringart.tick_sleep', 0.03)
-        self.__max_ticks = Config.get('screensavers.configs.stringart.max_ticks', 10000)
 
         # Canvas buffer
         self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
@@ -162,23 +157,16 @@ class StringArt(Screensaver):
         self.__hue = (self.__hue + 0.001) % 1.0
         self.__tick += 1
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting String Art screensaver")
+    def _setup(self):
+        """Initialize the pattern."""
         self.__init_pattern()
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            self.__update()
+    def _tick(self, tick):
+        """Update pattern and render one frame."""
+        self.__update()
 
-            # Convert to uint8 frame
-            frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
-
-            self.__led_frame_player.play_frame(frame)
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("String Art screensaver ended")
+        frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
+        self.__led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -9,7 +9,6 @@ import math
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -18,10 +17,6 @@ class StringArt(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -166,7 +161,7 @@ class StringArt(Screensaver):
         self.__update()
 
         frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -168,7 +168,7 @@ class StringArt(Screensaver):
         self.__init_pattern()
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             self.__update()
 

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -30,14 +30,14 @@ class StringArt(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Config
-        self.__num_points = Config.get('stringart.num_points', 64)
-        self.__num_strings = Config.get('stringart.num_strings', 32)
-        self.__multiplier_speed = Config.get('stringart.multiplier_speed', 0.02)
-        self.__rotation_speed = Config.get('stringart.rotation_speed', 0.01)
-        self.__fade = Config.get('stringart.fade', 0.15)
-        self.__line_brightness = Config.get('stringart.line_brightness', 0.4)
-        self.__tick_sleep = Config.get('stringart.tick_sleep', 0.03)
-        self.__max_ticks = Config.get('stringart.max_ticks', 10000)
+        self.__num_points = Config.get('screensavers.configs.stringart.num_points', 64)
+        self.__num_strings = Config.get('screensavers.configs.stringart.num_strings', 32)
+        self.__multiplier_speed = Config.get('screensavers.configs.stringart.multiplier_speed', 0.02)
+        self.__rotation_speed = Config.get('screensavers.configs.stringart.rotation_speed', 0.01)
+        self.__fade = Config.get('screensavers.configs.stringart.fade', 0.15)
+        self.__line_brightness = Config.get('screensavers.configs.stringart.line_brightness', 0.4)
+        self.__tick_sleep = Config.get('screensavers.configs.stringart.tick_sleep', 0.03)
+        self.__max_ticks = Config.get('screensavers.configs.stringart.max_ticks', 10000)
 
         # Canvas buffer
         self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -168,6 +168,8 @@ class StringArt(Screensaver):
         self.__init_pattern()
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             self.__update()
 
             # Convert to uint8 frame

--- a/pifi/screensaver/transition.py
+++ b/pifi/screensaver/transition.py
@@ -151,8 +151,8 @@ class TransitionPlayer:
     def play_transition(self, from_frame=None, to_frame=None):
         width = Config.get_or_throw('leds.display_width')
         height = Config.get_or_throw('leds.display_height')
-        duration = Config.get('transitions.duration', 1.0)
-        num_steps = Config.get('transitions.num_steps', 30)
+        duration = Config.get('screensavers.transitions.duration', 1.0)
+        num_steps = Config.get('screensavers.transitions.num_steps', 30)
 
         if from_frame is None:
             from_frame = self.__led_frame_player.get_current_frame()

--- a/pifi/screensaver/transition.py
+++ b/pifi/screensaver/transition.py
@@ -158,9 +158,15 @@ class TransitionPlayer:
             from_frame = self.__led_frame_player.get_current_frame()
         if from_frame is None:
             from_frame = np.zeros([height, width, 3], np.uint8)
+        # Monochrome video modes produce (H, W) frames. Expand to (H, W, 3)
+        # so blending math works with consistent shapes.
+        if from_frame.ndim == 2:
+            from_frame = np.stack([from_frame] * 3, axis=-1)
 
         if to_frame is None:
             to_frame = np.zeros([height, width, 3], np.uint8)
+        if to_frame.ndim == 2:
+            to_frame = np.stack([to_frame] * 3, axis=-1)
 
         # Convert to float32 for blending math
         from_float = from_frame.astype(np.float32)

--- a/pifi/screensaver/transition.py
+++ b/pifi/screensaver/transition.py
@@ -1,0 +1,186 @@
+import random
+import time
+
+import numpy as np
+
+from pifi.config import Config
+from pifi.logger import Logger
+
+
+# Transition effect functions.
+# Each takes (from_frame, to_frame, progress, width, height) where progress is 0.0 to 1.0.
+# Returns a blended [height, width, 3] uint8 numpy array.
+
+def crossfade(from_frame, to_frame, progress, width, height):
+    return (from_frame * (1 - progress) + to_frame * progress).astype(np.uint8)
+
+
+def wipe_left(from_frame, to_frame, progress, width, height):
+    result = from_frame.copy()
+    boundary = int(progress * width)
+    result[:, :boundary] = to_frame[:, :boundary]
+    return result
+
+
+def wipe_right(from_frame, to_frame, progress, width, height):
+    result = from_frame.copy()
+    boundary = width - int(progress * width)
+    result[:, boundary:] = to_frame[:, boundary:]
+    return result
+
+
+def wipe_down(from_frame, to_frame, progress, width, height):
+    result = from_frame.copy()
+    boundary = int(progress * height)
+    result[:boundary, :] = to_frame[:boundary, :]
+    return result
+
+
+def wipe_up(from_frame, to_frame, progress, width, height):
+    result = from_frame.copy()
+    boundary = height - int(progress * height)
+    result[boundary:, :] = to_frame[boundary:, :]
+    return result
+
+
+def push_left(from_frame, to_frame, progress, width, height):
+    result = np.zeros_like(from_frame)
+    offset = int(progress * width)
+    if offset < width:
+        result[:, :width - offset] = from_frame[:, offset:]
+    if offset > 0:
+        result[:, width - offset:] = to_frame[:, :offset]
+    return result
+
+
+def push_right(from_frame, to_frame, progress, width, height):
+    result = np.zeros_like(from_frame)
+    offset = int(progress * width)
+    if offset < width:
+        result[:, offset:] = from_frame[:, :width - offset]
+    if offset > 0:
+        result[:, :offset] = to_frame[:, width - offset:]
+    return result
+
+
+def push_down(from_frame, to_frame, progress, width, height):
+    result = np.zeros_like(from_frame)
+    offset = int(progress * height)
+    if offset < height:
+        result[offset:, :] = from_frame[:height - offset, :]
+    if offset > 0:
+        result[:offset, :] = to_frame[height - offset:, :]
+    return result
+
+
+def push_up(from_frame, to_frame, progress, width, height):
+    result = np.zeros_like(from_frame)
+    offset = int(progress * height)
+    if offset < height:
+        result[:height - offset, :] = from_frame[offset:, :]
+    if offset > 0:
+        result[height - offset:, :] = to_frame[:offset, :]
+    return result
+
+
+def _make_dissolve(width, height):
+    """Factory that pre-shuffles pixel order for dissolve effect."""
+    total_pixels = width * height
+    indices = np.arange(total_pixels)
+    np.random.shuffle(indices)
+
+    def dissolve(from_frame, to_frame, progress, width, height):
+        result = from_frame.copy()
+        num_switched = int(progress * total_pixels)
+        switched = indices[:num_switched]
+        ys, xs = np.divmod(switched, width)
+        result[ys, xs] = to_frame[ys, xs]
+        return result
+
+    return dissolve
+
+
+def _make_spiral(width, height):
+    """Factory that pre-computes spiral order from center outward."""
+    cy, cx = height / 2, width / 2
+    coords = np.array([(y, x) for y in range(height) for x in range(width)])
+    # Sort by angle, then by distance, to create a spiral pattern
+    dy = coords[:, 0] - cy
+    dx = coords[:, 1] - cx
+    angles = np.arctan2(dy, dx)
+    distances = np.sqrt(dy ** 2 + dx ** 2)
+    max_dist = distances.max() if distances.max() > 0 else 1
+    # Combine distance and angle to get spiral ordering:
+    # each "ring" of distance completes a full angular sweep
+    spiral_key = distances / max_dist + angles / (2 * np.pi * 3)
+    order = np.argsort(spiral_key)
+
+    def spiral(from_frame, to_frame, progress, width, height):
+        result = from_frame.copy()
+        total_pixels = width * height
+        num_switched = int(progress * total_pixels)
+        switched = order[:num_switched]
+        ys = coords[switched, 0]
+        xs = coords[switched, 1]
+        result[ys, xs] = to_frame[ys, xs]
+        return result
+
+    return spiral
+
+
+# Simple effects that don't need factories
+SIMPLE_EFFECTS = [
+    crossfade,
+    wipe_left,
+    wipe_right,
+    wipe_down,
+    wipe_up,
+    push_left,
+    push_right,
+    push_down,
+    push_up,
+]
+
+
+class TransitionPlayer:
+
+    def __init__(self, led_frame_player):
+        self.__led_frame_player = led_frame_player
+        self.__logger = Logger().set_namespace(self.__class__.__name__)
+
+    def play_transition(self, from_frame=None, to_frame=None):
+        width = Config.get_or_throw('leds.display_width')
+        height = Config.get_or_throw('leds.display_height')
+        duration = Config.get('transitions.duration', 1.0)
+        num_steps = Config.get('transitions.num_steps', 30)
+
+        if from_frame is None:
+            from_frame = self.__led_frame_player.get_current_frame()
+        if from_frame is None:
+            from_frame = np.zeros([height, width, 3], np.uint8)
+
+        if to_frame is None:
+            to_frame = np.zeros([height, width, 3], np.uint8)
+
+        # Convert to float32 for blending math
+        from_float = from_frame.astype(np.float32)
+        to_float = to_frame.astype(np.float32)
+
+        # Pick a random effect - include factory-generated effects
+        effect = self.__pick_effect(width, height)
+
+        self.__logger.info(f"Playing transition: {effect.__name__}")
+
+        sleep_time = duration / num_steps
+        for step in range(1, num_steps + 1):
+            progress = step / num_steps
+            blended = effect(from_float, to_float, progress, width, height)
+            self.__led_frame_player.play_frame(blended.astype(np.uint8))
+            time.sleep(sleep_time)
+
+    def __pick_effect(self, width, height):
+        # Build the full list including factory effects
+        effects = list(SIMPLE_EFFECTS)
+        effects.append(_make_dissolve(width, height))
+        effects.append(_make_spiral(width, height))
+        return random.choice(effects)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -152,7 +152,8 @@ class TransitionPlayer:
         width = Config.get_or_throw('leds.display_width')
         height = Config.get_or_throw('leds.display_height')
         duration = Config.get('screensavers.transitions.duration', 1.0)
-        num_steps = Config.get('screensavers.transitions.num_steps', 30)
+        tick_sleep = Config.get('screensavers.transitions.tick_sleep', 0.03)
+        num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
 
         if from_frame is None:
             from_frame = self.__led_frame_player.get_current_frame()
@@ -177,12 +178,11 @@ class TransitionPlayer:
 
         self.__logger.info(f"Playing transition: {effect.__name__}")
 
-        sleep_time = duration / num_steps
         for step in range(1, num_steps + 1):
             progress = step / num_steps
             blended = effect(from_float, to_float, progress, width, height)
             self.__led_frame_player.play_frame(blended.astype(np.uint8))
-            time.sleep(sleep_time)
+            time.sleep(tick_sleep)
 
     def __pick_effect(self, width, height):
         # Build the full list including factory effects

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -6,11 +6,9 @@ waveforms that pulse and evolve, evoking pulsar radio signals.
 """
 
 import numpy as np
-import time
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,7 +17,6 @@ class UnknownPleasures(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -36,8 +33,6 @@ class UnknownPleasures(Screensaver):
         self.__line_brightness = Config.get('screensavers.configs.unknownpleasures.line_brightness', 1.0)
         self.__fill_below = Config.get('screensavers.configs.unknownpleasures.fill_below', True)
         self.__color_mode = Config.get('screensavers.configs.unknownpleasures.color_mode', 'white')
-        self.__tick_sleep = Config.get('screensavers.configs.unknownpleasures.tick_sleep', 0.05)
-        self.__max_ticks = Config.get('screensavers.configs.unknownpleasures.max_ticks', 10000)
 
         # Auto-calculate line count
         if self.__num_lines <= 0:
@@ -180,23 +175,16 @@ class UnknownPleasures(Screensaver):
 
         self.__led_frame_player.play_frame(frame)
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting Unknown Pleasures screensaver")
-
-        # Initialize
+    def _setup(self):
+        """Initialize noise and colors."""
         self.__perm = self.__generate_permutation()
         self.__init_colors()
         self.__time = 0.0
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            self.__time += self.__wave_speed
-            self.__render()
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("Unknown Pleasures screensaver ended")
+    def _tick(self, tick):
+        """Advance time and render one frame."""
+        self.__time += self.__wave_speed
+        self.__render()
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -8,7 +8,6 @@ waveforms that pulse and evolve, evoking pulsar radio signals.
 import numpy as np
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,10 +16,6 @@ class UnknownPleasures(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -173,7 +168,7 @@ class UnknownPleasures(Screensaver):
             # Draw the wave line using advanced indexing
             frame[pixel_heights, self.__x_indices] = color
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def _setup(self):
         """Initialize noise and colors."""

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -190,7 +190,7 @@ class UnknownPleasures(Screensaver):
         self.__time = 0.0
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             self.__time += self.__wave_speed
             self.__render()

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -29,15 +29,15 @@ class UnknownPleasures(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Config
-        self.__num_lines = Config.get('unknownpleasures.num_lines', 0)  # 0 = auto
-        self.__wave_speed = Config.get('unknownpleasures.wave_speed', 0.05)
-        self.__noise_scale = Config.get('unknownpleasures.noise_scale', 0.15)
-        self.__amplitude = Config.get('unknownpleasures.amplitude', 1.0)
-        self.__line_brightness = Config.get('unknownpleasures.line_brightness', 1.0)
-        self.__fill_below = Config.get('unknownpleasures.fill_below', True)
-        self.__color_mode = Config.get('unknownpleasures.color_mode', 'white')
-        self.__tick_sleep = Config.get('unknownpleasures.tick_sleep', 0.05)
-        self.__max_ticks = Config.get('unknownpleasures.max_ticks', 10000)
+        self.__num_lines = Config.get('screensavers.configs.unknownpleasures.num_lines', 0)  # 0 = auto
+        self.__wave_speed = Config.get('screensavers.configs.unknownpleasures.wave_speed', 0.05)
+        self.__noise_scale = Config.get('screensavers.configs.unknownpleasures.noise_scale', 0.15)
+        self.__amplitude = Config.get('screensavers.configs.unknownpleasures.amplitude', 1.0)
+        self.__line_brightness = Config.get('screensavers.configs.unknownpleasures.line_brightness', 1.0)
+        self.__fill_below = Config.get('screensavers.configs.unknownpleasures.fill_below', True)
+        self.__color_mode = Config.get('screensavers.configs.unknownpleasures.color_mode', 'white')
+        self.__tick_sleep = Config.get('screensavers.configs.unknownpleasures.tick_sleep', 0.05)
+        self.__max_ticks = Config.get('screensavers.configs.unknownpleasures.max_ticks', 10000)
 
         # Auto-calculate line count
         if self.__num_lines <= 0:

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -190,6 +190,8 @@ class UnknownPleasures(Screensaver):
         self.__time = 0.0
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             self.__time += self.__wave_speed
             self.__render()
             time.sleep(self.__tick_sleep)

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -23,6 +23,9 @@ class VideoScreensaver(Screensaver):
         if not self.video_list:
             return False
 
+        # Note: process_and_play() is a blocking call that plays the entire video.
+        # The base class timeout check only runs between ticks, so timeout is
+        # effectively governed by video length, not the configured timeout.
         url = self.__getScreensaverPath() + '/' + random.choice(self.video_list)
         VideoProcessor(
             url = url,

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -19,10 +19,9 @@ class VideoScreensaver(Screensaver):
         os.makedirs(save_dir, exist_ok=True)
         return save_dir
 
-    def play(self):
-        # If no videos are configured, do nothing
+    def _tick(self, tick):
         if not self.video_list:
-            return
+            return False
 
         url = self.__getScreensaverPath() + '/' + random.choice(self.video_list)
         VideoProcessor(

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -12,7 +12,7 @@ class VideoScreensaver(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         # Get video list from config instead of constructor parameter
-        self.video_list = Config.get("screensavers.saved_videos", [])
+        self.video_list = Config.get("screensavers.configs.video_screensaver.saved_videos", [])
 
     def __getScreensaverPath(self):
         save_dir = DirectoryUtils().root_dir + '/' + self.__DATA_DIRECTORY

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -30,7 +30,8 @@ class VideoScreensaver(Screensaver):
         VideoProcessor(
             url = url,
             clear_screen = True,
-            show_loading_screen = False
+            show_loading_screen = False,
+            led_frame_player = self._led_frame_player
         ).process_and_play()
 
     @classmethod

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -48,7 +48,7 @@ class WaveInterference(Screensaver):
         max_ticks = Config.get('wave_interference.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks and not self._is_past_dwell_time():
+        while tick < max_ticks and not self._is_past_screensaver_timeout():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,11 +16,6 @@ class WaveInterference(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-
-        if led_frame_player is None:
-            self.__led_frame_player = LedFramePlayer()
-        else:
-            self.__led_frame_player = led_frame_player
 
         self.__width = Config.get_or_throw('leds.display_width')
         self.__height = Config.get_or_throw('leds.display_height')
@@ -150,7 +144,7 @@ class WaveInterference(Screensaver):
             frame[:, :, 1] = (brightness * 150).astype(np.uint8)  # G
             frame[:, :, 2] = (brightness * 255).astype(np.uint8)  # B
 
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __hsv_array_to_rgb(self, h, s, v):
         """Convert HSV arrays to RGB frame."""

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -1,10 +1,8 @@
 import math
 import numpy as np
-import time
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,7 +17,6 @@ class WaveInterference(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
 
         if led_frame_player is None:
             self.__led_frame_player = LedFramePlayer()
@@ -41,19 +38,15 @@ class WaveInterference(Screensaver):
         # Color palette
         self.__hue_offset = 0.0
 
-    def play(self):
-        self.__logger.info("Starting Wave Interference screensaver")
+    def _setup(self):
         self.__reset()
 
-        max_ticks = Config.get('screensavers.configs.wave_interference.max_ticks', 2000)
-        tick = 0
+    def _tick(self, tick):
+        self.__update_sources()
+        self.__render()
 
-        while tick < max_ticks and not self._is_past_screensaver_timeout():
-            self.__tick()
-            time.sleep(self.__get_tick_sleep())
-            tick += 1
-
-        self.__logger.info("Wave Interference screensaver ended")
+        time_speed = Config.get('screensavers.configs.wave_interference.time_speed', 0.15)
+        self.__time += time_speed
 
     def __reset(self):
         num_sources = Config.get('screensavers.configs.wave_interference.num_sources', 4)
@@ -78,13 +71,6 @@ class WaveInterference(Screensaver):
         vy = math.sin(angle) * drift_speed
 
         self.__sources.append([x, y, phase_offset, vx, vy])
-
-    def __tick(self):
-        self.__update_sources()
-        self.__render()
-
-        time_speed = Config.get('screensavers.configs.wave_interference.time_speed', 0.15)
-        self.__time += time_speed
 
     def __update_sources(self):
         """Update source positions (drifting)."""
@@ -194,9 +180,6 @@ class WaveInterference(Screensaver):
         frame[:, :, 2] = (b * 255).astype(np.uint8)
 
         return frame
-
-    def __get_tick_sleep(self):
-        return Config.get('screensavers.configs.wave_interference.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -45,7 +45,7 @@ class WaveInterference(Screensaver):
         self.__logger.info("Starting Wave Interference screensaver")
         self.__reset()
 
-        max_ticks = Config.get('wave_interference.max_ticks', 2000)
+        max_ticks = Config.get('screensavers.configs.wave_interference.max_ticks', 2000)
         tick = 0
 
         while tick < max_ticks and not self._is_past_screensaver_timeout():
@@ -56,7 +56,7 @@ class WaveInterference(Screensaver):
         self.__logger.info("Wave Interference screensaver ended")
 
     def __reset(self):
-        num_sources = Config.get('wave_interference.num_sources', 4)
+        num_sources = Config.get('screensavers.configs.wave_interference.num_sources', 4)
 
         self.__sources = []
         for _ in range(num_sources):
@@ -72,7 +72,7 @@ class WaveInterference(Screensaver):
         phase_offset = random.uniform(0, 2 * math.pi)
 
         # Slow drift velocity
-        drift_speed = Config.get('wave_interference.drift_speed', 0.3)
+        drift_speed = Config.get('screensavers.configs.wave_interference.drift_speed', 0.3)
         angle = random.uniform(0, 2 * math.pi)
         vx = math.cos(angle) * drift_speed
         vy = math.sin(angle) * drift_speed
@@ -83,7 +83,7 @@ class WaveInterference(Screensaver):
         self.__update_sources()
         self.__render()
 
-        time_speed = Config.get('wave_interference.time_speed', 0.15)
+        time_speed = Config.get('screensavers.configs.wave_interference.time_speed', 0.15)
         self.__time += time_speed
 
     def __update_sources(self):
@@ -102,8 +102,8 @@ class WaveInterference(Screensaver):
                 source[1] = max(0, min(self.__height - 1, source[1]))
 
     def __render(self):
-        wave_frequency = Config.get('wave_interference.wave_frequency', 0.5)
-        color_mode = Config.get('wave_interference.color_mode', 'rainbow')
+        wave_frequency = Config.get('screensavers.configs.wave_interference.wave_frequency', 0.5)
+        color_mode = Config.get('screensavers.configs.wave_interference.color_mode', 'rainbow')
 
         # Calculate combined wave amplitude at each pixel
         amplitude = np.zeros((self.__height, self.__width), dtype=np.float64)
@@ -196,7 +196,7 @@ class WaveInterference(Screensaver):
         return frame
 
     def __get_tick_sleep(self):
-        return Config.get('wave_interference.tick_sleep', 0.03)
+        return Config.get('screensavers.configs.wave_interference.tick_sleep', 0.03)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -48,7 +48,7 @@ class WaveInterference(Screensaver):
         max_ticks = Config.get('wave_interference.max_ticks', 2000)
         tick = 0
 
-        while tick < max_ticks:
+        while tick < max_ticks and not self._is_past_dwell_time():
             self.__tick()
             time.sleep(self.__get_tick_sleep())
             tick += 1

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -151,7 +151,7 @@ class Wfmu(Screensaver):
         self.__start_background_fetch()
 
         for tick in range(self.__max_ticks):
-            if self._is_past_dwell_time():
+            if self._is_past_screensaver_timeout():
                 break
             # Periodic refresh
             current_time = time.time()

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -11,7 +11,6 @@ import threading
 import xml.etree.ElementTree as ET
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver import textutils
@@ -39,10 +38,6 @@ class Wfmu(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        if led_frame_player is None:
-            led_frame_player = LedFramePlayer()
-        self.__led_frame_player = led_frame_player
 
         self.__width = Config.get('leds.display_width')
         self.__height = Config.get('leds.display_height')
@@ -181,7 +176,7 @@ class Wfmu(Screensaver):
 
         self.__tick_count += 1
         self.__scroll_offset += 1.0
-        self.__led_frame_player.play_frame(frame)
+        self._led_frame_player.play_frame(frame)
 
     def __render_now_playing(self, frame):
         """Render the now playing info."""

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -151,6 +151,8 @@ class Wfmu(Screensaver):
         self.__start_background_fetch()
 
         for tick in range(self.__max_ticks):
+            if self._is_past_dwell_time():
+                break
             # Periodic refresh
             current_time = time.time()
             if current_time - self.__last_update > self.__update_interval:

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -51,8 +51,6 @@ class Wfmu(Screensaver):
         channel_name = Config.get('screensavers.configs.wfmu.channel', 'wfmu')
         self.__channel = self.CHANNELS.get(channel_name, 0)
         self.__update_interval = Config.get('screensavers.configs.wfmu.update_interval', 15)
-        self.__max_ticks = Config.get('screensavers.configs.wfmu.max_ticks', 3000)
-        self.__tick_sleep = Config.get('screensavers.configs.wfmu.tick_sleep', 0.05)
 
         # State
         self.__show_name = ""
@@ -143,26 +141,18 @@ class Wfmu(Screensaver):
         finally:
             self.__fetch_in_progress = False
 
-    def play(self):
-        """Run the screensaver."""
-        self.__logger.info("Starting WFMU screensaver")
-
-        # Start initial fetch
+    def _setup(self):
+        """Start initial data fetch."""
         self.__start_background_fetch()
 
-        for tick in range(self.__max_ticks):
-            if self._is_past_screensaver_timeout():
-                break
-            # Periodic refresh
-            current_time = time.time()
-            if current_time - self.__last_update > self.__update_interval:
-                self.__start_background_fetch()
-                self.__last_update = current_time
+    def _tick(self, tick):
+        """Fetch new data if needed and render one frame."""
+        current_time = time.time()
+        if current_time - self.__last_update > self.__update_interval:
+            self.__start_background_fetch()
+            self.__last_update = current_time
 
-            self.__render()
-            time.sleep(self.__tick_sleep)
-
-        self.__logger.info("WFMU screensaver ended")
+        self.__render()
 
     def __render(self):
         """Render the current track info."""

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -48,11 +48,11 @@ class Wfmu(Screensaver):
         self.__height = Config.get('leds.display_height')
 
         # Configuration
-        channel_name = Config.get('wfmu.channel', 'wfmu')
+        channel_name = Config.get('screensavers.configs.wfmu.channel', 'wfmu')
         self.__channel = self.CHANNELS.get(channel_name, 0)
-        self.__update_interval = Config.get('wfmu.update_interval', 15)
-        self.__max_ticks = Config.get('wfmu.max_ticks', 3000)
-        self.__tick_sleep = Config.get('wfmu.tick_sleep', 0.05)
+        self.__update_interval = Config.get('screensavers.configs.wfmu.update_interval', 15)
+        self.__max_ticks = Config.get('screensavers.configs.wfmu.max_ticks', 3000)
+        self.__tick_sleep = Config.get('screensavers.configs.wfmu.tick_sleep', 0.05)
 
         # State
         self.__show_name = ""

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -278,6 +278,8 @@ class PifiAPI():
 
         if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
             t = post_data['transitions']
+            if 'enabled' in t and not isinstance(t['enabled'], bool):
+                return {'success': False, 'error': 'transitions.enabled must be a boolean'}
             if 'duration' in t and (not isinstance(t['duration'], (int, float)) or t['duration'] <= 0):
                 return {'success': False, 'error': 'transitions.duration must be a positive number'}
             if 'num_steps' in t and (not isinstance(t['num_steps'], int) or t['num_steps'] <= 0):

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -26,7 +26,6 @@ class PifiAPI():
         self.__vol_controller = VolumeController()
         self.__settings_db = SettingsDb()
         self.__logger = Logger().set_namespace(self.__class__.__name__)
-        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
     # get all the data that we poll for every second in the pifi
     def get_queue(self):
@@ -228,7 +227,7 @@ class PifiAPI():
 
     def get_screensavers(self):
         all_screensavers = ScreensaverManager.get_all_screensavers()
-        enabled = ScreensaverManager.get_enabled_screensavers()
+        enabled = Config.get('screensavers.enabled')
 
         configs = {}
         for s in all_screensavers:
@@ -256,13 +255,23 @@ class PifiAPI():
         }
 
     def set_screensavers(self, post_data):
-        overrides = self.__get_screensaver_overrides()
+        # Read existing overrides from DB. The DB stores {"screensavers": {...}},
+        # wrapping is needed for reload_overrides compatibility with the config structure.
+        raw_json = self.__settings_db.get(SettingsDb.SCREENSAVER_SETTINGS)
+        overrides = json.loads(raw_json).get('screensavers', {}) if raw_json else {}
 
         if 'enabled' in post_data:
+            if not isinstance(post_data['enabled'], list):
+                return {'success': False, 'error': 'enabled must be an array'}
+            if not all(isinstance(s, str) for s in post_data['enabled']):
+                return {'success': False, 'error': 'enabled must be an array of strings'}
             overrides['enabled'] = post_data['enabled']
 
         if 'timeout' in post_data:
-            overrides['timeout'] = post_data['timeout']
+            timeout = post_data['timeout']
+            if timeout is not None and not isinstance(timeout, (int, float)):
+                return {'success': False, 'error': 'timeout must be a number or null'}
+            overrides['timeout'] = timeout
 
         if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
             transitions = overrides.setdefault('transitions', {})
@@ -278,30 +287,12 @@ class PifiAPI():
                 elif isinstance(config, dict):
                     existing_configs[screensaver_id] = config
 
-        self.__save_screensaver_overrides(overrides)
+        self.__settings_db.set(SettingsDb.SCREENSAVER_SETTINGS, json.dumps({'screensavers': overrides}))
         Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
         # Signal queue to restart screensaver so changes take effect immediately
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
         return {'success': True}
-
-    def __get_screensaver_overrides(self):
-        """Read screensaver overrides from DB.
-
-        Returns the screensavers dict (enabled, timeout, transitions, configs).
-        DB stores: {"screensavers": {...}}
-        """
-        raw_json = self.__settings_db.get(SettingsDb.SCREENSAVER_SETTINGS)
-        if not raw_json:
-            return {}
-        return json.loads(raw_json).get('screensavers', {})
-
-    def __save_screensaver_overrides(self, overrides):
-        """Write screensaver overrides to DB.
-
-        Takes a flat screensavers dict and wraps it for reload_overrides compatibility.
-        """
-        self.__settings_db.set(SettingsDb.SCREENSAVER_SETTINGS, json.dumps({'screensavers': overrides}))
 
 
 class PifiServerRequestHandler(BaseHTTPRequestHandler):
@@ -477,6 +468,7 @@ class PifiThreadingHTTPServer(ThreadingHTTPServer):
 class Server:
 
     def __init__(self):
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
         self.__secure = Config.get('server.use_ssl')
 
         if not self.__secure:

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -328,6 +328,67 @@ class PifiAPI():
 
         return {'success': True, 'screensaver_id': screensaver_id, 'config': config}
 
+    def get_global_settings(self):
+        """Get global screensaver rotation and transition settings."""
+        from pifi.config import Config
+
+        # The settings we expose
+        keys = {
+            'screensavers': ['dwell_time'],
+            'transitions': ['enabled', 'duration', 'num_steps'],
+        }
+
+        current = {}
+        defaults = {}
+        for section, fields in keys.items():
+            current[section] = {}
+            defaults[section] = {}
+            for field in fields:
+                current[section][field] = Config.get(f'{section}.{field}')
+                defaults[section][field] = current[section][field]
+
+        # Read base defaults from the config before any DB overrides were applied.
+        # We already have the merged values in Config, but we can get the "true" defaults
+        # by checking what's NOT overridden. Instead, just re-read default_config.json.
+        import pyjson5
+        try:
+            with open(Config._Config__DEFAULT_CONFIG_PATH) as f:
+                base_config = pyjson5.decode(f.read())
+            for section, fields in keys.items():
+                if section in base_config:
+                    for field in fields:
+                        if field in base_config[section]:
+                            defaults[section][field] = base_config[section][field]
+        except Exception:
+            pass  # Fall back to current values as defaults
+
+        return {
+            'success': True,
+            'current': current,
+            'defaults': defaults,
+        }
+
+    def set_global_settings(self, post_data):
+        """Save global screensaver rotation and transition settings."""
+        # Build the overrides object with only the sections we allow
+        overrides = {}
+        if 'screensavers' in post_data and isinstance(post_data['screensavers'], dict):
+            overrides['screensavers'] = {}
+            if 'dwell_time' in post_data['screensavers']:
+                val = post_data['screensavers']['dwell_time']
+                overrides['screensavers']['dwell_time'] = val
+
+        if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
+            overrides['transitions'] = {}
+            for key in ('enabled', 'duration', 'num_steps'):
+                if key in post_data['transitions']:
+                    overrides['transitions'][key] = post_data['transitions'][key]
+
+        self.__settings_db.set(SettingsDb.GLOBAL_SETTINGS, json.dumps(overrides))
+        self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
+
+        return {'success': True}
+
     def reset_screensaver_config(self, post_data):
         """Reset a screensaver's config to defaults."""
         screensaver_id = post_data.get('screensaver_id')
@@ -412,6 +473,8 @@ class PifiServerRequestHandler(BaseHTTPRequestHandler):
             response = self.__api.get_screensavers()
         elif parsed_path.path == 'screensaver_configs':
             response = self.__api.get_all_screensaver_configs()
+        elif parsed_path.path == 'global_settings':
+            response = self.__api.get_global_settings()
         elif parsed_path.path.startswith('screensaver_config/'):
             screensaver_id = parsed_path.path.split('/')[1]
             response = self.__api.get_screensaver_config(screensaver_id)
@@ -457,6 +520,8 @@ class PifiServerRequestHandler(BaseHTTPRequestHandler):
             response = self.__api.submit_game_score_initials(post_data)
         elif path == 'screensavers':
             response = self.__api.set_screensavers(post_data)
+        elif path == 'global_settings':
+            response = self.__api.set_global_settings(post_data)
         elif path == 'screensaver_config':
             response = self.__api.set_screensaver_config(post_data)
         elif path == 'screensaver_config_reset':

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -266,46 +266,33 @@ class PifiAPI():
         return {'success': True}
 
     def get_screensaver_config(self, screensaver_id):
-        """Get config for a specific screensaver, merging defaults with overrides."""
-        from pifi.config import Config
+        """Get config for a specific screensaver."""
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
-        # Get default config from Config (reads from default_config.json)
-        default_config = Config.get(f'screensavers.configs.{screensaver_id}', {})
-        if not isinstance(default_config, dict):
-            default_config = {}
-
-        # Get user overrides from SettingsDb
-        overrides = self.__get_screensaver_overrides().get('configs', {}).get(screensaver_id, {})
-
-        # Merge defaults with overrides
-        config = {**default_config, **overrides}
+        config = Config.get(f'screensavers.configs.{screensaver_id}', {})
+        defaults = Config.get_default(f'screensavers.configs.{screensaver_id}', {})
 
         return {
             'success': True,
             'screensaver_id': screensaver_id,
-            'config': config,
-            'defaults': default_config,
+            'config': config if isinstance(config, dict) else {},
+            'defaults': defaults if isinstance(defaults, dict) else {},
         }
 
     def get_all_screensaver_configs(self):
         """Get configs for all screensavers."""
-        from pifi.config import Config
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
         all_screensavers = ScreensaverManager.get_all_screensavers()
-
-        # Get all user overrides
-        all_config_overrides = self.__get_screensaver_overrides().get('configs', {})
 
         configs = {}
         for s in all_screensavers:
             sid = s['id']
-            default_config = Config.get(f'screensavers.configs.{sid}', {})
-            if not isinstance(default_config, dict):
-                default_config = {}
-            overrides = all_config_overrides.get(sid, {})
+            config = Config.get(f'screensavers.configs.{sid}', {})
+            defaults = Config.get_default(f'screensavers.configs.{sid}', {})
             configs[sid] = {
-                'config': {**default_config, **overrides},
-                'defaults': default_config,
+                'config': config if isinstance(config, dict) else {},
+                'defaults': defaults if isinstance(defaults, dict) else {},
             }
 
         return {
@@ -335,8 +322,6 @@ class PifiAPI():
 
     def __get_global_screensaver_settings(self):
         """Get global screensaver transition and timeout settings."""
-        from pifi.config import Config
-
         def get_values(getter):
             return {
                 'screensavers': {

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -259,16 +259,12 @@ class PifiAPI():
         from pifi.config import Config
 
         # Get default config from Config (reads from default_config.json)
-        default_config = Config.get(screensaver_id, {})
+        default_config = Config.get(f'screensavers.configs.{screensaver_id}', {})
         if not isinstance(default_config, dict):
             default_config = {}
 
         # Get user overrides from SettingsDb
-        overrides_json = self.__settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
-        overrides = {}
-        if overrides_json:
-            all_overrides = json.loads(overrides_json)
-            overrides = all_overrides.get(screensaver_id, {})
+        overrides = self.__get_screensaver_config_overrides(screensaver_id)
 
         # Merge defaults with overrides
         config = {**default_config, **overrides}
@@ -287,15 +283,12 @@ class PifiAPI():
         all_screensavers = ScreensaverManager.get_all_screensavers()
 
         # Get all user overrides
-        overrides_json = self.__settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
-        all_overrides = {}
-        if overrides_json:
-            all_overrides = json.loads(overrides_json)
+        all_overrides = self.__get_all_screensaver_config_overrides()
 
         configs = {}
         for s in all_screensavers:
             sid = s['id']
-            default_config = Config.get(sid, {})
+            default_config = Config.get(f'screensavers.configs.{sid}', {})
             if not isinstance(default_config, dict):
                 default_config = {}
             overrides = all_overrides.get(sid, {})
@@ -321,16 +314,13 @@ class PifiAPI():
             return {'success': False, 'error': 'config must be an object'}
 
         # Get existing overrides
-        overrides_json = self.__settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
-        all_overrides = {}
-        if overrides_json:
-            all_overrides = json.loads(overrides_json)
+        all_overrides = self.__get_all_screensaver_config_overrides()
 
         # Update overrides for this screensaver
         all_overrides[screensaver_id] = config
 
         # Save back to database
-        self.__settings_db.set(SettingsDb.SCREENSAVER_CONFIGS, json.dumps(all_overrides))
+        self.__save_all_screensaver_config_overrides(all_overrides)
 
         # Signal restart
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
@@ -341,52 +331,63 @@ class PifiAPI():
         """Get global screensaver transition and timeout settings."""
         from pifi.config import Config
 
-        keys = {
-            'screensavers': ['screensaver_timeout'],
-            'transitions': ['enabled', 'duration', 'num_steps'],
-        }
-
-        current = {}
-        defaults = {}
-        for section, fields in keys.items():
-            current[section] = {}
-            defaults[section] = {}
-            for field in fields:
-                current[section][field] = Config.get(f'{section}.{field}')
-                defaults[section][field] = current[section][field]
-
-        import pyjson5
-        try:
-            with open(Config._Config__DEFAULT_CONFIG_PATH) as f:
-                base_config = pyjson5.decode(f.read())
-            for section, fields in keys.items():
-                if section in base_config:
-                    for field in fields:
-                        if field in base_config[section]:
-                            defaults[section][field] = base_config[section][field]
-        except Exception:
-            pass  # Fall back to current values as defaults
+        def get_values(getter):
+            return {
+                'screensavers': {
+                    'timeout': getter('screensavers.timeout'),
+                },
+                'transitions': {
+                    'enabled': getter('screensavers.transitions.enabled'),
+                    'duration': getter('screensavers.transitions.duration'),
+                    'num_steps': getter('screensavers.transitions.num_steps'),
+                },
+            }
 
         return {
-            'current': current,
-            'defaults': defaults,
+            'current': get_values(Config.get),
+            'defaults': get_values(Config.get_default),
         }
 
     def __save_global_screensaver_settings(self, settings):
         """Save global screensaver transition and timeout settings."""
-        overrides = {}
+        screensavers_overrides = {}
         if 'screensavers' in settings and isinstance(settings['screensavers'], dict):
-            overrides['screensavers'] = {}
-            if 'screensaver_timeout' in settings['screensavers']:
-                overrides['screensavers']['screensaver_timeout'] = settings['screensavers']['screensaver_timeout']
+            if 'timeout' in settings['screensavers']:
+                screensavers_overrides['timeout'] = settings['screensavers']['timeout']
 
         if 'transitions' in settings and isinstance(settings['transitions'], dict):
-            overrides['transitions'] = {}
+            transitions = {}
             for key in ('enabled', 'duration', 'num_steps'):
                 if key in settings['transitions']:
-                    overrides['transitions'][key] = settings['transitions'][key]
+                    transitions[key] = settings['transitions'][key]
+            if transitions:
+                screensavers_overrides['transitions'] = transitions
 
+        overrides = {}
+        if screensavers_overrides:
+            overrides['screensavers'] = screensavers_overrides
         self.__settings_db.set(SettingsDb.GLOBAL_SCREENSAVER_SETTINGS, json.dumps(overrides))
+
+    def __get_all_screensaver_config_overrides(self):
+        """Get flat {screensaver_id: {key: value}} overrides from DB.
+
+        DB stores nested format for reload_overrides compatibility:
+        {"screensavers": {"configs": {screensaver_id: {key: value}}}}
+        """
+        overrides_json = self.__settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
+        if not overrides_json:
+            return {}
+        raw = json.loads(overrides_json)
+        return raw.get('screensavers', {}).get('configs', {})
+
+    def __get_screensaver_config_overrides(self, screensaver_id):
+        """Get overrides for a single screensaver."""
+        return self.__get_all_screensaver_config_overrides().get(screensaver_id, {})
+
+    def __save_all_screensaver_config_overrides(self, all_overrides):
+        """Save flat {screensaver_id: {key: value}} overrides to DB in nested format."""
+        nested = {'screensavers': {'configs': all_overrides}}
+        self.__settings_db.set(SettingsDb.SCREENSAVER_CONFIGS, json.dumps(nested))
 
     def reset_screensaver_config(self, post_data):
         """Reset a screensaver's config to defaults."""
@@ -396,17 +397,14 @@ class PifiAPI():
             return {'success': False, 'error': 'screensaver_id required'}
 
         # Get existing overrides
-        overrides_json = self.__settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
-        all_overrides = {}
-        if overrides_json:
-            all_overrides = json.loads(overrides_json)
+        all_overrides = self.__get_all_screensaver_config_overrides()
 
         # Remove overrides for this screensaver
         if screensaver_id in all_overrides:
             del all_overrides[screensaver_id]
 
         # Save back to database
-        self.__settings_db.set(SettingsDb.SCREENSAVER_CONFIGS, json.dumps(all_overrides))
+        self.__save_all_screensaver_config_overrides(all_overrides)
 
         # Signal restart
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -272,7 +272,7 @@ class PifiAPI():
 
         if 'timeout' in post_data:
             timeout = post_data['timeout']
-            if timeout is not None and (not isinstance(timeout, (int, float)) or timeout < 0):
+            if timeout is not None and (isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or timeout < 0):
                 return {'success': False, 'error': 'timeout must be a non-negative number or null'}
             overrides['timeout'] = timeout
 
@@ -283,9 +283,9 @@ class PifiAPI():
             t = post_data['transitions']
             if 'enabled' in t and not isinstance(t['enabled'], bool):
                 return {'success': False, 'error': 'transitions.enabled must be a boolean'}
-            if 'duration' in t and (not isinstance(t['duration'], (int, float)) or t['duration'] <= 0):
+            if 'duration' in t and (isinstance(t['duration'], bool) or not isinstance(t['duration'], (int, float)) or t['duration'] <= 0):
                 return {'success': False, 'error': 'transitions.duration must be a positive number'}
-            if 'tick_sleep' in t and (not isinstance(t['tick_sleep'], (int, float)) or t['tick_sleep'] < 0):
+            if 'tick_sleep' in t and (isinstance(t['tick_sleep'], bool) or not isinstance(t['tick_sleep'], (int, float)) or t['tick_sleep'] < 0):
                 return {'success': False, 'error': 'transitions.tick_sleep must be a non-negative number'}
             transitions = overrides.setdefault('transitions', {})
             for key in ('enabled', 'duration', 'tick_sleep'):
@@ -302,6 +302,8 @@ class PifiAPI():
                     existing_configs.pop(screensaver_id, None)
                 elif isinstance(config, dict):
                     existing_configs[screensaver_id] = config
+                else:
+                    return {'success': False, 'error': f'configs.{screensaver_id} must be an object or null'}
 
         self.__settings_db.set(SettingsDb.SCREENSAVER_SETTINGS, json.dumps({'screensavers': overrides}))
         Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -232,18 +232,27 @@ class PifiAPI():
         # Get enabled screensavers from settings
         enabled = ScreensaverManager.get_enabled_screensavers()
 
+        # Get global screensaver settings (timeout, transitions)
+        global_settings = self.__get_global_screensaver_settings()
+
         return {
             'success': True,
             'screensavers': all_screensavers,
             'enabled': enabled,
+            'global_settings': global_settings,
         }
 
     def set_screensavers(self, post_data):
-        enabled = post_data.get('enabled', [])
-        self.__settings_db.set(SettingsDb.ENABLED_SCREENSAVERS, json.dumps(enabled))
+        if 'enabled' in post_data:
+            enabled = post_data['enabled']
+            self.__settings_db.set(SettingsDb.ENABLED_SCREENSAVERS, json.dumps(enabled))
+
+        if 'global_settings' in post_data:
+            self.__save_global_screensaver_settings(post_data['global_settings'])
+
         # Signal queue to restart screensaver so changes take effect immediately
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
-        return {'success': True, 'enabled': enabled}
+        return {'success': True}
 
     def get_screensaver_config(self, screensaver_id):
         """Get config for a specific screensaver, merging defaults with overrides."""
@@ -328,13 +337,12 @@ class PifiAPI():
 
         return {'success': True, 'screensaver_id': screensaver_id, 'config': config}
 
-    def get_global_settings(self):
-        """Get global screensaver rotation and transition settings."""
+    def __get_global_screensaver_settings(self):
+        """Get global screensaver transition and timeout settings."""
         from pifi.config import Config
 
-        # The settings we expose
         keys = {
-            'screensavers': ['dwell_time'],
+            'screensavers': ['screensaver_timeout'],
             'transitions': ['enabled', 'duration', 'num_steps'],
         }
 
@@ -347,9 +355,6 @@ class PifiAPI():
                 current[section][field] = Config.get(f'{section}.{field}')
                 defaults[section][field] = current[section][field]
 
-        # Read base defaults from the config before any DB overrides were applied.
-        # We already have the merged values in Config, but we can get the "true" defaults
-        # by checking what's NOT overridden. Instead, just re-read default_config.json.
         import pyjson5
         try:
             with open(Config._Config__DEFAULT_CONFIG_PATH) as f:
@@ -363,31 +368,25 @@ class PifiAPI():
             pass  # Fall back to current values as defaults
 
         return {
-            'success': True,
             'current': current,
             'defaults': defaults,
         }
 
-    def set_global_settings(self, post_data):
-        """Save global screensaver rotation and transition settings."""
-        # Build the overrides object with only the sections we allow
+    def __save_global_screensaver_settings(self, settings):
+        """Save global screensaver transition and timeout settings."""
         overrides = {}
-        if 'screensavers' in post_data and isinstance(post_data['screensavers'], dict):
+        if 'screensavers' in settings and isinstance(settings['screensavers'], dict):
             overrides['screensavers'] = {}
-            if 'dwell_time' in post_data['screensavers']:
-                val = post_data['screensavers']['dwell_time']
-                overrides['screensavers']['dwell_time'] = val
+            if 'screensaver_timeout' in settings['screensavers']:
+                overrides['screensavers']['screensaver_timeout'] = settings['screensavers']['screensaver_timeout']
 
-        if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
+        if 'transitions' in settings and isinstance(settings['transitions'], dict):
             overrides['transitions'] = {}
             for key in ('enabled', 'duration', 'num_steps'):
-                if key in post_data['transitions']:
-                    overrides['transitions'][key] = post_data['transitions'][key]
+                if key in settings['transitions']:
+                    overrides['transitions'][key] = settings['transitions'][key]
 
-        self.__settings_db.set(SettingsDb.GLOBAL_SETTINGS, json.dumps(overrides))
-        self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
-
-        return {'success': True}
+        self.__settings_db.set(SettingsDb.GLOBAL_SCREENSAVER_SETTINGS, json.dumps(overrides))
 
     def reset_screensaver_config(self, post_data):
         """Reset a screensaver's config to defaults."""
@@ -473,8 +472,6 @@ class PifiServerRequestHandler(BaseHTTPRequestHandler):
             response = self.__api.get_screensavers()
         elif parsed_path.path == 'screensaver_configs':
             response = self.__api.get_all_screensaver_configs()
-        elif parsed_path.path == 'global_settings':
-            response = self.__api.get_global_settings()
         elif parsed_path.path.startswith('screensaver_config/'):
             screensaver_id = parsed_path.path.split('/')[1]
             response = self.__api.get_screensaver_config(screensaver_id)
@@ -520,8 +517,6 @@ class PifiServerRequestHandler(BaseHTTPRequestHandler):
             response = self.__api.submit_game_score_initials(post_data)
         elif path == 'screensavers':
             response = self.__api.set_screensavers(post_data)
-        elif path == 'global_settings':
-            response = self.__api.set_global_settings(post_data)
         elif path == 'screensaver_config':
             response = self.__api.set_screensaver_config(post_data)
         elif path == 'screensaver_config_reset':

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -26,6 +26,7 @@ class PifiAPI():
         self.__vol_controller = VolumeController()
         self.__settings_db = SettingsDb()
         self.__logger = Logger().set_namespace(self.__class__.__name__)
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
     # get all the data that we poll for every second in the pifi
     def get_queue(self):
@@ -226,64 +227,8 @@ class PifiAPI():
         }
 
     def get_screensavers(self):
-        # Get all available screensavers dynamically from the classes
         all_screensavers = ScreensaverManager.get_all_screensavers()
-
-        # Get enabled screensavers from settings
         enabled = ScreensaverManager.get_enabled_screensavers()
-
-        # Get global screensaver settings (timeout, transitions)
-        global_settings = self.__get_global_screensaver_settings()
-
-        return {
-            'success': True,
-            'screensavers': all_screensavers,
-            'enabled': enabled,
-            'global_settings': global_settings,
-        }
-
-    def set_screensavers(self, post_data):
-        overrides = self.__get_screensaver_overrides()
-
-        if 'enabled' in post_data:
-            overrides['enabled'] = post_data['enabled']
-
-        if 'global_settings' in post_data:
-            settings = post_data['global_settings']
-            if 'screensavers' in settings and isinstance(settings['screensavers'], dict):
-                if 'timeout' in settings['screensavers']:
-                    overrides['timeout'] = settings['screensavers']['timeout']
-            if 'transitions' in settings and isinstance(settings['transitions'], dict):
-                transitions = overrides.setdefault('transitions', {})
-                for key in ('enabled', 'duration', 'num_steps'):
-                    if key in settings['transitions']:
-                        transitions[key] = settings['transitions'][key]
-
-        self.__save_screensaver_overrides(overrides)
-
-        # Signal queue to restart screensaver so changes take effect immediately
-        self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
-        return {'success': True}
-
-    def get_screensaver_config(self, screensaver_id):
-        """Get config for a specific screensaver."""
-        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-
-        config = Config.get(f'screensavers.configs.{screensaver_id}', {})
-        defaults = Config.get_default(f'screensavers.configs.{screensaver_id}', {})
-
-        return {
-            'success': True,
-            'screensaver_id': screensaver_id,
-            'config': config if isinstance(config, dict) else {},
-            'defaults': defaults if isinstance(defaults, dict) else {},
-        }
-
-    def get_all_screensaver_configs(self):
-        """Get configs for all screensavers."""
-        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-
-        all_screensavers = ScreensaverManager.get_all_screensavers()
 
         configs = {}
         for s in all_screensavers:
@@ -297,8 +242,40 @@ class PifiAPI():
 
         return {
             'success': True,
+            'screensavers': all_screensavers,
+            'enabled': enabled,
+            'timeout': {
+                'current': Config.get('screensavers.timeout'),
+                'default': Config.get_default('screensavers.timeout'),
+            },
+            'transitions': {
+                'current': Config.get('screensavers.transitions'),
+                'default': Config.get_default('screensavers.transitions'),
+            },
             'configs': configs,
         }
+
+    def set_screensavers(self, post_data):
+        overrides = self.__get_screensaver_overrides()
+
+        if 'enabled' in post_data:
+            overrides['enabled'] = post_data['enabled']
+
+        if 'timeout' in post_data:
+            overrides['timeout'] = post_data['timeout']
+
+        if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
+            transitions = overrides.setdefault('transitions', {})
+            for key in ('enabled', 'duration', 'num_steps'):
+                if key in post_data['transitions']:
+                    transitions[key] = post_data['transitions'][key]
+
+        self.__save_screensaver_overrides(overrides)
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
+
+        # Signal queue to restart screensaver so changes take effect immediately
+        self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
+        return {'success': True}
 
     def set_screensaver_config(self, post_data):
         """Set config overrides for a screensaver."""
@@ -314,30 +291,12 @@ class PifiAPI():
         overrides = self.__get_screensaver_overrides()
         overrides.setdefault('configs', {})[screensaver_id] = config
         self.__save_screensaver_overrides(overrides)
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
         # Signal restart
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
 
         return {'success': True, 'screensaver_id': screensaver_id, 'config': config}
-
-    def __get_global_screensaver_settings(self):
-        """Get global screensaver transition and timeout settings."""
-        def get_values(getter):
-            return {
-                'screensavers': {
-                    'timeout': getter('screensavers.timeout'),
-                },
-                'transitions': {
-                    'enabled': getter('screensavers.transitions.enabled'),
-                    'duration': getter('screensavers.transitions.duration'),
-                    'num_steps': getter('screensavers.transitions.num_steps'),
-                },
-            }
-
-        return {
-            'current': get_values(Config.get),
-            'defaults': get_values(Config.get_default),
-        }
 
     def __get_screensaver_overrides(self):
         """Read screensaver overrides from DB.
@@ -369,6 +328,7 @@ class PifiAPI():
         if screensaver_id in configs:
             del configs[screensaver_id]
         self.__save_screensaver_overrides(overrides)
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
         # Signal restart
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
@@ -432,11 +392,6 @@ class PifiServerRequestHandler(BaseHTTPRequestHandler):
             response = self.__api.get_youtube_api_key()
         elif parsed_path.path == 'screensavers':
             response = self.__api.get_screensavers()
-        elif parsed_path.path == 'screensaver_configs':
-            response = self.__api.get_all_screensaver_configs()
-        elif parsed_path.path.startswith('screensaver_config/'):
-            screensaver_id = parsed_path.path.split('/')[1]
-            response = self.__api.get_screensaver_config(screensaver_id)
         else:
             self.__do_404()
             return

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -258,7 +258,10 @@ class PifiAPI():
         # Read existing overrides from DB. The DB stores {"screensavers": {...}},
         # wrapping is needed for reload_overrides compatibility with the config structure.
         raw_json = self.__settings_db.get(SettingsDb.SCREENSAVER_SETTINGS)
-        overrides = json.loads(raw_json).get('screensavers', {}) if raw_json else {}
+        try:
+            overrides = json.loads(raw_json).get('screensavers', {}) if raw_json else {}
+        except (json.JSONDecodeError, TypeError):
+            overrides = {}
 
         if 'enabled' in post_data:
             if not isinstance(post_data['enabled'], list):
@@ -269,8 +272,8 @@ class PifiAPI():
 
         if 'timeout' in post_data:
             timeout = post_data['timeout']
-            if timeout is not None and not isinstance(timeout, (int, float)):
-                return {'success': False, 'error': 'timeout must be a number or null'}
+            if timeout is not None and (not isinstance(timeout, (int, float)) or timeout < 0):
+                return {'success': False, 'error': 'timeout must be a non-negative number or null'}
             overrides['timeout'] = timeout
 
         if 'transitions' in post_data and isinstance(post_data['transitions'], dict):

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -276,7 +276,10 @@ class PifiAPI():
                 return {'success': False, 'error': 'timeout must be a non-negative number or null'}
             overrides['timeout'] = timeout
 
-        if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
+        if 'transitions' in post_data:
+            if not isinstance(post_data['transitions'], dict):
+                return {'success': False, 'error': 'transitions must be an object'}
+
             t = post_data['transitions']
             if 'enabled' in t and not isinstance(t['enabled'], bool):
                 return {'success': False, 'error': 'transitions.enabled must be a boolean'}
@@ -289,7 +292,10 @@ class PifiAPI():
                 if key in t:
                     transitions[key] = t[key]
 
-        if 'configs' in post_data and isinstance(post_data['configs'], dict):
+        if 'configs' in post_data:
+            if not isinstance(post_data['configs'], dict):
+                return {'success': False, 'error': 'configs must be an object'}
+
             existing_configs = overrides.setdefault('configs', {})
             for screensaver_id, config in post_data['configs'].items():
                 if config is None:

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -270,33 +270,20 @@ class PifiAPI():
                 if key in post_data['transitions']:
                     transitions[key] = post_data['transitions'][key]
 
+        if 'configs' in post_data and isinstance(post_data['configs'], dict):
+            existing_configs = overrides.setdefault('configs', {})
+            for screensaver_id, config in post_data['configs'].items():
+                if config is None:
+                    existing_configs.pop(screensaver_id, None)
+                elif isinstance(config, dict):
+                    existing_configs[screensaver_id] = config
+
         self.__save_screensaver_overrides(overrides)
         Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
 
         # Signal queue to restart screensaver so changes take effect immediately
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
         return {'success': True}
-
-    def set_screensaver_config(self, post_data):
-        """Set config overrides for a screensaver."""
-        screensaver_id = post_data.get('screensaver_id')
-        config = post_data.get('config', {})
-
-        if not screensaver_id:
-            return {'success': False, 'error': 'screensaver_id required'}
-
-        if not isinstance(config, dict):
-            return {'success': False, 'error': 'config must be an object'}
-
-        overrides = self.__get_screensaver_overrides()
-        overrides.setdefault('configs', {})[screensaver_id] = config
-        self.__save_screensaver_overrides(overrides)
-        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-
-        # Signal restart
-        self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
-
-        return {'success': True, 'screensaver_id': screensaver_id, 'config': config}
 
     def __get_screensaver_overrides(self):
         """Read screensaver overrides from DB.
@@ -316,24 +303,6 @@ class PifiAPI():
         """
         self.__settings_db.set(SettingsDb.SCREENSAVER_SETTINGS, json.dumps({'screensavers': overrides}))
 
-    def reset_screensaver_config(self, post_data):
-        """Reset a screensaver's config to defaults."""
-        screensaver_id = post_data.get('screensaver_id')
-
-        if not screensaver_id:
-            return {'success': False, 'error': 'screensaver_id required'}
-
-        overrides = self.__get_screensaver_overrides()
-        configs = overrides.get('configs', {})
-        if screensaver_id in configs:
-            del configs[screensaver_id]
-        self.__save_screensaver_overrides(overrides)
-        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-
-        # Signal restart
-        self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
-
-        return {'success': True, 'screensaver_id': screensaver_id}
 
 class PifiServerRequestHandler(BaseHTTPRequestHandler):
 
@@ -434,10 +403,6 @@ class PifiServerRequestHandler(BaseHTTPRequestHandler):
             response = self.__api.submit_game_score_initials(post_data)
         elif path == 'screensavers':
             response = self.__api.set_screensavers(post_data)
-        elif path == 'screensaver_config':
-            response = self.__api.set_screensaver_config(post_data)
-        elif path == 'screensaver_config_reset':
-            response = self.__api.reset_screensaver_config(post_data)
         else:
             self.__do_404()
             return

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -33,7 +33,7 @@ class PifiAPI():
         queue = self.__playlist.get_queue()
         response_details['queue'] = queue
         response_details['vol_pct'] = self.__vol_controller.get_vol_pct()
-        response_details[SettingsDb.SCREENSAVER_SETTING] = self.__settings_db.is_enabled(SettingsDb.SCREENSAVER_SETTING, True)
+        response_details[SettingsDb.IS_SCREENSAVER_ENABLED] = self.__settings_db.is_enabled(SettingsDb.IS_SCREENSAVER_ENABLED, True)
         response_details['success'] = True
         return response_details
 
@@ -188,7 +188,7 @@ class PifiAPI():
         return {'success': success}
 
     def set_screensaver_enabled(self, post_data):
-        self.__settings_db.set(SettingsDb.SCREENSAVER_SETTING, bool(post_data[SettingsDb.SCREENSAVER_SETTING]))
+        self.__settings_db.set(SettingsDb.IS_SCREENSAVER_ENABLED, bool(post_data[SettingsDb.IS_SCREENSAVER_ENABLED]))
         return {'success': True}
 
     def set_vol_pct(self, post_data):
@@ -243,12 +243,23 @@ class PifiAPI():
         }
 
     def set_screensavers(self, post_data):
+        overrides = self.__get_screensaver_overrides()
+
         if 'enabled' in post_data:
-            enabled = post_data['enabled']
-            self.__settings_db.set(SettingsDb.ENABLED_SCREENSAVERS, json.dumps(enabled))
+            overrides['enabled'] = post_data['enabled']
 
         if 'global_settings' in post_data:
-            self.__save_global_screensaver_settings(post_data['global_settings'])
+            settings = post_data['global_settings']
+            if 'screensavers' in settings and isinstance(settings['screensavers'], dict):
+                if 'timeout' in settings['screensavers']:
+                    overrides['timeout'] = settings['screensavers']['timeout']
+            if 'transitions' in settings and isinstance(settings['transitions'], dict):
+                transitions = overrides.setdefault('transitions', {})
+                for key in ('enabled', 'duration', 'num_steps'):
+                    if key in settings['transitions']:
+                        transitions[key] = settings['transitions'][key]
+
+        self.__save_screensaver_overrides(overrides)
 
         # Signal queue to restart screensaver so changes take effect immediately
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
@@ -264,7 +275,7 @@ class PifiAPI():
             default_config = {}
 
         # Get user overrides from SettingsDb
-        overrides = self.__get_screensaver_config_overrides(screensaver_id)
+        overrides = self.__get_screensaver_overrides().get('configs', {}).get(screensaver_id, {})
 
         # Merge defaults with overrides
         config = {**default_config, **overrides}
@@ -283,7 +294,7 @@ class PifiAPI():
         all_screensavers = ScreensaverManager.get_all_screensavers()
 
         # Get all user overrides
-        all_overrides = self.__get_all_screensaver_config_overrides()
+        all_config_overrides = self.__get_screensaver_overrides().get('configs', {})
 
         configs = {}
         for s in all_screensavers:
@@ -291,7 +302,7 @@ class PifiAPI():
             default_config = Config.get(f'screensavers.configs.{sid}', {})
             if not isinstance(default_config, dict):
                 default_config = {}
-            overrides = all_overrides.get(sid, {})
+            overrides = all_config_overrides.get(sid, {})
             configs[sid] = {
                 'config': {**default_config, **overrides},
                 'defaults': default_config,
@@ -313,14 +324,9 @@ class PifiAPI():
         if not isinstance(config, dict):
             return {'success': False, 'error': 'config must be an object'}
 
-        # Get existing overrides
-        all_overrides = self.__get_all_screensaver_config_overrides()
-
-        # Update overrides for this screensaver
-        all_overrides[screensaver_id] = config
-
-        # Save back to database
-        self.__save_all_screensaver_config_overrides(all_overrides)
+        overrides = self.__get_screensaver_overrides()
+        overrides.setdefault('configs', {})[screensaver_id] = config
+        self.__save_screensaver_overrides(overrides)
 
         # Signal restart
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')
@@ -348,46 +354,23 @@ class PifiAPI():
             'defaults': get_values(Config.get_default),
         }
 
-    def __save_global_screensaver_settings(self, settings):
-        """Save global screensaver transition and timeout settings."""
-        screensavers_overrides = {}
-        if 'screensavers' in settings and isinstance(settings['screensavers'], dict):
-            if 'timeout' in settings['screensavers']:
-                screensavers_overrides['timeout'] = settings['screensavers']['timeout']
+    def __get_screensaver_overrides(self):
+        """Read screensaver overrides from DB.
 
-        if 'transitions' in settings and isinstance(settings['transitions'], dict):
-            transitions = {}
-            for key in ('enabled', 'duration', 'num_steps'):
-                if key in settings['transitions']:
-                    transitions[key] = settings['transitions'][key]
-            if transitions:
-                screensavers_overrides['transitions'] = transitions
-
-        overrides = {}
-        if screensavers_overrides:
-            overrides['screensavers'] = screensavers_overrides
-        self.__settings_db.set(SettingsDb.GLOBAL_SCREENSAVER_SETTINGS, json.dumps(overrides))
-
-    def __get_all_screensaver_config_overrides(self):
-        """Get flat {screensaver_id: {key: value}} overrides from DB.
-
-        DB stores nested format for reload_overrides compatibility:
-        {"screensavers": {"configs": {screensaver_id: {key: value}}}}
+        Returns the screensavers dict (enabled, timeout, transitions, configs).
+        DB stores: {"screensavers": {...}}
         """
-        overrides_json = self.__settings_db.get(SettingsDb.SCREENSAVER_CONFIGS)
-        if not overrides_json:
+        raw_json = self.__settings_db.get(SettingsDb.SCREENSAVER_SETTINGS)
+        if not raw_json:
             return {}
-        raw = json.loads(overrides_json)
-        return raw.get('screensavers', {}).get('configs', {})
+        return json.loads(raw_json).get('screensavers', {})
 
-    def __get_screensaver_config_overrides(self, screensaver_id):
-        """Get overrides for a single screensaver."""
-        return self.__get_all_screensaver_config_overrides().get(screensaver_id, {})
+    def __save_screensaver_overrides(self, overrides):
+        """Write screensaver overrides to DB.
 
-    def __save_all_screensaver_config_overrides(self, all_overrides):
-        """Save flat {screensaver_id: {key: value}} overrides to DB in nested format."""
-        nested = {'screensavers': {'configs': all_overrides}}
-        self.__settings_db.set(SettingsDb.SCREENSAVER_CONFIGS, json.dumps(nested))
+        Takes a flat screensavers dict and wraps it for reload_overrides compatibility.
+        """
+        self.__settings_db.set(SettingsDb.SCREENSAVER_SETTINGS, json.dumps({'screensavers': overrides}))
 
     def reset_screensaver_config(self, post_data):
         """Reset a screensaver's config to defaults."""
@@ -396,15 +379,11 @@ class PifiAPI():
         if not screensaver_id:
             return {'success': False, 'error': 'screensaver_id required'}
 
-        # Get existing overrides
-        all_overrides = self.__get_all_screensaver_config_overrides()
-
-        # Remove overrides for this screensaver
-        if screensaver_id in all_overrides:
-            del all_overrides[screensaver_id]
-
-        # Save back to database
-        self.__save_all_screensaver_config_overrides(all_overrides)
+        overrides = self.__get_screensaver_overrides()
+        configs = overrides.get('configs', {})
+        if screensaver_id in configs:
+            del configs[screensaver_id]
+        self.__save_screensaver_overrides(overrides)
 
         # Signal restart
         self.__settings_db.set(SettingsDb.RESTART_SCREENSAVER, '1')

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -274,10 +274,15 @@ class PifiAPI():
             overrides['timeout'] = timeout
 
         if 'transitions' in post_data and isinstance(post_data['transitions'], dict):
+            t = post_data['transitions']
+            if 'duration' in t and (not isinstance(t['duration'], (int, float)) or t['duration'] <= 0):
+                return {'success': False, 'error': 'transitions.duration must be a positive number'}
+            if 'num_steps' in t and (not isinstance(t['num_steps'], int) or t['num_steps'] <= 0):
+                return {'success': False, 'error': 'transitions.num_steps must be a positive integer'}
             transitions = overrides.setdefault('transitions', {})
             for key in ('enabled', 'duration', 'num_steps'):
-                if key in post_data['transitions']:
-                    transitions[key] = post_data['transitions'][key]
+                if key in t:
+                    transitions[key] = t[key]
 
         if 'configs' in post_data and isinstance(post_data['configs'], dict):
             existing_configs = overrides.setdefault('configs', {})

--- a/pifi/server.py
+++ b/pifi/server.py
@@ -285,10 +285,10 @@ class PifiAPI():
                 return {'success': False, 'error': 'transitions.enabled must be a boolean'}
             if 'duration' in t and (not isinstance(t['duration'], (int, float)) or t['duration'] <= 0):
                 return {'success': False, 'error': 'transitions.duration must be a positive number'}
-            if 'num_steps' in t and (not isinstance(t['num_steps'], int) or t['num_steps'] <= 0):
-                return {'success': False, 'error': 'transitions.num_steps must be a positive integer'}
+            if 'tick_sleep' in t and (not isinstance(t['tick_sleep'], (int, float)) or t['tick_sleep'] < 0):
+                return {'success': False, 'error': 'transitions.tick_sleep must be a non-negative number'}
             transitions = overrides.setdefault('transitions', {})
-            for key in ('enabled', 'duration', 'num_steps'):
+            for key in ('enabled', 'duration', 'tick_sleep'):
                 if key in t:
                     transitions[key] = t[key]
 

--- a/pifi/settingsdb.py
+++ b/pifi/settingsdb.py
@@ -10,24 +10,19 @@ only read at program startup.
 class SettingsDb:
 
     # game of life screensaver
-    SCREENSAVER_SETTING = 'is_screensaver_enabled'
-
-    # Which screensavers are enabled (JSON array)
-    ENABLED_SCREENSAVERS = 'enabled_screensavers'
+    IS_SCREENSAVER_ENABLED = 'is_screensaver_enabled'
 
     # Flag to trigger screensaver restart (checked and cleared by queue)
     RESTART_SCREENSAVER = 'restart_screensaver'
 
-    # Screensaver config overrides (JSON object: {screensaver_id: {key: value, ...}, ...})
-    SCREENSAVER_CONFIGS = 'screensaver_configs'
+    # All screensaver settings: enabled list, timeout, transitions, per-screensaver configs.
+    # JSON object merged into Config under "screensavers".
+    SCREENSAVER_SETTINGS = 'screensaver_settings'
 
     SETTING_YOUTUBE_API_KEY = 'youtube_api_key'
 
     # Global LED brightness (0-100 percentage)
     BRIGHTNESS = 'brightness'
-
-    # Global screensaver/transition settings (JSON object)
-    GLOBAL_SCREENSAVER_SETTINGS = 'global_screensaver_settings'
 
     def __init__(self):
         self.__cursor = pifi.database.Database().get_cursor()

--- a/pifi/settingsdb.py
+++ b/pifi/settingsdb.py
@@ -27,7 +27,7 @@ class SettingsDb:
     BRIGHTNESS = 'brightness'
 
     # Global screensaver/transition settings (JSON object)
-    GLOBAL_SETTINGS = 'global_settings'
+    GLOBAL_SCREENSAVER_SETTINGS = 'global_screensaver_settings'
 
     def __init__(self):
         self.__cursor = pifi.database.Database().get_cursor()

--- a/pifi/settingsdb.py
+++ b/pifi/settingsdb.py
@@ -26,6 +26,9 @@ class SettingsDb:
     # Global LED brightness (0-100 percentage)
     BRIGHTNESS = 'brightness'
 
+    # Global screensaver/transition settings (JSON object)
+    GLOBAL_SETTINGS = 'global_settings'
+
     def __init__(self):
         self.__cursor = pifi.database.Database().get_cursor()
         self.__logger = Logger().set_namespace(self.__class__.__name__)

--- a/pifi/settingsdb.py
+++ b/pifi/settingsdb.py
@@ -9,7 +9,7 @@ only read at program startup.
 """
 class SettingsDb:
 
-    # game of life screensaver
+    # Whether the screensaver is enabled (on/off toggle)
     IS_SCREENSAVER_ENABLED = 'is_screensaver_enabled'
 
     # Flag to trigger screensaver restart (checked and cleared by queue)

--- a/pifi/video/videoprocessor.py
+++ b/pifi/video/videoprocessor.py
@@ -46,13 +46,17 @@ class VideoProcessor:
     #   Refer to yt-dlp documentation for the '--use-extractors' flag for more details.
     #
     # show_loading_screen: boolean. Whether or not we display the loading screen at all.
-    def __init__(self, url, clear_screen, yt_dlp_extractors = None, show_loading_screen = True):
+    def __init__(self, url, clear_screen, yt_dlp_extractors = None, show_loading_screen = True,
+                 led_frame_player = None):
         self.__logger = Logger().set_namespace(self.__class__.__name__)
         self.__url = url
-        self.__led_frame_player = LedFramePlayer(
-            clear_screen = clear_screen,
-            video_color_mode = Config.get('video.color_mode')
-        )
+        if led_frame_player is not None:
+            self.__led_frame_player = led_frame_player
+        else:
+            self.__led_frame_player = LedFramePlayer(
+                clear_screen = clear_screen,
+                video_color_mode = Config.get('video.color_mode')
+            )
         self.__process_and_play_vid_proc_pgid = None
         self.__init_time = time.time()
 

--- a/pifi/video/videoprocessor.py
+++ b/pifi/video/videoprocessor.py
@@ -55,7 +55,6 @@ class VideoProcessor:
             self.__led_frame_player = led_frame_player
         else:
             self.__led_frame_player = LedFramePlayer(clear_screen = clear_screen)
-        self.__led_frame_player.set_video_color_mode(Config.get('video.color_mode'))
         self.__process_and_play_vid_proc_pgid = None
         self.__init_time = time.time()
 
@@ -68,6 +67,7 @@ class VideoProcessor:
         self.__register_signal_handlers()
 
     def process_and_play(self):
+        self.__led_frame_player.set_video_color_mode(Config.get('video.color_mode'))
         self.__logger.info(f"Starting process_and_play for url: {self.__url}")
         self.__show_loading_screen()
         video_save_path = self.__get_video_save_path()
@@ -102,10 +102,6 @@ class VideoProcessor:
                 self.__do_housekeeping(clear_screen = clear_screen)
             attempt += 1
 
-        # Restore default color mode if using an external player so subsequent
-        # screensavers (which pass 3D RGB frames) render correctly.
-        if self.__external_led_frame_player:
-            self.__led_frame_player.set_video_color_mode(VideoColorMode.COLOR_MODE_COLOR)
         self.__logger.info("Finished process_and_play")
 
     def download_video(self, save_path):
@@ -493,6 +489,10 @@ class VideoProcessor:
         self.__logger.info("Update yt-dlp output: {}".format(update_yt_dlp_output))
 
     def __do_housekeeping(self, clear_screen = True):
+        # Restore default color mode if using an external player so subsequent
+        # screensavers (which pass 3D RGB frames) render correctly.
+        if self.__external_led_frame_player:
+            self.__led_frame_player.set_video_color_mode(VideoColorMode.COLOR_MODE_COLOR)
         if clear_screen:
             self.__led_frame_player.clear_screen()
         if self.__process_and_play_vid_proc_pgid:

--- a/pifi/video/videoprocessor.py
+++ b/pifi/video/videoprocessor.py
@@ -50,13 +50,12 @@ class VideoProcessor:
                  led_frame_player = None):
         self.__logger = Logger().set_namespace(self.__class__.__name__)
         self.__url = url
+        self.__external_led_frame_player = led_frame_player is not None
         if led_frame_player is not None:
             self.__led_frame_player = led_frame_player
         else:
-            self.__led_frame_player = LedFramePlayer(
-                clear_screen = clear_screen,
-                video_color_mode = Config.get('video.color_mode')
-            )
+            self.__led_frame_player = LedFramePlayer(clear_screen = clear_screen)
+        self.__led_frame_player.set_video_color_mode(Config.get('video.color_mode'))
         self.__process_and_play_vid_proc_pgid = None
         self.__init_time = time.time()
 
@@ -102,6 +101,11 @@ class VideoProcessor:
             finally:
                 self.__do_housekeeping(clear_screen = clear_screen)
             attempt += 1
+
+        # Restore default color mode if using an external player so subsequent
+        # screensavers (which pass 3D RGB frames) render correctly.
+        if self.__external_led_frame_player:
+            self.__led_frame_player.set_video_color_mode(VideoColorMode.COLOR_MODE_COLOR)
         self.__logger.info("Finished process_and_play")
 
     def download_video(self, save_path):

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -45,7 +45,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         overrides = {'screensavers': {'configs': {'boids': {'num_boids': 50}}}}
         MockSettingsDb.return_value.get.return_value = json.dumps(overrides)
 
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
 
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         # Non-overridden keys should be preserved
@@ -58,12 +58,12 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         # First call: apply overrides
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Second call: overrides removed (reset)
         mock_db.get.return_value = json.dumps({})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
 
     @patch('pifi.settingsdb.SettingsDb')
@@ -75,14 +75,14 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db.get.return_value = json.dumps({
             'screensavers': {'configs': {'boids': {'num_boids': 50, 'tick_sleep': 0.01, 'max_ticks': 100}}}
         })
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.01)
         self.assertEqual(Config.get('screensavers.configs.boids.max_ticks'), 100)
 
         # Reset
         mock_db.get.return_value = None
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.05)
         self.assertEqual(Config.get('screensavers.configs.boids.max_ticks'), 3000)
@@ -93,7 +93,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
 
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.04)
@@ -110,7 +110,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
                 'aurora': {'tick_sleep': 0.1},
             }}
         })
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
@@ -120,7 +120,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
                 'aurora': {'tick_sleep': 0.1},
             }}
         })
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
@@ -131,12 +131,12 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         # Override a screensaver that has no base config
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'newss': {'foo': 'bar'}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.newss.foo'), 'bar')
 
         # Reset
         mock_db.get.return_value = json.dumps({})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertIsNone(Config.get('screensavers.configs.newss.foo'))
         self.assertIsNone(Config.get('screensavers.configs.newss'))
 
@@ -146,7 +146,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
 
         self.assertEqual(Config.get('leds.driver'), 'apa102')
         self.assertEqual(Config.get('leds.display_width'), 32)
@@ -157,7 +157,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = None
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
 
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.04)
@@ -168,7 +168,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = 'not valid json{'
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
 
         # Config should remain unchanged
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
@@ -179,7 +179,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': 'a string'}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
 
         self.assertEqual(Config.get('screensavers.configs.boids'), 'a string')
 
@@ -243,14 +243,14 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Mutate config directly to detect if rebuild happens
         Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999
 
         # Same DB value — should skip rebuild, keeping the mutation
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 999)
 
     @patch('pifi.settingsdb.SettingsDb')
@@ -259,7 +259,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Mutate config directly
@@ -267,7 +267,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         # Different DB value — should rebuild, overwriting the mutation
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 75}}}})
-        Config.reload_overrides(['screensaver_configs'])
+        Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 75)
 
     @patch('pifi.settingsdb.SettingsDb')
@@ -278,7 +278,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db.get.return_value = json.dumps({
             'screensavers': {'timeout': 30, 'transitions': {'enabled': False}}
         })
-        Config.reload_overrides(['global_screensaver_settings'])
+        Config.reload_overrides(['screensaver_settings'])
 
         self.assertEqual(Config.get('screensavers.timeout'), 30)
         self.assertFalse(Config.get('screensavers.transitions.enabled'))

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Unit tests for Config.reload_screensaver_overrides().
+Unit tests for Config.reload_overrides().
 
-Verifies that screensaver config overrides from the database are correctly
+Verifies that config overrides from the database are correctly
 applied to and removed from the in-memory config.
 """
 
@@ -38,9 +38,8 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         """Overrides from DB are applied to config."""
         overrides = {'boids': {'num_boids': 50}}
         MockSettingsDb.return_value.get.return_value = json.dumps(overrides)
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
 
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
 
         self.assertEqual(Config.get('boids.num_boids'), 50)
         # Non-overridden keys should be preserved
@@ -49,37 +48,35 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     @patch('pifi.settingsdb.SettingsDb')
     def test_reset_restores_defaults(self, MockSettingsDb):
         """After overrides are removed from DB, config reverts to defaults."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         # First call: apply overrides
         mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('boids.num_boids'), 50)
 
         # Second call: overrides removed (reset)
         mock_db.get.return_value = json.dumps({})
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('boids.num_boids'), 15)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_reset_restores_all_keys(self, MockSettingsDb):
         """Reset restores all keys in a section, not just overridden ones."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         # Override multiple keys
         mock_db.get.return_value = json.dumps({
             'boids': {'num_boids': 50, 'tick_sleep': 0.01, 'max_ticks': 100}
         })
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('boids.num_boids'), 50)
         self.assertEqual(Config.get('boids.tick_sleep'), 0.01)
         self.assertEqual(Config.get('boids.max_ticks'), 100)
 
         # Reset
         mock_db.get.return_value = None
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('boids.num_boids'), 15)
         self.assertEqual(Config.get('boids.tick_sleep'), 0.05)
         self.assertEqual(Config.get('boids.max_ticks'), 3000)
@@ -87,11 +84,10 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     @patch('pifi.settingsdb.SettingsDb')
     def test_independent_screensavers(self, MockSettingsDb):
         """Overriding one screensaver does not affect another."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
 
         self.assertEqual(Config.get('boids.num_boids'), 50)
         self.assertEqual(Config.get('aurora.tick_sleep'), 0.04)
@@ -99,7 +95,6 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     @patch('pifi.settingsdb.SettingsDb')
     def test_reset_one_keeps_other(self, MockSettingsDb):
         """Resetting one screensaver's overrides preserves another's."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         # Override both
@@ -107,7 +102,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
             'boids': {'num_boids': 50},
             'aurora': {'tick_sleep': 0.1},
         })
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('boids.num_boids'), 50)
         self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
 
@@ -115,35 +110,33 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db.get.return_value = json.dumps({
             'aurora': {'tick_sleep': 0.1},
         })
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('boids.num_boids'), 15)
         self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_override_new_screensaver_then_reset(self, MockSettingsDb):
         """Overriding a screensaver not in base config, then resetting, removes it."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         # Override a screensaver that has no base config
         mock_db.get.return_value = json.dumps({'newss': {'foo': 'bar'}})
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertEqual(Config.get('newss.foo'), 'bar')
 
         # Reset
         mock_db.get.return_value = json.dumps({})
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
         self.assertIsNone(Config.get('newss.foo'))
         self.assertIsNone(Config.get('newss'))
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_non_screensaver_config_untouched(self, MockSettingsDb):
         """Non-screensaver config sections are never modified by overrides."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
 
         self.assertEqual(Config.get('leds.driver'), 'apa102')
         self.assertEqual(Config.get('leds.display_width'), 32)
@@ -151,11 +144,10 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     @patch('pifi.settingsdb.SettingsDb')
     def test_no_overrides_in_db(self, MockSettingsDb):
         """No overrides in DB leaves config unchanged."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = None
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
 
         self.assertEqual(Config.get('boids.num_boids'), 15)
         self.assertEqual(Config.get('aurora.tick_sleep'), 0.04)
@@ -163,25 +155,23 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     @patch('pifi.settingsdb.SettingsDb')
     def test_invalid_json_in_db(self, MockSettingsDb):
         """Invalid JSON in DB is handled gracefully without crashing."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = 'not valid json{'
-        Config.reload_screensaver_overrides()
+        Config.reload_overrides(['screensaver_configs'])
 
         # Config should remain unchanged
         self.assertEqual(Config.get('boids.num_boids'), 15)
 
     @patch('pifi.settingsdb.SettingsDb')
-    def test_non_dict_override_ignored(self, MockSettingsDb):
-        """Non-dict override values are ignored."""
-        MockSettingsDb.SCREENSAVER_CONFIGS = 'screensaver_configs'
+    def test_non_dict_override_replaces_value(self, MockSettingsDb):
+        """Non-dict override replaces the existing value."""
         mock_db = MockSettingsDb.return_value
 
-        mock_db.get.return_value = json.dumps({'boids': 'not a dict'})
-        Config.reload_screensaver_overrides()
+        mock_db.get.return_value = json.dumps({'boids': 'a string'})
+        Config.reload_overrides(['screensaver_configs'])
 
-        self.assertEqual(Config.get('boids.num_boids'), 15)
+        self.assertEqual(Config.get('boids'), 'a string')
 
 
 if __name__ == '__main__':

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -31,7 +31,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config._Config__is_loaded = True
         Config._Config__config = copy.deepcopy(self.BASE_CONFIG)
         Config._Config__base_config = copy.deepcopy(self.BASE_CONFIG)
-        Config._Config__previously_overridden = set()
+        Config._Config__applied_overrides = {}
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_applies_overrides(self, MockSettingsDb):
@@ -172,6 +172,93 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config.reload_overrides(['screensaver_configs'])
 
         self.assertEqual(Config.get('boids'), 'a string')
+
+
+    @patch('pifi.settingsdb.SettingsDb')
+    def test_multiple_db_keys(self, MockSettingsDb):
+        """Overrides from multiple DB keys are all applied."""
+        mock_db = MockSettingsDb.return_value
+
+        def get_by_key(key):
+            if key == 'key1':
+                return json.dumps({'boids': {'num_boids': 50}})
+            elif key == 'key2':
+                return json.dumps({'aurora': {'tick_sleep': 0.1}})
+            return None
+
+        mock_db.get.side_effect = get_by_key
+        Config.reload_overrides(['key1', 'key2'])
+
+        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+
+    @patch('pifi.settingsdb.SettingsDb')
+    def test_partial_reload_preserves_other_keys(self, MockSettingsDb):
+        """Reloading one DB key doesn't clobber overrides from another."""
+        mock_db = MockSettingsDb.return_value
+
+        # Load overrides from key1
+        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        Config.reload_overrides(['key1'])
+        self.assertEqual(Config.get('boids.num_boids'), 50)
+
+        # Load overrides from key2 — key1 overrides should persist
+        mock_db.get.return_value = json.dumps({'aurora': {'tick_sleep': 0.1}})
+        Config.reload_overrides(['key2'])
+        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+
+    @patch('pifi.settingsdb.SettingsDb')
+    def test_partial_reload_reset_preserves_other_keys(self, MockSettingsDb):
+        """Removing overrides from one DB key doesn't affect another's overrides."""
+        mock_db = MockSettingsDb.return_value
+
+        # Load overrides from both keys
+        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        Config.reload_overrides(['key1'])
+        mock_db.get.return_value = json.dumps({'aurora': {'tick_sleep': 0.1}})
+        Config.reload_overrides(['key2'])
+
+        # Remove key1 overrides
+        mock_db.get.return_value = None
+        Config.reload_overrides(['key1'])
+
+        # key1 overrides gone, key2 overrides preserved
+        self.assertEqual(Config.get('boids.num_boids'), 15)
+        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+
+    @patch('pifi.settingsdb.SettingsDb')
+    def test_skips_rebuild_when_unchanged(self, MockSettingsDb):
+        """Config is not rebuilt when DB values haven't changed."""
+        mock_db = MockSettingsDb.return_value
+
+        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        Config.reload_overrides(['screensaver_configs'])
+        self.assertEqual(Config.get('boids.num_boids'), 50)
+
+        # Mutate config directly to detect if rebuild happens
+        Config._Config__config['boids']['num_boids'] = 999
+
+        # Same DB value — should skip rebuild, keeping the mutation
+        Config.reload_overrides(['screensaver_configs'])
+        self.assertEqual(Config.get('boids.num_boids'), 999)
+
+    @patch('pifi.settingsdb.SettingsDb')
+    def test_rebuilds_when_changed(self, MockSettingsDb):
+        """Config is rebuilt when DB values change."""
+        mock_db = MockSettingsDb.return_value
+
+        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        Config.reload_overrides(['screensaver_configs'])
+        self.assertEqual(Config.get('boids.num_boids'), 50)
+
+        # Mutate config directly
+        Config._Config__config['boids']['num_boids'] = 999
+
+        # Different DB value — should rebuild, overwriting the mutation
+        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 75}})
+        Config.reload_overrides(['screensaver_configs'])
+        self.assertEqual(Config.get('boids.num_boids'), 75)
 
 
 if __name__ == '__main__':

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -271,8 +271,8 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 75)
 
     @patch('pifi.settingsdb.SettingsDb')
-    def test_global_settings_override_transitions(self, MockSettingsDb):
-        """Global settings DB key can override transition settings."""
+    def test_override_timeout_and_transitions(self, MockSettingsDb):
+        """DB overrides can set timeout and transition settings."""
         mock_db = MockSettingsDb.return_value
 
         mock_db.get.return_value = json.dumps({

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -24,7 +24,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         'leds': {'driver': 'apa102', 'display_width': 32, 'display_height': 16},
         'screensavers': {
             'timeout': 120,
-            'transitions': {'enabled': True, 'duration': 1.0, 'num_steps': 30},
+            'transitions': {'enabled': True, 'duration': 1.0, 'tick_sleep': 0.03},
             'configs': {
                 'boids': {'num_boids': 15, 'tick_sleep': 0.05},
                 'aurora': {'tick_sleep': 0.04},

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -23,11 +23,11 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     BASE_CONFIG = {
         'leds': {'driver': 'apa102', 'display_width': 32, 'display_height': 16},
         'screensavers': {
-            'timeout': None,
+            'timeout': 120,
             'transitions': {'enabled': True, 'duration': 1.0, 'num_steps': 30},
             'configs': {
-                'boids': {'num_boids': 15, 'tick_sleep': 0.05, 'max_ticks': 3000},
-                'aurora': {'tick_sleep': 0.04, 'max_ticks': 3000},
+                'boids': {'num_boids': 15, 'tick_sleep': 0.05},
+                'aurora': {'tick_sleep': 0.04},
             },
         },
     }
@@ -73,19 +73,17 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         # Override multiple keys
         mock_db.get.return_value = json.dumps({
-            'screensavers': {'configs': {'boids': {'num_boids': 50, 'tick_sleep': 0.01, 'max_ticks': 100}}}
+            'screensavers': {'configs': {'boids': {'num_boids': 50, 'tick_sleep': 0.01}}}
         })
         Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.01)
-        self.assertEqual(Config.get('screensavers.configs.boids.max_ticks'), 100)
 
         # Reset
         mock_db.get.return_value = None
         Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.05)
-        self.assertEqual(Config.get('screensavers.configs.boids.max_ticks'), 3000)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_independent_screensavers(self, MockSettingsDb):

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -22,8 +22,14 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
     BASE_CONFIG = {
         'leds': {'driver': 'apa102', 'display_width': 32, 'display_height': 16},
-        'boids': {'num_boids': 15, 'tick_sleep': 0.05, 'max_ticks': 3000},
-        'aurora': {'tick_sleep': 0.04, 'max_ticks': 3000},
+        'screensavers': {
+            'timeout': None,
+            'transitions': {'enabled': True, 'duration': 1.0, 'num_steps': 30},
+            'configs': {
+                'boids': {'num_boids': 15, 'tick_sleep': 0.05, 'max_ticks': 3000},
+                'aurora': {'tick_sleep': 0.04, 'max_ticks': 3000},
+            },
+        },
     }
 
     def setUp(self):
@@ -36,14 +42,14 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
     @patch('pifi.settingsdb.SettingsDb')
     def test_applies_overrides(self, MockSettingsDb):
         """Overrides from DB are applied to config."""
-        overrides = {'boids': {'num_boids': 50}}
+        overrides = {'screensavers': {'configs': {'boids': {'num_boids': 50}}}}
         MockSettingsDb.return_value.get.return_value = json.dumps(overrides)
 
         Config.reload_overrides(['screensaver_configs'])
 
-        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         # Non-overridden keys should be preserved
-        self.assertEqual(Config.get('boids.tick_sleep'), 0.05)
+        self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.05)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_reset_restores_defaults(self, MockSettingsDb):
@@ -51,14 +57,14 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         # First call: apply overrides
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Second call: overrides removed (reset)
         mock_db.get.return_value = json.dumps({})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 15)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_reset_restores_all_keys(self, MockSettingsDb):
@@ -67,30 +73,30 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         # Override multiple keys
         mock_db.get.return_value = json.dumps({
-            'boids': {'num_boids': 50, 'tick_sleep': 0.01, 'max_ticks': 100}
+            'screensavers': {'configs': {'boids': {'num_boids': 50, 'tick_sleep': 0.01, 'max_ticks': 100}}}
         })
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
-        self.assertEqual(Config.get('boids.tick_sleep'), 0.01)
-        self.assertEqual(Config.get('boids.max_ticks'), 100)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.01)
+        self.assertEqual(Config.get('screensavers.configs.boids.max_ticks'), 100)
 
         # Reset
         mock_db.get.return_value = None
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 15)
-        self.assertEqual(Config.get('boids.tick_sleep'), 0.05)
-        self.assertEqual(Config.get('boids.max_ticks'), 3000)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
+        self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.05)
+        self.assertEqual(Config.get('screensavers.configs.boids.max_ticks'), 3000)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_independent_screensavers(self, MockSettingsDb):
         """Overriding one screensaver does not affect another."""
         mock_db = MockSettingsDb.return_value
 
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['screensaver_configs'])
 
-        self.assertEqual(Config.get('boids.num_boids'), 50)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.04)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.04)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_reset_one_keeps_other(self, MockSettingsDb):
@@ -99,20 +105,24 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         # Override both
         mock_db.get.return_value = json.dumps({
-            'boids': {'num_boids': 50},
-            'aurora': {'tick_sleep': 0.1},
+            'screensavers': {'configs': {
+                'boids': {'num_boids': 50},
+                'aurora': {'tick_sleep': 0.1},
+            }}
         })
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
         # Reset only boids
         mock_db.get.return_value = json.dumps({
-            'aurora': {'tick_sleep': 0.1},
+            'screensavers': {'configs': {
+                'aurora': {'tick_sleep': 0.1},
+            }}
         })
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 15)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_override_new_screensaver_then_reset(self, MockSettingsDb):
@@ -120,22 +130,22 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         # Override a screensaver that has no base config
-        mock_db.get.return_value = json.dumps({'newss': {'foo': 'bar'}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'newss': {'foo': 'bar'}}}})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('newss.foo'), 'bar')
+        self.assertEqual(Config.get('screensavers.configs.newss.foo'), 'bar')
 
         # Reset
         mock_db.get.return_value = json.dumps({})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertIsNone(Config.get('newss.foo'))
-        self.assertIsNone(Config.get('newss'))
+        self.assertIsNone(Config.get('screensavers.configs.newss.foo'))
+        self.assertIsNone(Config.get('screensavers.configs.newss'))
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_non_screensaver_config_untouched(self, MockSettingsDb):
         """Non-screensaver config sections are never modified by overrides."""
         mock_db = MockSettingsDb.return_value
 
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['screensaver_configs'])
 
         self.assertEqual(Config.get('leds.driver'), 'apa102')
@@ -149,8 +159,8 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db.get.return_value = None
         Config.reload_overrides(['screensaver_configs'])
 
-        self.assertEqual(Config.get('boids.num_boids'), 15)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.04)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.04)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_invalid_json_in_db(self, MockSettingsDb):
@@ -161,17 +171,17 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config.reload_overrides(['screensaver_configs'])
 
         # Config should remain unchanged
-        self.assertEqual(Config.get('boids.num_boids'), 15)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_non_dict_override_replaces_value(self, MockSettingsDb):
         """Non-dict override replaces the existing value."""
         mock_db = MockSettingsDb.return_value
 
-        mock_db.get.return_value = json.dumps({'boids': 'a string'})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': 'a string'}}})
         Config.reload_overrides(['screensaver_configs'])
 
-        self.assertEqual(Config.get('boids'), 'a string')
+        self.assertEqual(Config.get('screensavers.configs.boids'), 'a string')
 
 
     @patch('pifi.settingsdb.SettingsDb')
@@ -181,16 +191,16 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
         def get_by_key(key):
             if key == 'key1':
-                return json.dumps({'boids': {'num_boids': 50}})
+                return json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
             elif key == 'key2':
-                return json.dumps({'aurora': {'tick_sleep': 0.1}})
+                return json.dumps({'screensavers': {'configs': {'aurora': {'tick_sleep': 0.1}}}})
             return None
 
         mock_db.get.side_effect = get_by_key
         Config.reload_overrides(['key1', 'key2'])
 
-        self.assertEqual(Config.get('boids.num_boids'), 50)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_partial_reload_preserves_other_keys(self, MockSettingsDb):
@@ -198,15 +208,15 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         # Load overrides from key1
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['key1'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Load overrides from key2 — key1 overrides should persist
-        mock_db.get.return_value = json.dumps({'aurora': {'tick_sleep': 0.1}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'aurora': {'tick_sleep': 0.1}}}})
         Config.reload_overrides(['key2'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_partial_reload_reset_preserves_other_keys(self, MockSettingsDb):
@@ -214,9 +224,9 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         mock_db = MockSettingsDb.return_value
 
         # Load overrides from both keys
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['key1'])
-        mock_db.get.return_value = json.dumps({'aurora': {'tick_sleep': 0.1}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'aurora': {'tick_sleep': 0.1}}}})
         Config.reload_overrides(['key2'])
 
         # Remove key1 overrides
@@ -224,41 +234,56 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config.reload_overrides(['key1'])
 
         # key1 overrides gone, key2 overrides preserved
-        self.assertEqual(Config.get('boids.num_boids'), 15)
-        self.assertEqual(Config.get('aurora.tick_sleep'), 0.1)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
+        self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_skips_rebuild_when_unchanged(self, MockSettingsDb):
         """Config is not rebuilt when DB values haven't changed."""
         mock_db = MockSettingsDb.return_value
 
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Mutate config directly to detect if rebuild happens
-        Config._Config__config['boids']['num_boids'] = 999
+        Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999
 
         # Same DB value — should skip rebuild, keeping the mutation
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 999)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 999)
 
     @patch('pifi.settingsdb.SettingsDb')
     def test_rebuilds_when_changed(self, MockSettingsDb):
         """Config is rebuilt when DB values change."""
         mock_db = MockSettingsDb.return_value
 
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 50}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 50}}}})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 50)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Mutate config directly
-        Config._Config__config['boids']['num_boids'] = 999
+        Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999
 
         # Different DB value — should rebuild, overwriting the mutation
-        mock_db.get.return_value = json.dumps({'boids': {'num_boids': 75}})
+        mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 75}}}})
         Config.reload_overrides(['screensaver_configs'])
-        self.assertEqual(Config.get('boids.num_boids'), 75)
+        self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 75)
+
+    @patch('pifi.settingsdb.SettingsDb')
+    def test_global_settings_override_transitions(self, MockSettingsDb):
+        """Global settings DB key can override transition settings."""
+        mock_db = MockSettingsDb.return_value
+
+        mock_db.get.return_value = json.dumps({
+            'screensavers': {'timeout': 30, 'transitions': {'enabled': False}}
+        })
+        Config.reload_overrides(['global_screensaver_settings'])
+
+        self.assertEqual(Config.get('screensavers.timeout'), 30)
+        self.assertFalse(Config.get('screensavers.transitions.enabled'))
+        # Non-overridden transition keys preserved
+        self.assertEqual(Config.get('screensavers.transitions.duration'), 1.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_screensaver_interface.py
+++ b/tests/test_screensaver_interface.py
@@ -150,7 +150,7 @@ class TestScreensaverInterface(unittest.TestCase):
         with open(default_config_path) as f:
             default_config = pyjson5.decode(f.read())
 
-        config_keys = set(default_config.keys())
+        config_keys = set(default_config.get('screensavers', {}).get('configs', {}).keys())
         # Screensavers that intentionally have no config section
         no_config_screensavers = {'video_screensaver'}
 

--- a/tests/test_screensaver_interface.py
+++ b/tests/test_screensaver_interface.py
@@ -38,8 +38,8 @@ def setUpModule():
             'saved_videos': [],
         },
         # Add minimal config for each screensaver
-        'boids': {'tick_sleep': 0.05, 'max_ticks': 100},
-        'aurora': {'tick_sleep': 0.04, 'max_ticks': 100},
+        'boids': {'tick_sleep': 0.05},
+        'aurora': {'tick_sleep': 0.04},
         'game_of_life': {
             'tick_sleep': 0.1,
             'game_over_detection_lookback': 100,

--- a/tests/test_screensaver_interface.py
+++ b/tests/test_screensaver_interface.py
@@ -135,7 +135,7 @@ class TestScreensaverInterface(unittest.TestCase):
         )
 
     def test_config_keys_match_screensaver_ids(self):
-        """Verify every screensaver has a matching config key in default_config.json.
+        """Verify screensavers.configs keys in default_config.json match screensaver IDs.
 
         The settings API keys configs by screensaver ID, so if default_config.json
         uses 'airplaykaraoke' but get_id() returns 'airplay_karaoke', overrides
@@ -151,26 +151,22 @@ class TestScreensaverInterface(unittest.TestCase):
             default_config = pyjson5.decode(f.read())
 
         config_keys = set(default_config.get('screensavers', {}).get('configs', {}).keys())
-        # Screensavers that intentionally have no config section
-        no_config_screensavers = {'video_screensaver'}
+        screensaver_ids = set(ScreensaverManager.SCREENSAVER_CLASSES.keys())
 
-        for screensaver_id in ScreensaverManager.SCREENSAVER_CLASSES:
-            if screensaver_id in no_config_screensavers:
-                # If it now has a config key, remove it from the ignore list
-                with self.subTest(screensaver=screensaver_id):
-                    self.assertNotIn(
-                        screensaver_id, config_keys,
-                        f"Screensaver '{screensaver_id}' is in no_config_screensavers "
-                        f"but has a config key in default_config.json. "
-                        f"Remove it from no_config_screensavers."
-                    )
-                continue
+        # Every config key should correspond to a real screensaver class
+        for key in config_keys:
+            with self.subTest(config_key=key):
+                self.assertIn(
+                    key, screensaver_ids,
+                    f"Config key '{key}' in screensavers.configs has no matching screensaver class."
+                )
+
+        # Every screensaver class should have a config key
+        for screensaver_id in screensaver_ids:
             with self.subTest(screensaver=screensaver_id):
                 self.assertIn(
                     screensaver_id, config_keys,
-                    f"Screensaver '{screensaver_id}' has no matching config key "
-                    f"in default_config.json. Typo or missing underscore? "
-                    f"If this screensaver has no config, add it to no_config_screensavers."
+                    f"Screensaver '{screensaver_id}' has no matching key in screensavers.configs."
                 )
 
     def test_all_screensavers_call_super_init(self):

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -7,7 +7,8 @@ Verifies the config resolution chain:
 
 And the timeout semantics:
   positive number = timeout after N seconds
-  0 or None       = unlimited (no timeout)
+  0 or None      = unlimited (no timeout)
+  Per-screensaver None = fall back to global
 """
 
 import copy
@@ -59,9 +60,14 @@ class TestTimeoutResolution(unittest.TestCase):
         return _StubScreensaver(led_frame_player=None)
 
     def test_default_timeout_is_120(self):
-        """When no timeout is configured anywhere, default is 120."""
-        ss = self._make({'screensavers': {}})
+        """When timeout is set to 120 in config (as in default_config.json), it's used."""
+        ss = self._make({'screensavers': {'timeout': 120}})
         self.assertEqual(ss._timeout, 120)
+
+    def test_timeout_absent_means_unlimited(self):
+        """When timeout key is absent from config entirely, it's unlimited."""
+        ss = self._make({'screensavers': {}})
+        self.assertEqual(ss._timeout, 0)
 
     def test_global_timeout_overrides_default(self):
         """Global screensavers.timeout overrides the hardcoded default."""
@@ -95,10 +101,32 @@ class TestTimeoutResolution(unittest.TestCase):
         ss._start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
-    def test_timeout_none_means_unlimited(self):
-        """Timeout of None means unlimited — _is_past_timeout always returns False."""
+    def test_global_timeout_none_means_unlimited(self):
+        """Global timeout of None means unlimited (same as 0)."""
         ss = self._make({'screensavers': {'timeout': None}})
-        self.assertIsNone(ss._timeout)
+        self.assertEqual(ss._timeout, 0)
+        ss._start_time = time.time() - 99999
+        self.assertFalse(ss._is_past_timeout())
+
+    def test_per_screensaver_timeout_null_falls_back_to_global(self):
+        """Per-screensaver timeout of null falls back to global timeout."""
+        ss = self._make({
+            'screensavers': {
+                'timeout': 60,
+                'configs': {'stub': {'timeout': None}},
+            }
+        })
+        self.assertEqual(ss._timeout, 60)
+
+    def test_per_screensaver_timeout_zero_means_unlimited(self):
+        """Per-screensaver timeout of 0 means unlimited, not fallback."""
+        ss = self._make({
+            'screensavers': {
+                'timeout': 60,
+                'configs': {'stub': {'timeout': 0}},
+            }
+        })
+        self.assertEqual(ss._timeout, 0)
         ss._start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
@@ -126,9 +154,14 @@ class TestTickSleepResolution(unittest.TestCase):
         return _StubScreensaver(led_frame_player=None)
 
     def test_default_tick_sleep(self):
-        """When no tick_sleep is configured, default is 0.05."""
-        ss = self._make({'screensavers': {}})
+        """When tick_sleep is set to 0.05 in config (as in default_config.json), it's used."""
+        ss = self._make({'screensavers': {'tick_sleep': 0.05}})
         self.assertEqual(ss._tick_sleep, 0.05)
+
+    def test_tick_sleep_absent_means_zero(self):
+        """When tick_sleep key is absent from config entirely, it's 0."""
+        ss = self._make({'screensavers': {}})
+        self.assertEqual(ss._tick_sleep, 0)
 
     def test_global_tick_sleep_overrides_default(self):
         """Global screensavers.tick_sleep overrides the hardcoded default."""
@@ -154,6 +187,21 @@ class TestTickSleepResolution(unittest.TestCase):
             }
         })
         self.assertEqual(ss._tick_sleep, 0.08)
+
+    def test_per_screensaver_tick_sleep_null_falls_back_to_global(self):
+        """Per-screensaver tick_sleep of null falls back to global tick_sleep."""
+        ss = self._make({
+            'screensavers': {
+                'tick_sleep': 0.08,
+                'configs': {'stub': {'tick_sleep': None}},
+            }
+        })
+        self.assertEqual(ss._tick_sleep, 0.08)
+
+    def test_global_tick_sleep_none_means_zero(self):
+        """Global tick_sleep of None means 0 (no sleep between ticks)."""
+        ss = self._make({'screensavers': {'tick_sleep': None}})
+        self.assertEqual(ss._tick_sleep, 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -11,6 +11,7 @@ And the timeout semantics:
 """
 
 import copy
+import time
 import unittest
 import sys
 import os
@@ -91,24 +92,26 @@ class TestTimeoutResolution(unittest.TestCase):
         """Timeout of 0 means unlimited — _is_past_timeout always returns False."""
         ss = self._make({'screensavers': {'timeout': 0}})
         self.assertEqual(ss._timeout, 0)
+        ss._start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
     def test_timeout_none_means_unlimited(self):
         """Timeout of None means unlimited — _is_past_timeout always returns False."""
         ss = self._make({'screensavers': {'timeout': None}})
         self.assertIsNone(ss._timeout)
+        ss._start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
     def test_positive_timeout_expires(self):
         """A positive timeout causes _is_past_timeout to return True after elapsed time."""
         ss = self._make({'screensavers': {'timeout': 10}})
-        # Simulate time passing
-        ss._start_time -= 11
+        ss._start_time = time.time() - 11
         self.assertTrue(ss._is_past_timeout())
 
     def test_positive_timeout_not_expired(self):
         """A positive timeout returns False before the time elapses."""
         ss = self._make({'screensavers': {'timeout': 10}})
+        ss._start_time = time.time()
         self.assertFalse(ss._is_past_timeout())
 
 

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Unit tests for Screensaver timeout and tick_sleep resolution.
+
+Verifies the config resolution chain:
+  per-screensaver -> global -> hardcoded default
+
+And the timeout semantics:
+  positive number = timeout after N seconds
+  0 or None       = unlimited (no timeout)
+"""
+
+import copy
+import unittest
+import sys
+import os
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pifi.config import Config
+from pifi.led.ledframeplayer import LedFramePlayer
+from pifi.screensaver.screensaver import Screensaver
+
+
+# Concrete subclass for testing
+class _StubScreensaver(Screensaver):
+    def _tick(self, tick):
+        pass
+
+    @classmethod
+    def get_id(cls):
+        return 'stub'
+
+    @classmethod
+    def get_name(cls):
+        return 'Stub'
+
+    @classmethod
+    def get_description(cls):
+        return 'Test stub'
+
+
+def setUpModule():
+    # Mock LedFramePlayer to avoid hardware initialization
+    LedFramePlayer.__init__ = lambda self: None
+    LedFramePlayer.play_frame = MagicMock()
+
+
+class TestTimeoutResolution(unittest.TestCase):
+    """Test the timeout config resolution chain."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+
+    def _make(self, config):
+        Config._Config__config = copy.deepcopy(config)
+        return _StubScreensaver(led_frame_player=None)
+
+    def test_default_timeout_is_120(self):
+        """When no timeout is configured anywhere, default is 120."""
+        ss = self._make({'screensavers': {}})
+        self.assertEqual(ss._timeout, 120)
+
+    def test_global_timeout_overrides_default(self):
+        """Global screensavers.timeout overrides the hardcoded default."""
+        ss = self._make({'screensavers': {'timeout': 60}})
+        self.assertEqual(ss._timeout, 60)
+
+    def test_per_screensaver_timeout_overrides_global(self):
+        """Per-screensaver timeout overrides the global timeout."""
+        ss = self._make({
+            'screensavers': {
+                'timeout': 60,
+                'configs': {'stub': {'timeout': 30}},
+            }
+        })
+        self.assertEqual(ss._timeout, 30)
+
+    def test_no_per_screensaver_timeout_falls_back_to_global(self):
+        """When per-screensaver timeout is absent, global timeout is used."""
+        ss = self._make({
+            'screensavers': {
+                'timeout': 90,
+                'configs': {'stub': {'tick_sleep': 0.01}},
+            }
+        })
+        self.assertEqual(ss._timeout, 90)
+
+    def test_timeout_zero_means_unlimited(self):
+        """Timeout of 0 means unlimited — _is_past_timeout always returns False."""
+        ss = self._make({'screensavers': {'timeout': 0}})
+        self.assertEqual(ss._timeout, 0)
+        self.assertFalse(ss._is_past_timeout())
+
+    def test_timeout_none_means_unlimited(self):
+        """Timeout of None means unlimited — _is_past_timeout always returns False."""
+        ss = self._make({'screensavers': {'timeout': None}})
+        self.assertIsNone(ss._timeout)
+        self.assertFalse(ss._is_past_timeout())
+
+    def test_positive_timeout_expires(self):
+        """A positive timeout causes _is_past_timeout to return True after elapsed time."""
+        ss = self._make({'screensavers': {'timeout': 10}})
+        # Simulate time passing
+        ss._start_time -= 11
+        self.assertTrue(ss._is_past_timeout())
+
+    def test_positive_timeout_not_expired(self):
+        """A positive timeout returns False before the time elapses."""
+        ss = self._make({'screensavers': {'timeout': 10}})
+        self.assertFalse(ss._is_past_timeout())
+
+
+class TestTickSleepResolution(unittest.TestCase):
+    """Test the tick_sleep config resolution chain."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+
+    def _make(self, config):
+        Config._Config__config = copy.deepcopy(config)
+        return _StubScreensaver(led_frame_player=None)
+
+    def test_default_tick_sleep(self):
+        """When no tick_sleep is configured, default is 0.05."""
+        ss = self._make({'screensavers': {}})
+        self.assertEqual(ss._tick_sleep, 0.05)
+
+    def test_global_tick_sleep_overrides_default(self):
+        """Global screensavers.tick_sleep overrides the hardcoded default."""
+        ss = self._make({'screensavers': {'tick_sleep': 0.1}})
+        self.assertEqual(ss._tick_sleep, 0.1)
+
+    def test_per_screensaver_tick_sleep_overrides_global(self):
+        """Per-screensaver tick_sleep overrides the global tick_sleep."""
+        ss = self._make({
+            'screensavers': {
+                'tick_sleep': 0.1,
+                'configs': {'stub': {'tick_sleep': 0.02}},
+            }
+        })
+        self.assertEqual(ss._tick_sleep, 0.02)
+
+    def test_no_per_screensaver_tick_sleep_falls_back_to_global(self):
+        """When per-screensaver tick_sleep is absent, global is used."""
+        ss = self._make({
+            'screensavers': {
+                'tick_sleep': 0.08,
+                'configs': {'stub': {'timeout': 60}},
+            }
+        })
+        self.assertEqual(ss._tick_sleep, 0.08)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds animated transitions between screensavers and overhauls the screensaver lifecycle, configuration, and API.

### Transitions
- Animated transitions (crossfade, wipes, pushes, dissolve, spiral) between screensavers
- Configurable via `screensavers.transitions.enabled`, `duration`, and `tick_sleep`
- Handles monochrome video frames by normalizing to 3D before blending
- VideoScreensaver passes shared LedFramePlayer to VideoProcessor so transitions fade from the actual last video frame

### Screensaver lifecycle
- Replace `max_ticks` with timeout-based lifecycle (`screensavers.timeout`, default 120s)
- Template method pattern: base `Screensaver.play()` calls `_setup()`, `_tick()`, `_teardown()`
- Move `_start_time` from `__init__` to `play()` so it resets each run
- Move LedFramePlayer creation to base class (`self._led_frame_player`), removing ~90 lines of duplicated boilerplate across 26 subclasses
- Karaoke connection error: display for 10s or until timeout, whichever is shorter

### Config resolution
- Per-screensaver config → global config → hardcoded default (0)
- `null` at per-screensaver level = fall back to global
- `null` or `0` at global level = unlimited (timeout) / no sleep (tick_sleep)
- Fix `Config.get()` null coalescing bug: explicit `None` checks instead of relying on default parameter
- Deduplicate `Config.get_default` via shared `__get` with `config_dict` param

### API consolidation
- Merge 4 screensaver endpoints into single `GET/POST /api/screensavers`
- Consolidate 3 DB keys into single `SCREENSAVER_SETTINGS`
- `Config.reload_overrides` supports partial reloads with change detection
- Validate `transitions` and `configs` payload types (return error instead of silently ignoring)

### Settings UI
- Add global timeout, transition duration, tick_sleep controls
- Consolidate duplicate `/api/screensavers` calls into single `loadSettings()`
- Fix hint text: "Empty or 0 means unlimited" with "Unlimited" placeholder

### Other cleanup
- Rename `transition.py` → `transitionplayer.py`
- Replace transition `num_steps` with `tick_sleep` for consistency
- Restore lost `rgbmatrix` stanza in `default_config.json`
- Move per-screensaver configs under `screensavers.configs.*`

## Test plan
- [x] 46 unit tests pass (+ 180 subtests)
- [x] Timeout resolution: default, global override, per-screensaver override, null fallback, 0=unlimited
- [x] Tick sleep resolution: same patterns as timeout
- [x] Config override reload: partial reload, reset, change detection
- [x] Screensaver interface: all subclasses call super().__init__, standard constructor, no duplicate IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)