### PR TITLE
feat: smooth transitions between screensavers

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -147,6 +147,12 @@
 
             // Optional, float, default: 0.03. Seconds to sleep between transition frames.
             "tick_sleep": 0.03,
+
+            // Optional, integer, default: 60. Number of ticks to pre-render the next screensaver
+            // before playing the transition. This makes the transition move into an already-running
+            // screensaver instead of a blank frame. Higher values give the next screensaver more
+            // time to build up visual state. Set to 0 to disable pre-rendering.
+            "warm_up_ticks": 60,
         },
 
         // Per-screensaver configuration.

--- a/pifi/led/blackholeframeplayer.py
+++ b/pifi/led/blackholeframeplayer.py
@@ -1,0 +1,25 @@
+from pifi.led.frameplayerbase import FramePlayerBase
+
+
+class BlackHoleFramePlayer(FramePlayerBase):
+    """Frame player that captures frames without displaying them.
+
+    Used internally by Screensaver.render_tick() to intercept frames
+    that a screensaver renders via self._led_frame_player, without
+    sending them to LED hardware.
+    """
+
+    def __init__(self):
+        self.__current_frame = None
+
+    def play_frame(self, frame):
+        self.__current_frame = frame.copy()
+
+    def get_current_frame(self):
+        if self.__current_frame is None:
+            return None
+        return self.__current_frame.copy()
+
+    def fade_to_frame(self, frame):
+        """Skip the fade animation and just capture the target frame."""
+        self.__current_frame = frame.copy()

--- a/pifi/led/blackholeframeplayer.py
+++ b/pifi/led/blackholeframeplayer.py
@@ -13,7 +13,7 @@ class BlackHoleFramePlayer(FramePlayerBase):
         self.__current_frame = None
 
     def play_frame(self, frame):
-        self.__current_frame = frame.copy()
+        self.__current_frame = frame
 
     def get_current_frame(self):
         if self.__current_frame is None:
@@ -22,4 +22,4 @@ class BlackHoleFramePlayer(FramePlayerBase):
 
     def fade_to_frame(self, frame):
         """Skip the fade animation and just capture the target frame."""
-        self.__current_frame = frame.copy()
+        self.__current_frame = frame

--- a/pifi/led/frameplayerbase.py
+++ b/pifi/led/frameplayerbase.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+
+class FramePlayerBase(ABC):
+    """Abstract base class for frame players.
+
+    Concrete implementations include LedFramePlayer (renders to LED hardware)
+    and BlackHoleFramePlayer (captures frames without displaying).
+    """
+
+    @abstractmethod
+    def play_frame(self, frame):
+        pass
+
+    @abstractmethod
+    def get_current_frame(self):
+        pass
+
+    @abstractmethod
+    def fade_to_frame(self, frame):
+        pass

--- a/pifi/led/ledframeplayer.py
+++ b/pifi/led/ledframeplayer.py
@@ -4,12 +4,13 @@ import numpy as np
 
 from pifi.config import Config
 from pifi.directoryutils import DirectoryUtils
+from pifi.led.frameplayerbase import FramePlayerBase
 from pifi.led.gamma import Gamma
 from pifi.led.drivers.leddrivers import LedDrivers
 from pifi.settingsdb import SettingsDb
 from pifi.video.videocolormode import VideoColorMode
 
-class LedFramePlayer:
+class LedFramePlayer(FramePlayerBase):
 
     __FADE_STEPS = 5
 

--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -40,7 +40,7 @@ class Aurora(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         time_speed = Config.get('screensavers.configs.aurora.time_speed', 1.0)
         self.__time += 0.05 * time_speed
 

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -27,7 +27,7 @@ class Boids(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         self.__update_velocities()
         self.__update_positions()
         self.__render()

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -20,7 +20,7 @@ class CellularAutomaton(Screensaver, ABC):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         self._update_board()
         self.__show_board()
         self.__do_tick_bookkeeping()

--- a/pifi/screensaver/cloudscape.py
+++ b/pifi/screensaver/cloudscape.py
@@ -59,8 +59,6 @@ class Cloudscape(Screensaver):
         self.__sky_cache_tick = -999  # Ensures first frame triggers update
         self.__sky_update_interval = 30  # Update sky every N frames
 
-        self.__time = 0.0
-
     def __generate_permutation(self):
         """Generate permutation table for Perlin noise."""
         p = np.arange(256, dtype=np.int32)
@@ -181,9 +179,10 @@ class Cloudscape(Screensaver):
         base = np.array(cloud_colors.get(self.__sky_mode, (255, 255, 255)), dtype=np.float32)
         return base * layer_brightness
 
-    def __render(self, tick):
+    def __render(self):
         """Render the cloudscape with optimized buffer reuse."""
         # Update sky gradient less frequently (it changes slowly)
+        tick = self.get_last_tick()
         if tick - self.__sky_cache_tick >= self.__sky_update_interval:
             self.__compute_sky_gradient()
             self.__sky_cache_tick = tick
@@ -203,7 +202,7 @@ class Cloudscape(Screensaver):
             layer_alpha = 0.7 + layer_depth * 0.3
 
             # Calculate noise coordinates (reuse grid)
-            drift_x = self.__time * self.__drift_speed * layer_speed
+            drift_x = tick * self.__drift_speed * layer_speed
             noise_x = (self.__x_grid + drift_x) * layer_scale
             noise_y = self.__y_grid * layer_scale * 1.2 + layer * 100
 
@@ -239,13 +238,11 @@ class Cloudscape(Screensaver):
     def _setup(self):
         """Initialize noise and reset state."""
         self.__perm = self.__generate_permutation()
-        self.__time = 0.0
         self.__sky_cache_tick = -1
 
-    def _tick(self, tick):
-        """Advance time and render one frame."""
-        self.__time += 1
-        self.__render(tick)
+    def _tick(self):
+        """Render one frame."""
+        self.__render()
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -42,14 +42,12 @@ class CosmicDream(Screensaver):
 
         # Time tracking for animations
         self.__start_time = None
-        self.__frame_count = 0
 
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         t = time.time() - self.__start_time
-        self.__frame_count += 1
 
         # Create the layered frame
         frame = self.__render_plasma_layer(t)
@@ -63,7 +61,6 @@ class CosmicDream(Screensaver):
 
     def __reset(self):
         self.__start_time = time.time()
-        self.__frame_count = 0
 
         # Initialize particles for flow field
         num_particles = Config.get('screensavers.configs.cosmic_dream.num_particles', 20)

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -52,7 +52,7 @@ class DvdBounce(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         """Update position and check for bounces."""
         # Update position
         self.__x += self.__vx

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -37,7 +37,7 @@ class FlowField(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Fade buffer
         fade = Config.get('screensavers.configs.flowfield.fade', 0.95)
         self.__buffer *= fade

--- a/pifi/screensaver/gradienttest.py
+++ b/pifi/screensaver/gradienttest.py
@@ -159,7 +159,7 @@ class GradientTest(Screensaver):
         self.__mode = old_mode
         return frame
 
-    def _tick(self, tick):
+    def _tick(self):
         """Display the pre-generated static frame."""
         self._led_frame_player.play_frame(self.__frame)
 

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -27,7 +27,7 @@ class InkInWater(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Add new drops more frequently for more activity
         drop_chance = Config.get('screensavers.configs.inkinwater.drop_chance', 0.06)
         if random.random() < drop_chance:

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -974,7 +974,7 @@ class KaraokeBase(Screensaver):
                 line_end_time = self.__line_start_time + self.__line_duration
                 dwell_buffer = 0.3
                 time_for_scroll = max(0.5, line_end_time - self.__preview_wall_start - dwell_buffer)
-                complete_in_ticks = int(time_for_scroll / self._tick_sleep)
+                complete_in_ticks = int(time_for_scroll / self.tick_sleep())
 
                 preview_scroll_offset = self.__tick_count - self.__preview_scroll_start
                 textutils.draw_scrolling_text(
@@ -1039,7 +1039,7 @@ class KaraokeBase(Screensaver):
                 line_end_time = self.__line_start_time + self.__line_duration
                 dwell_buffer = 0.3
                 time_for_scroll = max(0.5, line_end_time - self.__preview_wall_start - dwell_buffer)
-                complete_in_ticks = int(time_for_scroll / self._tick_sleep)
+                complete_in_ticks = int(time_for_scroll / self.tick_sleep())
 
                 preview_scroll_offset = self.__tick_count - self.__preview_scroll_start
                 textutils.draw_scrolling_text(

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -974,7 +974,7 @@ class KaraokeBase(Screensaver):
                 line_end_time = self.__line_start_time + self.__line_duration
                 dwell_buffer = 0.3
                 time_for_scroll = max(0.5, line_end_time - self.__preview_wall_start - dwell_buffer)
-                complete_in_ticks = int(time_for_scroll / self.tick_sleep())
+                complete_in_ticks = int(time_for_scroll / self._tick_sleep)
 
                 preview_scroll_offset = self.__tick_count - self.__preview_scroll_start
                 textutils.draw_scrolling_text(
@@ -1039,7 +1039,7 @@ class KaraokeBase(Screensaver):
                 line_end_time = self.__line_start_time + self.__line_duration
                 dwell_buffer = 0.3
                 time_for_scroll = max(0.5, line_end_time - self.__preview_wall_start - dwell_buffer)
-                complete_in_ticks = int(time_for_scroll / self.tick_sleep())
+                complete_in_ticks = int(time_for_scroll / self._tick_sleep)
 
                 preview_scroll_offset = self.__tick_count - self.__preview_scroll_start
                 textutils.draw_scrolling_text(

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -113,7 +113,7 @@ class KaraokeBase(Screensaver):
         self.__poll_thread = threading.Thread(target=self._polling_loop, daemon=True)
         self.__poll_thread.start()
 
-    def _tick(self, tick):
+    def _tick(self):
         if self.__connection_failed_time is not None:
             if (time.time() - self.__connection_failed_time) > 10:
                 return False

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -21,19 +21,15 @@ class LavaLamp(Screensaver):
         self.__height = Config.get_or_throw('leds.display_height')
 
         self.__blobs = []
-        self.__time = 0
 
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         self.__update_blobs()
         self.__render()
-        self.__time += 1
 
     def __reset(self):
-        self.__time = 0
-
         # Create blobs - more blobs for more activity
         num_blobs = Config.get('screensavers.configs.lavalamp.num_blobs', 10)
         self.__blobs = []
@@ -83,7 +79,7 @@ class LavaLamp(Screensaver):
             blob['vy'] += (target_y - blob['y']) * buoyancy * 0.15
 
             # Add wobble motion using sine waves for organic movement
-            wobble = math.sin(self.__time * 0.05 + blob['x']) * 0.02
+            wobble = math.sin(self.get_last_tick() * 0.05 + blob['x']) * 0.02
             blob['vx'] += wobble
 
             # More horizontal drift

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -35,7 +35,7 @@ class Lorenz(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Lorenz system parameters (classic values)
         sigma = Config.get('screensavers.configs.lorenz.sigma', 10.0)
         rho = Config.get('screensavers.configs.lorenz.rho', 28.0)

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -60,7 +60,7 @@ class Mandelbrot(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Smoothly move center towards target
         lerp_factor = Config.get('screensavers.configs.mandelbrot.lerp_factor', 0.02)
         self.__center_x += (self.__target_x - self.__center_x) * lerp_factor

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -32,7 +32,7 @@ class MatrixRain(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         fade_rate = Config.get('screensavers.configs.matrix_rain.fade_rate', 0.85)
         spawn_rate = Config.get('screensavers.configs.matrix_rain.spawn_rate', 0.08)
 

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -137,7 +137,7 @@ class MeltingClock(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Get current time in configured timezone
         if self.__timezone:
             current_datetime = datetime.now(self.__timezone)

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -33,7 +33,7 @@ class Metaballs(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         self.__update_balls()
         self.__render()
         self.__time += 0.1

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -355,9 +355,6 @@ class NycSubway(Screensaver):
             # Advance scroll
             self.__scroll_offset += 1.0
 
-        # Advance animation tick
-        self.__tick_count += 1
-
         self._led_frame_player.play_frame(frame)
 
     def __update_display_rows(self, new_arrivals):
@@ -500,7 +497,7 @@ class NycSubway(Screensaver):
         for idx, (time_text, time_color) in enumerate(times_display):
             # Pulse effect for imminent arrivals
             if int(time_text) <= 1:
-                pulse = abs((self.__tick_count % 20) - 10) / 10.0
+                pulse = abs((self.get_last_tick() % 20) - 10) / 10.0
                 time_color = (
                     int(time_color[0] * (0.5 + 0.5 * pulse)),
                     int(time_color[1] * (0.5 + 0.5 * pulse)),

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -91,7 +91,6 @@ class NycSubway(Screensaver):
         self.__station_names_loaded = False
         self.__fetch_in_progress = False  # Background fetch flag
         self.__fetch_lock = threading.Lock()  # Protect shared state
-        self.__tick_count = 0  # For animations
 
         # Animation state for smooth transitions
         self.__display_rows = []  # Currently displayed rows with animation state
@@ -308,7 +307,7 @@ class NycSubway(Screensaver):
         """Start initial data fetch."""
         self.__start_background_fetch()
 
-    def _tick(self, tick):
+    def _tick(self):
         """Fetch new data if needed and render one frame."""
         current_time = time.time()
         if current_time - self.__last_update > self.__update_interval:

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -36,8 +36,6 @@ class PendulumWaves(Screensaver):
         # Canvas buffer
         self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
 
-        self.__tick = 0
-
     def __init_pendulums(self):
         """Initialize pendulum parameters."""
         # Each pendulum completes one more oscillation than the previous
@@ -57,7 +55,6 @@ class PendulumWaves(Screensaver):
             self.__periods.append(period)
 
         self.__canvas.fill(0)
-        self.__tick = 0
 
     def __hsv_to_rgb(self, h, s, v):
         """Convert HSV to RGB."""
@@ -138,7 +135,7 @@ class PendulumWaves(Screensaver):
 
             # Y position based on sinusoidal motion
             # Phase is determined by time and period
-            phase = (self.__tick / self.__periods[i]) * 2 * math.pi
+            phase = (self.get_last_tick() / self.__periods[i]) * 2 * math.pi
             y_normalized = math.sin(phase)
 
             # Map to screen coordinates
@@ -151,13 +148,11 @@ class PendulumWaves(Screensaver):
             r, g, b = self.__get_pendulum_color(i)
             self.__draw_bob(x, y, r, g, b, self.__bob_size)
 
-        self.__tick += 1
-
     def _setup(self):
         """Initialize pendulums."""
         self.__init_pendulums()
 
-    def _tick(self, tick):
+    def _tick(self):
         """Update pendulums and render one frame."""
         self.__update()
 

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -212,7 +212,7 @@ class PerlinWorms(Screensaver):
         """Initialize worms."""
         self.__init_worms()
 
-    def _tick(self, tick):
+    def _tick(self):
         """Update worms and render one frame."""
         self.__time += self.__time_speed
         self.__update_worms()

--- a/pifi/screensaver/reactiondiffusion.py
+++ b/pifi/screensaver/reactiondiffusion.py
@@ -26,12 +26,10 @@ class ReactionDiffusion(Screensaver):
         self.__A = None  # Chemical A
         self.__B = None  # Chemical B
 
-        self.__time = 0
-
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Run multiple simulation steps per frame for faster evolution
         steps_per_frame = Config.get('screensavers.configs.reactiondiffusion.steps_per_frame', 10)
         for _ in range(steps_per_frame):
@@ -39,15 +37,13 @@ class ReactionDiffusion(Screensaver):
 
         # Periodically inject new seeds to keep evolution going
         inject_interval = Config.get('screensavers.configs.reactiondiffusion.inject_interval', 100)
-        if self.__time > 0 and self.__time % inject_interval == 0:
+        tick = self.get_last_tick()
+        if tick > 0 and tick % inject_interval == 0:
             self.__inject_seed()
 
         self.__render()
-        self.__time += 1
 
     def __reset(self):
-        self.__time = 0
-
         # Initialize with A=1 everywhere, B=0 with some seed points
         self.__A = np.ones((self.__height, self.__width), dtype=np.float32)
         self.__B = np.zeros((self.__height, self.__width), dtype=np.float32)

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -65,11 +65,11 @@ class Screensaver(ABC):
         self.__render_capture = BlackHoleFramePlayer()
         self.__is_set_up = False
 
-    def tick_sleep(self):
+    def get_tick_sleep(self):
         """Seconds to sleep between ticks (read-only, from config)."""
         return self._tick_sleep
 
-    def last_tick(self):
+    def get_last_tick(self):
         """The tick number reached when play() last exited (read-only)."""
         return self.__last_tick
 
@@ -136,7 +136,7 @@ class Screensaver(ABC):
             while not self._is_past_timeout():
                 if self._tick(tick) is False:
                     break
-                time.sleep(self.tick_sleep())
+                time.sleep(self.get_tick_sleep())
                 tick += 1
             self.__last_tick = tick
         except Exception:

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -45,11 +45,11 @@ class Screensaver(ABC):
         # e.g. screensavers.configs.boids.tick_sleep overrides screensavers.tick_sleep
         sid = self.get_id()
 
-        self.__tick_sleep = Config.get(f'screensavers.configs.{sid}.tick_sleep')
-        if self.__tick_sleep is None:
-            self.__tick_sleep = Config.get('screensavers.tick_sleep')
-        if self.__tick_sleep is None:
-            self.__tick_sleep = 0
+        self._tick_sleep = Config.get(f'screensavers.configs.{sid}.tick_sleep')
+        if self._tick_sleep is None:
+            self._tick_sleep = Config.get('screensavers.tick_sleep')
+        if self._tick_sleep is None:
+            self._tick_sleep = 0
 
         # For timeout, null means unlimited at the global level (0 also means
         # unlimited). At the per-screensaver level, null falls back to global.
@@ -67,7 +67,7 @@ class Screensaver(ABC):
 
     def tick_sleep(self):
         """Seconds to sleep between ticks (read-only, from config)."""
-        return self.__tick_sleep
+        return self._tick_sleep
 
     def last_tick(self):
         """The tick number reached when play() last exited (read-only)."""

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -104,12 +104,14 @@ class Screensaver(ABC):
         if _tick() returned False early, _warmed_up stays False and the
         screensaver should not be reused.
         """
-        self._setup()
-
-        # Temporarily swap to a capture player
+        # Swap to capture BEFORE _setup() — some screensavers render in
+        # _setup() (e.g. CellularAutomaton seeds the board), and we don't
+        # want those frames going to the real display.
         real_player = self._led_frame_player
         capture = FrameCapture()
         self._led_frame_player = capture
+
+        self._setup()
 
         completed = True
         try:

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -60,7 +60,6 @@ class Screensaver(ABC):
             self.__timeout = 0
 
         self.live_transition_warmed_up = False
-        self.live_transition_warm_up_ticks = 0
         self.__last_tick = 0
         self.__black_hole_frame_player = BlackHoleFramePlayer()
         self.__is_set_up = False
@@ -70,7 +69,12 @@ class Screensaver(ABC):
         return self._tick_sleep
 
     def get_last_tick(self):
-        """The tick number reached when play() last exited (read-only)."""
+        """The next tick number to execute (read-only).
+
+        Updated by both play() and render_tick(). Starts at 0 for a fresh
+        screensaver; after a transition warm-up it reflects how far the
+        screensaver has already been ticked.
+        """
         return self.__last_tick
 
     def _is_past_timeout(self):
@@ -94,7 +98,7 @@ class Screensaver(ABC):
         self._teardown()
         self.__is_set_up = False
 
-    def render_tick(self, tick):
+    def render_tick(self):
         """Advance state by one tick, capturing the rendered frame without
         displaying it on the LED hardware.
 
@@ -109,7 +113,9 @@ class Screensaver(ABC):
         self._led_frame_player = self.__black_hole_frame_player
         try:
             self.setup()
-            alive = self._tick(tick) is not False
+            alive = self._tick() is not False
+            if alive:
+                self.__last_tick += 1
             return self.__black_hole_frame_player.get_current_frame(), alive
         finally:
             self._led_frame_player = real_player
@@ -129,16 +135,13 @@ class Screensaver(ABC):
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
         self.__start_time = time.time()
         self.setup()
-        start_tick = self.live_transition_warm_up_ticks if self.live_transition_warmed_up else 0
 
         try:
-            tick = start_tick
             while not self._is_past_timeout():
-                if self._tick(tick) is False:
+                if self._tick() is False:
                     break
                 time.sleep(self.get_tick_sleep())
-                tick += 1
-            self.__last_tick = tick
+                self.__last_tick += 1
         except Exception:
             self.teardown()
             raise
@@ -155,11 +158,12 @@ class Screensaver(ABC):
         pass
 
     @abstractmethod
-    def _tick(self, tick) -> None:
+    def _tick(self) -> None:
         """Called each iteration of the tick loop.
 
         Return False to stop the loop early. Any other return value
-        (including None) continues the loop.
+        (including None) continues the loop. Use self.get_last_tick()
+        to get the current tick number if needed.
         """
         pass
 

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -9,8 +9,8 @@ from pifi.logger import Logger
 class FrameCapture:
     """Lightweight stand-in for LedFramePlayer that captures frames without displaying.
 
-    Used during screensaver warm-up to build visual state without sending
-    frames to the LED hardware.
+    Used internally by render_tick() to intercept frames that a screensaver
+    renders via self._led_frame_player, without sending them to LED hardware.
     """
 
     def __init__(self):
@@ -25,7 +25,7 @@ class FrameCapture:
         return self.__current_frame.copy()
 
     def fade_to_frame(self, frame):
-        """During warm-up, skip the fade animation and just capture the target frame."""
+        """During capture, skip the fade animation and just capture the target frame."""
         self.__current_frame = frame.copy()
 
 
@@ -67,11 +67,11 @@ class Screensaver(ABC):
         # e.g. screensavers.configs.boids.tick_sleep overrides screensavers.tick_sleep
         sid = self.get_id()
 
-        self._tick_sleep = Config.get(f'screensavers.configs.{sid}.tick_sleep')
-        if self._tick_sleep is None:
-            self._tick_sleep = Config.get('screensavers.tick_sleep')
-        if self._tick_sleep is None:
-            self._tick_sleep = 0
+        self.__tick_sleep = Config.get(f'screensavers.configs.{sid}.tick_sleep')
+        if self.__tick_sleep is None:
+            self.__tick_sleep = Config.get('screensavers.tick_sleep')
+        if self.__tick_sleep is None:
+            self.__tick_sleep = 0
 
         # For timeout, null means unlimited at the global level (0 also means
         # unlimited). At the per-screensaver level, null falls back to global.
@@ -81,9 +81,19 @@ class Screensaver(ABC):
         if self._timeout is None:
             self._timeout = 0
 
-        self._warmed_up = False
-        self._warm_up_ticks = 0
-        self._last_tick = 0
+        self.warmed_up = False
+        self.warm_up_ticks = 0
+        self.__last_tick = 0
+        self._render_capture = FrameCapture()
+        self._is_set_up = False
+
+    def tick_sleep(self):
+        """Seconds to sleep between ticks (read-only, from config)."""
+        return self.__tick_sleep
+
+    def last_tick(self):
+        """The tick number reached when play() last exited (read-only)."""
+        return self.__last_tick
 
     def _is_past_timeout(self):
         """Check if the screensaver timeout has been exceeded.
@@ -94,44 +104,69 @@ class Screensaver(ABC):
             return False
         return (time.time() - self._start_time) > self._timeout
 
+    def setup(self):
+        """Initialize the screensaver for ticking. Idempotent — safe to call
+        multiple times, but only runs _setup() once."""
+        if not self._is_set_up:
+            self._setup()
+            self._is_set_up = True
+
+    def teardown(self):
+        """Clean up resources after the screensaver finishes."""
+        self._teardown()
+        self._is_set_up = False
+
+    def render_tick(self, tick):
+        """Advance state by one tick, capturing the rendered frame without
+        displaying it on the LED hardware.
+
+        Calls setup() on first invocation (under the capture, so any frames
+        rendered during _setup() are intercepted rather than displayed).
+
+        Returns:
+            (frame, alive) where frame is a numpy array (or None if nothing
+            was rendered) and alive is True unless _tick() returned False.
+        """
+        real_player = self._led_frame_player
+        self._led_frame_player = self._render_capture
+        try:
+            self.setup()
+            alive = self._tick(tick) is not False
+            return self._render_capture.get_current_frame(), alive
+        finally:
+            self._led_frame_player = real_player
+
     def play(self, auto_teardown=True) -> None:
         """Run the screensaver tick loop.
 
-        If the screensaver was warmed up by a transition, skips _setup()
+        If the screensaver was warmed up by a transition, skips setup()
         and continues from where warm-up left off. Otherwise starts fresh.
         Timeout always counts from when play() is called, not from warm-up.
 
         Args:
-            auto_teardown: If True (default), _teardown() is called when the
+            auto_teardown: If True (default), teardown() is called when the
                 loop ends. Set to False to keep the screensaver alive for
-                live transitions — the caller must call _teardown() manually.
+                live transitions — the caller must call teardown() manually.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
         self._start_time = time.time()
-        if not self._warmed_up:
-            self._setup()
-            start_tick = 0
-        else:
-            start_tick = self._warm_up_ticks
+        self.setup()
+        start_tick = self.warm_up_ticks if self.warmed_up else 0
 
         try:
             tick = start_tick
             while not self._is_past_timeout():
                 if self._tick(tick) is False:
                     break
-                time.sleep(self._tick_sleep)
+                time.sleep(self.tick_sleep())
                 tick += 1
-            self._last_tick = tick
+            self.__last_tick = tick
         except Exception:
-            self._teardown()
+            self.teardown()
             raise
         if auto_teardown:
-            self._teardown()
+            self.teardown()
         self._screensaver_logger.info(f"{self.get_name()} screensaver ended")
-
-    def set_led_frame_player(self, led_frame_player):
-        """Replace the LED frame player (e.g. with a FrameCapture during transitions)."""
-        self._led_frame_player = led_frame_player
 
     def _setup(self):
         """Called once before the tick loop. Override for initialization."""
@@ -168,8 +203,7 @@ class Screensaver(ABC):
         """Return brief description"""
         pass
 
-    @classmethod
-    def supports_live_transition(cls) -> bool:
+    def supports_live_transition(self) -> bool:
         """Whether this screensaver can participate in live transitions.
 
         Screensavers that block in _tick() or require the full LedFramePlayer

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -2,31 +2,9 @@ import time
 from abc import ABC, abstractmethod
 
 from pifi.config import Config
+from pifi.led.blackholeframeplayer import BlackHoleFramePlayer
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
-
-
-class FrameCapture:
-    """Lightweight stand-in for LedFramePlayer that captures frames without displaying.
-
-    Used internally by render_tick() to intercept frames that a screensaver
-    renders via self._led_frame_player, without sending them to LED hardware.
-    """
-
-    def __init__(self):
-        self.__current_frame = None
-
-    def play_frame(self, frame):
-        self.__current_frame = frame.copy()
-
-    def get_current_frame(self):
-        if self.__current_frame is None:
-            return None
-        return self.__current_frame.copy()
-
-    def fade_to_frame(self, frame):
-        """During capture, skip the fade animation and just capture the target frame."""
-        self.__current_frame = frame.copy()
 
 
 class Screensaver(ABC):
@@ -84,7 +62,7 @@ class Screensaver(ABC):
         self.warmed_up = False
         self.warm_up_ticks = 0
         self.__last_tick = 0
-        self._render_capture = FrameCapture()
+        self._render_capture = BlackHoleFramePlayer()
         self._is_set_up = False
 
     def tick_sleep(self):

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -33,7 +33,7 @@ class Screensaver(ABC):
               line of their __init__ method.
         """
         # Flag to verify subclasses call super().__init__()
-        self._screensaver_base_init_called = True
+        self.__screensaver_base_init_called = True
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -53,17 +53,17 @@ class Screensaver(ABC):
 
         # For timeout, null means unlimited at the global level (0 also means
         # unlimited). At the per-screensaver level, null falls back to global.
-        self._timeout = Config.get(f'screensavers.configs.{sid}.timeout')
-        if self._timeout is None:
-            self._timeout = Config.get('screensavers.timeout')
-        if self._timeout is None:
-            self._timeout = 0
+        self.__timeout = Config.get(f'screensavers.configs.{sid}.timeout')
+        if self.__timeout is None:
+            self.__timeout = Config.get('screensavers.timeout')
+        if self.__timeout is None:
+            self.__timeout = 0
 
         self.warmed_up = False
         self.warm_up_ticks = 0
         self.__last_tick = 0
-        self._render_capture = BlackHoleFramePlayer()
-        self._is_set_up = False
+        self.__render_capture = BlackHoleFramePlayer()
+        self.__is_set_up = False
 
     def tick_sleep(self):
         """Seconds to sleep between ticks (read-only, from config)."""
@@ -78,21 +78,21 @@ class Screensaver(ABC):
 
         A timeout of 0 or None means unlimited (never times out).
         """
-        if not self._timeout:
+        if not self.__timeout:
             return False
-        return (time.time() - self._start_time) > self._timeout
+        return (time.time() - self.__start_time) > self.__timeout
 
     def setup(self):
         """Initialize the screensaver for ticking. Idempotent — safe to call
         multiple times, but only runs _setup() once."""
-        if not self._is_set_up:
+        if not self.__is_set_up:
             self._setup()
-            self._is_set_up = True
+            self.__is_set_up = True
 
     def teardown(self):
         """Clean up resources after the screensaver finishes."""
         self._teardown()
-        self._is_set_up = False
+        self.__is_set_up = False
 
     def render_tick(self, tick):
         """Advance state by one tick, capturing the rendered frame without
@@ -106,11 +106,11 @@ class Screensaver(ABC):
             was rendered) and alive is True unless _tick() returned False.
         """
         real_player = self._led_frame_player
-        self._led_frame_player = self._render_capture
+        self._led_frame_player = self.__render_capture
         try:
             self.setup()
             alive = self._tick(tick) is not False
-            return self._render_capture.get_current_frame(), alive
+            return self.__render_capture.get_current_frame(), alive
         finally:
             self._led_frame_player = real_player
 
@@ -127,7 +127,7 @@ class Screensaver(ABC):
                 live transitions — the caller must call teardown() manually.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
-        self._start_time = time.time()
+        self.__start_time = time.time()
         self.setup()
         start_tick = self.warm_up_ticks if self.warmed_up else 0
 

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -62,7 +62,7 @@ class Screensaver(ABC):
         self.warmed_up = False
         self.warm_up_ticks = 0
         self.__last_tick = 0
-        self.__render_capture = BlackHoleFramePlayer()
+        self.__black_hole_frame_player = BlackHoleFramePlayer()
         self.__is_set_up = False
 
     def get_tick_sleep(self):
@@ -106,11 +106,11 @@ class Screensaver(ABC):
             was rendered) and alive is True unless _tick() returned False.
         """
         real_player = self._led_frame_player
-        self._led_frame_player = self.__render_capture
+        self._led_frame_player = self.__black_hole_frame_player
         try:
             self.setup()
             alive = self._tick(tick) is not False
-            return self.__render_capture.get_current_frame(), alive
+            return self.__black_hole_frame_player.get_current_frame(), alive
         finally:
             self._led_frame_player = real_player
 

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -1,9 +1,34 @@
 import time
 from abc import ABC, abstractmethod
 
+import numpy as np
+
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
+
+
+class FrameCapture:
+    """Lightweight stand-in for LedFramePlayer that captures frames without displaying.
+
+    Used during screensaver warm-up to build visual state without sending
+    frames to the LED hardware.
+    """
+
+    def __init__(self):
+        self.__current_frame = None
+
+    def play_frame(self, frame):
+        self.__current_frame = frame.copy()
+
+    def get_current_frame(self):
+        if self.__current_frame is None:
+            return None
+        return self.__current_frame.copy()
+
+    def fade_to_frame(self, frame):
+        """During warm-up, skip the fade animation and just capture the target frame."""
+        self.__current_frame = frame.copy()
 
 
 class Screensaver(ABC):
@@ -58,6 +83,9 @@ class Screensaver(ABC):
         if self._timeout is None:
             self._timeout = 0
 
+        self._warmed_up = False
+        self._warm_up_ticks = 0
+
     def _is_past_timeout(self):
         """Check if the screensaver timeout has been exceeded.
 
@@ -67,18 +95,55 @@ class Screensaver(ABC):
             return False
         return (time.time() - self._start_time) > self._timeout
 
+    def warm_up(self, num_ticks=60):
+        """Pre-render ticks to build up visual state without displaying.
+
+        Runs _setup() and num_ticks iterations of _tick() using a FrameCapture
+        instead of the real LED display. Sets _start_time backward so that
+        time-based screensavers see the correct elapsed time.
+
+        Returns the last captured frame (numpy array), or None if no frames
+        were rendered.
+        """
+        # Simulate time passage so time-based screensavers see realistic elapsed time
+        simulated_duration = num_ticks * max(self._tick_sleep, 0.05)
+        self._start_time = time.time() - simulated_duration
+        self._setup()
+        self._warmed_up = True
+
+        # Temporarily swap to a capture player
+        real_player = self._led_frame_player
+        capture = FrameCapture()
+        self._led_frame_player = capture
+
+        try:
+            for tick in range(num_ticks):
+                if self._tick(tick) is False:
+                    break
+            self._warm_up_ticks = tick + 1 if num_ticks > 0 else 0
+        finally:
+            self._led_frame_player = real_player
+
+        return capture.get_current_frame()
+
     def play(self) -> None:
         """Run the screensaver tick loop.
 
-        Calls _setup(), then runs _tick() in a loop until timeout or
-        _tick() returns False. Calls _teardown() in a finally block
-        to ensure cleanup.
+        If warm_up() was called first, skips _setup() and continues from
+        where warm-up left off. Otherwise starts fresh.
+
+        Calls _teardown() in a finally block to ensure cleanup.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
-        self._start_time = time.time()
-        self._setup()
+        if not self._warmed_up:
+            self._start_time = time.time()
+            self._setup()
+            start_tick = 0
+        else:
+            start_tick = self._warm_up_ticks
+
         try:
-            tick = 0
+            tick = start_tick
             while not self._is_past_timeout():
                 if self._tick(tick) is False:
                     break

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -59,8 +59,8 @@ class Screensaver(ABC):
         if self.__timeout is None:
             self.__timeout = 0
 
-        self.transition_warmed_up = False
-        self.transition_warm_up_ticks = 0
+        self.live_transition_warmed_up = False
+        self.live_transition_warm_up_ticks = 0
         self.__last_tick = 0
         self.__black_hole_frame_player = BlackHoleFramePlayer()
         self.__is_set_up = False
@@ -129,7 +129,7 @@ class Screensaver(ABC):
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
         self.__start_time = time.time()
         self.setup()
-        start_tick = self.transition_warm_up_ticks if self.transition_warmed_up else 0
+        start_tick = self.live_transition_warm_up_ticks if self.live_transition_warmed_up else 0
 
         try:
             tick = start_tick

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -124,7 +124,7 @@ class Screensaver(ABC):
         Args:
             auto_teardown: If True (default), teardown() is called when the
                 loop ends. Set to False to keep the screensaver alive for
-                live transitions — the caller must call teardown() manually.
+                transitions — the caller must call teardown() manually.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
         self.__start_time = time.time()
@@ -183,6 +183,9 @@ class Screensaver(ABC):
 
     def supports_live_transition(self) -> bool:
         """Whether this screensaver can participate in live transitions.
+
+        Live transitions animate both screensavers during the blend.
+        Static transitions crossfade from the last displayed frame to black.
 
         Screensavers that block in _tick() or require the full LedFramePlayer
         API (beyond play_frame/fade_to_frame) should return False.

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -128,14 +128,17 @@ class Screensaver(ABC):
 
         return capture.get_current_frame()
 
-    def play(self) -> None:
+    def play(self, auto_teardown=True) -> None:
         """Run the screensaver tick loop.
 
         If warm_up() was called first, skips _setup() and continues from
         where warm-up left off. Otherwise starts fresh. Timeout always
         counts from when play() is called, not from warm-up.
 
-        Calls _teardown() in a finally block to ensure cleanup.
+        Args:
+            auto_teardown: If True (default), _teardown() is called when the
+                loop ends. Set to False to keep the screensaver alive for
+                live transitions — the caller must call _teardown() manually.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
         self._start_time = time.time()
@@ -152,7 +155,11 @@ class Screensaver(ABC):
                     break
                 time.sleep(self._tick_sleep)
                 tick += 1
-        finally:
+            self._last_tick = tick
+        except:
+            self._teardown()
+            raise
+        if auto_teardown:
             self._teardown()
         self._screensaver_logger.info(f"{self.get_name()} screensaver ended")
 

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -59,8 +59,8 @@ class Screensaver(ABC):
         if self.__timeout is None:
             self.__timeout = 0
 
-        self.warmed_up = False
-        self.warm_up_ticks = 0
+        self.transition_warmed_up = False
+        self.transition_warm_up_ticks = 0
         self.__last_tick = 0
         self.__black_hole_frame_player = BlackHoleFramePlayer()
         self.__is_set_up = False
@@ -129,7 +129,7 @@ class Screensaver(ABC):
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
         self.__start_time = time.time()
         self.setup()
-        start_tick = self.warm_up_ticks if self.warmed_up else 0
+        start_tick = self.transition_warm_up_ticks if self.transition_warmed_up else 0
 
         try:
             tick = start_tick

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -154,7 +154,7 @@ class Screensaver(ABC):
         pass
 
     def _teardown(self):
-        """Called after the tick loop (in finally block). Override for cleanup."""
+        """Called after the tick loop ends. Override for cleanup."""
         pass
 
     @abstractmethod

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -94,9 +94,10 @@ class Screensaver(ABC):
             self.__is_set_up = True
 
     def teardown(self):
-        """Clean up resources after the screensaver finishes."""
-        self._teardown()
-        self.__is_set_up = False
+        """Clean up resources after the screensaver finishes. Idempotent."""
+        if self.__is_set_up:
+            self._teardown()
+            self.__is_set_up = False
 
     def render_tick(self):
         """Advance state by one tick, capturing the rendered frame without

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -1,8 +1,6 @@
 import time
 from abc import ABC, abstractmethod
 
-import numpy as np
-
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.logger import Logger
@@ -99,30 +97,34 @@ class Screensaver(ABC):
         """Pre-render ticks to build up visual state without displaying.
 
         Runs _setup() and num_ticks iterations of _tick() using a FrameCapture
-        instead of the real LED display. Sets _start_time backward so that
-        time-based screensavers see the correct elapsed time.
+        instead of the real LED display. Ticks run at full speed (no sleeping).
 
         Returns the last captured frame (numpy array), or None if no frames
-        were rendered.
+        were rendered. Sets _warmed_up to True only if all ticks completed;
+        if _tick() returned False early, _warmed_up stays False and the
+        screensaver should not be reused.
         """
-        # Simulate time passage so time-based screensavers see realistic elapsed time
-        simulated_duration = num_ticks * max(self._tick_sleep, 0.05)
-        self._start_time = time.time() - simulated_duration
         self._setup()
-        self._warmed_up = True
 
         # Temporarily swap to a capture player
         real_player = self._led_frame_player
         capture = FrameCapture()
         self._led_frame_player = capture
 
+        completed = True
         try:
             for tick in range(num_ticks):
                 if self._tick(tick) is False:
+                    completed = False
                     break
             self._warm_up_ticks = tick + 1 if num_ticks > 0 else 0
         finally:
             self._led_frame_player = real_player
+
+        if completed:
+            self._warmed_up = True
+        else:
+            self._teardown()
 
         return capture.get_current_frame()
 
@@ -130,13 +132,14 @@ class Screensaver(ABC):
         """Run the screensaver tick loop.
 
         If warm_up() was called first, skips _setup() and continues from
-        where warm-up left off. Otherwise starts fresh.
+        where warm-up left off. Otherwise starts fresh. Timeout always
+        counts from when play() is called, not from warm-up.
 
         Calls _teardown() in a finally block to ensure cleanup.
         """
         self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
+        self._start_time = time.time()
         if not self._warmed_up:
-            self._start_time = time.time()
             self._setup()
             start_tick = 0
         else:

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -83,6 +83,7 @@ class Screensaver(ABC):
 
         self._warmed_up = False
         self._warm_up_ticks = 0
+        self._last_tick = 0
 
     def _is_past_timeout(self):
         """Check if the screensaver timeout has been exceeded.
@@ -93,49 +94,12 @@ class Screensaver(ABC):
             return False
         return (time.time() - self._start_time) > self._timeout
 
-    def warm_up(self, num_ticks=60):
-        """Pre-render ticks to build up visual state without displaying.
-
-        Runs _setup() and num_ticks iterations of _tick() using a FrameCapture
-        instead of the real LED display. Ticks run at full speed (no sleeping).
-
-        Returns the last captured frame (numpy array), or None if no frames
-        were rendered. Sets _warmed_up to True only if all ticks completed;
-        if _tick() returned False early, _warmed_up stays False and the
-        screensaver should not be reused.
-        """
-        # Swap to capture BEFORE _setup() — some screensavers render in
-        # _setup() (e.g. CellularAutomaton seeds the board), and we don't
-        # want those frames going to the real display.
-        real_player = self._led_frame_player
-        capture = FrameCapture()
-        self._led_frame_player = capture
-
-        self._setup()
-
-        completed = True
-        try:
-            for tick in range(num_ticks):
-                if self._tick(tick) is False:
-                    completed = False
-                    break
-            self._warm_up_ticks = tick + 1 if num_ticks > 0 else 0
-        finally:
-            self._led_frame_player = real_player
-
-        if completed:
-            self._warmed_up = True
-        else:
-            self._teardown()
-
-        return capture.get_current_frame()
-
     def play(self, auto_teardown=True) -> None:
         """Run the screensaver tick loop.
 
-        If warm_up() was called first, skips _setup() and continues from
-        where warm-up left off. Otherwise starts fresh. Timeout always
-        counts from when play() is called, not from warm-up.
+        If the screensaver was warmed up by a transition, skips _setup()
+        and continues from where warm-up left off. Otherwise starts fresh.
+        Timeout always counts from when play() is called, not from warm-up.
 
         Args:
             auto_teardown: If True (default), _teardown() is called when the
@@ -158,12 +122,16 @@ class Screensaver(ABC):
                 time.sleep(self._tick_sleep)
                 tick += 1
             self._last_tick = tick
-        except:
+        except Exception:
             self._teardown()
             raise
         if auto_teardown:
             self._teardown()
         self._screensaver_logger.info(f"{self.get_name()} screensaver ended")
+
+    def set_led_frame_player(self, led_frame_player):
+        """Replace the LED frame player (e.g. with a FrameCapture during transitions)."""
+        self._led_frame_player = led_frame_player
 
     def _setup(self):
         """Called once before the tick loop. Override for initialization."""
@@ -199,3 +167,12 @@ class Screensaver(ABC):
     def get_description(cls) -> str:
         """Return brief description"""
         pass
+
+    @classmethod
+    def supports_live_transition(cls) -> bool:
+        """Whether this screensaver can participate in live transitions.
+
+        Screensavers that block in _tick() or require the full LedFramePlayer
+        API (beyond play_frame/fade_to_frame) should return False.
+        """
+        return True

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -142,7 +142,7 @@ class Screensaver(ABC):
                     break
                 time.sleep(self.get_tick_sleep())
                 self.__last_tick += 1
-        except Exception:
+        except BaseException:
             self.teardown()
             raise
         if auto_teardown:

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -160,47 +160,33 @@ class ScreensaverManager:
                 screensaver = self.__pick_next_screensaver(available_ids)
 
             transitions_enabled = Config.get('screensavers.transitions.enabled', True)
-            can_live_transition = (
-                transitions_enabled
-                and screensaver.supports_live_transition()
-            )
-            screensaver.play(auto_teardown=not can_live_transition)
+            screensaver.play(auto_teardown=not transitions_enabled)
 
             if not transitions_enabled:
                 continue
 
-            if can_live_transition:
-                next_screensaver = self.__pick_next_screensaver(
-                    available_ids, exclude_id=screensaver.get_id()
-                )
+            next_screensaver = self.__pick_next_screensaver(
+                available_ids, exclude_id=screensaver.get_id()
+            )
+            can_live_transition = (
+                screensaver.supports_live_transition()
+                and next_screensaver.supports_live_transition()
+            )
 
-                # If the next screensaver doesn't support live transition,
-                # fall back to a static-frame transition (crossfade to black)
-                if not next_screensaver.supports_live_transition():
-                    try:
-                        self.__transition_player.play_transition()
-                    finally:
-                        screensaver.teardown()
-                    next_screensaver = None
-                    continue
-
-                # Live transition: both screensavers animate during the blend.
-                # The transition handles setup() and warm-up of the next
-                # screensaver internally, spread across transition steps.
-                try:
+            try:
+                if can_live_transition:
                     self.__transition_player.play_transition(
                         from_screensaver=screensaver,
                         to_screensaver=next_screensaver,
                     )
-                finally:
-                    screensaver.teardown()
-
-                # If the next screensaver failed during warm-up (e.g. missing
-                # dependency), discard it so we don't immediately exit in play()
-                if not next_screensaver.warmed_up:
-                    next_screensaver.teardown()
+                else:
+                    self.__transition_player.play_transition()
                     next_screensaver = None
-            else:
-                # Screensaver doesn't support live transitions —
-                # do a static-frame transition (crossfade from last frame to black)
-                self.__transition_player.play_transition()
+            finally:
+                screensaver.teardown()
+
+            # If the next screensaver failed during warm-up (e.g. missing
+            # dependency), discard it so we don't immediately exit in play()
+            if next_screensaver is not None and not next_screensaver.warmed_up:
+                next_screensaver.teardown()
+                next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -152,8 +152,8 @@ class ScreensaverManager:
             screensaver.play(auto_teardown=not transitions_enabled)
 
             if transitions_enabled:
-                # Pick and pre-render the next screensaver so the transition
-                # moves into an already-running visual instead of a blank frame.
+                # Pick next screensaver. Warm-up is handled inside the
+                # transition so the from_screensaver keeps animating.
                 # Avoid repeating the same screensaver back-to-back.
                 current_id = screensaver.get_id()
                 candidates = [sid for sid in available_ids if sid != current_id]
@@ -162,18 +162,17 @@ class ScreensaverManager:
                 next_id = random.choice(candidates)
                 next_cls = self.SCREENSAVER_CLASSES[next_id]
                 next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
-                warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
-                to_frame = next_screensaver.warm_up(num_ticks=warm_up_ticks)
 
-                # If the screensaver ended early during warm-up (e.g. missing
-                # dependency), discard it so we don't immediately exit in play()
-                if not next_screensaver._warmed_up:
-                    next_screensaver = None
-
-                # Live transition: both screensavers animate during the blend
+                # Live transition: both screensavers animate during the blend.
+                # The transition handles _setup() and warm-up of the next
+                # screensaver internally, spread across transition steps.
                 self.__transition_player.play_transition(
-                    to_frame=to_frame,
                     from_screensaver=screensaver,
                     to_screensaver=next_screensaver,
                 )
                 screensaver._teardown()
+
+                # If the next screensaver failed during warm-up (e.g. missing
+                # dependency), discard it so we don't immediately exit in play()
+                if not next_screensaver._warmed_up:
+                    next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -119,6 +119,19 @@ class ScreensaverManager:
 
         return ScreensaverManager._all_screensavers_cache
 
+    def __pick_next_screensaver(self, available_ids, exclude_id=None):
+        """Pick a random screensaver, avoiding back-to-back repeats."""
+        n = len(available_ids)
+        if exclude_id not in available_ids or n <= 1:
+            next_id = random.choice(available_ids)
+        else:
+            idx = random.randrange(n - 1)
+            if available_ids[idx] == exclude_id:
+                idx = n - 1
+            next_id = available_ids[idx]
+        next_cls = self.SCREENSAVER_CLASSES[next_id]
+        return next_cls(led_frame_player=self.__led_frame_player)
+
     def run(self):
         next_screensaver = None
         while True:
@@ -144,9 +157,7 @@ class ScreensaverManager:
                 next_screensaver = None
             else:
                 # First iteration or transitions disabled — fresh start
-                screensaver_id = random.choice(available_ids)
-                screensaver_cls = self.SCREENSAVER_CLASSES[screensaver_id]
-                screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
+                screensaver = self.__pick_next_screensaver(available_ids)
 
             transitions_enabled = Config.get('screensavers.transitions.enabled', True)
             can_live_transition = (
@@ -155,26 +166,26 @@ class ScreensaverManager:
             )
             screensaver.play(auto_teardown=not can_live_transition)
 
-            if can_live_transition:
-                # Pick next screensaver. Warm-up is handled inside the
-                # transition so the from_screensaver keeps animating.
-                # Avoid repeating the same screensaver back-to-back.
-                current_id = screensaver.get_id()
-                candidates = [sid for sid in available_ids if sid != current_id]
-                if not candidates:
-                    candidates = available_ids
-                next_id = random.choice(candidates)
-                next_cls = self.SCREENSAVER_CLASSES[next_id]
-                next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
+            if not transitions_enabled:
+                continue
 
-                # Skip live transition if the next screensaver doesn't support it
+            if can_live_transition:
+                next_screensaver = self.__pick_next_screensaver(
+                    available_ids, exclude_id=screensaver.get_id()
+                )
+
+                # If the next screensaver doesn't support live transition,
+                # fall back to a static-frame transition (crossfade to black)
                 if not next_screensaver.supports_live_transition():
-                    screensaver._teardown()
+                    try:
+                        self.__transition_player.play_transition()
+                    finally:
+                        screensaver.teardown()
                     next_screensaver = None
                     continue
 
                 # Live transition: both screensavers animate during the blend.
-                # The transition handles _setup() and warm-up of the next
+                # The transition handles setup() and warm-up of the next
                 # screensaver internally, spread across transition steps.
                 try:
                     self.__transition_player.play_transition(
@@ -182,10 +193,14 @@ class ScreensaverManager:
                         to_screensaver=next_screensaver,
                     )
                 finally:
-                    screensaver._teardown()
+                    screensaver.teardown()
 
                 # If the next screensaver failed during warm-up (e.g. missing
                 # dependency), discard it so we don't immediately exit in play()
-                if not next_screensaver._warmed_up:
-                    next_screensaver._teardown()
+                if not next_screensaver.warmed_up:
+                    next_screensaver.teardown()
                     next_screensaver = None
+            else:
+                # Screensaver doesn't support live transitions —
+                # do a static-frame transition (crossfade from last frame to black)
+                self.__transition_player.play_transition()

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -168,6 +168,7 @@ class ScreensaverManager:
             next_screensaver = self.__pick_next_screensaver(
                 available_ids, exclude_id=screensaver.get_id()
             )
+
             can_live_transition = (
                 screensaver.supports_live_transition()
                 and next_screensaver.supports_live_transition()
@@ -181,12 +182,11 @@ class ScreensaverManager:
                     )
                 else:
                     self.__transition_player.play_transition()
-                    next_screensaver = None
             finally:
                 screensaver.teardown()
 
-            # If the next screensaver failed during warm-up (e.g. missing
-            # dependency), discard it so we don't immediately exit in play()
-            if next_screensaver is not None and not next_screensaver.warmed_up:
+            # If the transition tried to warm up next_screensaver but it
+            # failed, discard it so we don't immediately exit in play().
+            if can_live_transition and not next_screensaver.warmed_up:
                 next_screensaver.teardown()
                 next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -187,6 +187,6 @@ class ScreensaverManager:
 
             # If the transition tried to warm up next_screensaver but it
             # failed, discard it so we don't immediately exit in play().
-            if can_live_transition and not next_screensaver.transition_warmed_up:
+            if can_live_transition and not next_screensaver.live_transition_warmed_up:
                 next_screensaver.teardown()
                 next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -158,4 +158,10 @@ class ScreensaverManager:
                 next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
                 warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
                 to_frame = next_screensaver.warm_up(num_ticks=warm_up_ticks)
+
+                # If the screensaver ended early during warm-up (e.g. missing
+                # dependency), discard it so we don't immediately exit in play()
+                if not next_screensaver._warmed_up:
+                    next_screensaver = None
+
                 self.__transition_player.play_transition(to_frame=to_frame)

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -120,6 +120,7 @@ class ScreensaverManager:
         return ScreensaverManager._all_screensavers_cache
 
     def run(self):
+        next_screensaver = None
         while True:
             # Reload config overrides from database before playing
             # This picks up any changes made via the settings UI
@@ -137,12 +138,24 @@ class ScreensaverManager:
             if not available_ids:
                 available_ids.append('game_of_life')
 
-            # Pick a random screensaver and instantiate fresh
-            # Fresh instance is needed to pick up config changes from the UI
-            screensaver_id = random.choice(available_ids)
-            screensaver_cls = self.SCREENSAVER_CLASSES[screensaver_id]
-            screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
+            if next_screensaver is not None:
+                # Use the pre-warmed screensaver from last iteration's transition
+                screensaver = next_screensaver
+                next_screensaver = None
+            else:
+                # First iteration or transitions disabled — fresh start
+                screensaver_id = random.choice(available_ids)
+                screensaver_cls = self.SCREENSAVER_CLASSES[screensaver_id]
+                screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
+
             screensaver.play()
 
             if Config.get('screensavers.transitions.enabled', True):
-                self.__transition_player.play_transition()
+                # Pick and pre-render the next screensaver so the transition
+                # moves into an already-running visual instead of a blank frame
+                next_id = random.choice(available_ids)
+                next_cls = self.SCREENSAVER_CLASSES[next_id]
+                next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
+                warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
+                to_frame = next_screensaver.warm_up(num_ticks=warm_up_ticks)
+                self.__transition_player.play_transition(to_frame=to_frame)

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -136,16 +136,16 @@ class ScreensaverManager:
 
             transitions_enabled = Config.get('screensavers.transitions.enabled', True)
             screensaver.play(auto_teardown=not transitions_enabled)
-
-            # Reload config so next_screensaver picks up any settings
-            # changes made while the current screensaver was playing.
-            available_ids = self.__reload_screensaver_config()
-
-            if not transitions_enabled:
-                continue
-
             can_live_transition = False
             try:
+
+                # Reload config so next_screensaver picks up any settings
+                # changes made while the current screensaver was playing.
+                available_ids = self.__reload_screensaver_config()
+
+                if not transitions_enabled:
+                    continue
+
                 next_screensaver = self.__pick_next_screensaver(
                     available_ids, exclude_id=screensaver.get_id()
                 )
@@ -166,7 +166,7 @@ class ScreensaverManager:
                 # If the transition tried to warm up next_screensaver but it
                 # failed (or an exception occurred before warm-up finished),
                 # discard it so we don't immediately exit in play().
-                if can_live_transition and not next_screensaver.live_transition_warmed_up:
+                if can_live_transition and next_screensaver and not next_screensaver.live_transition_warmed_up:
                     next_screensaver.teardown()
                     next_screensaver = None
 

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -187,6 +187,6 @@ class ScreensaverManager:
 
             # If the transition tried to warm up next_screensaver but it
             # failed, discard it so we don't immediately exit in play().
-            if can_live_transition and not next_screensaver.warmed_up:
+            if can_live_transition and not next_screensaver.transition_warmed_up:
                 next_screensaver.teardown()
                 next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -148,9 +148,10 @@ class ScreensaverManager:
                 screensaver_cls = self.SCREENSAVER_CLASSES[screensaver_id]
                 screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
 
-            screensaver.play()
+            transitions_enabled = Config.get('screensavers.transitions.enabled', True)
+            screensaver.play(auto_teardown=not transitions_enabled)
 
-            if Config.get('screensavers.transitions.enabled', True):
+            if transitions_enabled:
                 # Pick and pre-render the next screensaver so the transition
                 # moves into an already-running visual instead of a blank frame
                 next_id = random.choice(available_ids)
@@ -164,4 +165,10 @@ class ScreensaverManager:
                 if not next_screensaver._warmed_up:
                     next_screensaver = None
 
-                self.__transition_player.play_transition(to_frame=to_frame)
+                # Live transition: both screensavers animate during the blend
+                self.__transition_player.play_transition(
+                    to_frame=to_frame,
+                    from_screensaver=screensaver,
+                    to_screensaver=next_screensaver,
+                )
+                screensaver._teardown()

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -162,12 +162,12 @@ class ScreensaverManager:
                     self.__transition_player.play_transition()
             finally:
                 screensaver.teardown()
-
-            # If the transition tried to warm up next_screensaver but it
-            # failed, discard it so we don't immediately exit in play().
-            if can_live_transition and not next_screensaver.live_transition_warmed_up:
-                next_screensaver.teardown()
-                next_screensaver = None
+                # If the transition tried to warm up next_screensaver but it
+                # failed (or an exception occurred before warm-up finished),
+                # discard it so we don't immediately exit in play().
+                if can_live_transition and not next_screensaver.live_transition_warmed_up:
+                    next_screensaver.teardown()
+                    next_screensaver = None
 
     def __reload_screensaver_config(self):
         Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -152,8 +152,8 @@ class ScreensaverManager:
             screensaver.play(auto_teardown=not transitions_enabled)
 
             if transitions_enabled:
-                # Pick next screensaver. Warm-up is handled inside the
-                # transition so the from_screensaver keeps animating.
+                # Pick and pre-render the next screensaver so the transition
+                # moves into an already-running visual instead of a blank frame.
                 # Avoid repeating the same screensaver back-to-back.
                 current_id = screensaver.get_id()
                 candidates = [sid for sid in available_ids if sid != current_id]
@@ -162,17 +162,18 @@ class ScreensaverManager:
                 next_id = random.choice(candidates)
                 next_cls = self.SCREENSAVER_CLASSES[next_id]
                 next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
+                warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
+                to_frame = next_screensaver.warm_up(num_ticks=warm_up_ticks)
 
-                # Live transition: both screensavers animate during the blend.
-                # The transition handles _setup() and warm-up of the next
-                # screensaver internally, spread across transition steps.
+                # If the screensaver ended early during warm-up (e.g. missing
+                # dependency), discard it so we don't immediately exit in play()
+                if not next_screensaver._warmed_up:
+                    next_screensaver = None
+
+                # Live transition: both screensavers animate during the blend
                 self.__transition_player.play_transition(
+                    to_frame=to_frame,
                     from_screensaver=screensaver,
                     to_screensaver=next_screensaver,
                 )
                 screensaver._teardown()
-
-                # If the next screensaver failed during warm-up (e.g. missing
-                # dependency), discard it so we don't immediately exit in play()
-                if not next_screensaver._warmed_up:
-                    next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -119,38 +119,13 @@ class ScreensaverManager:
 
         return ScreensaverManager._all_screensavers_cache
 
-    def __pick_next_screensaver(self, available_ids, exclude_id=None):
-        """Pick a random screensaver, avoiding back-to-back repeats."""
-        n = len(available_ids)
-        if exclude_id not in available_ids or n <= 1:
-            next_id = random.choice(available_ids)
-        else:
-            idx = random.randrange(n - 1)
-            if available_ids[idx] == exclude_id:
-                idx = n - 1
-            next_id = available_ids[idx]
-        next_cls = self.SCREENSAVER_CLASSES[next_id]
-        return next_cls(led_frame_player=self.__led_frame_player)
-
     def run(self):
         next_screensaver = None
+
+        # Reload config overrides from database before playing
+        # This picks up any changes made via the settings UI
+        available_ids = self.__reload_screensaver_config()
         while True:
-            # Reload config overrides from database before playing
-            # This picks up any changes made via the settings UI
-            Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
-
-            enabled = Config.get('screensavers.enabled')
-
-            # Build list of available screensaver IDs
-            available_ids = []
-            for screensaver_id in enabled:
-                if screensaver_id in self.SCREENSAVER_CLASSES:
-                    available_ids.append(screensaver_id)
-
-            # Fall back to game of life if nothing enabled
-            if not available_ids:
-                available_ids.append('game_of_life')
-
             if next_screensaver is not None:
                 # Use the pre-warmed screensaver from last iteration's transition
                 screensaver = next_screensaver
@@ -162,13 +137,16 @@ class ScreensaverManager:
             transitions_enabled = Config.get('screensavers.transitions.enabled', True)
             screensaver.play(auto_teardown=not transitions_enabled)
 
+            # Reload config so next_screensaver picks up any settings
+            # changes made while the current screensaver was playing.
+            available_ids = self.__reload_screensaver_config()
+
             if not transitions_enabled:
                 continue
 
             next_screensaver = self.__pick_next_screensaver(
                 available_ids, exclude_id=screensaver.get_id()
             )
-
             can_live_transition = (
                 screensaver.supports_live_transition()
                 and next_screensaver.supports_live_transition()
@@ -190,3 +168,34 @@ class ScreensaverManager:
             if can_live_transition and not next_screensaver.live_transition_warmed_up:
                 next_screensaver.teardown()
                 next_screensaver = None
+
+    def __reload_screensaver_config(self):
+        Config.reload_overrides([SettingsDb.SCREENSAVER_SETTINGS])
+        enabled = Config.get('screensavers.enabled')
+
+        # Build list of available screensaver IDs
+        available_ids = []
+        for screensaver_id in enabled:
+            if screensaver_id in self.SCREENSAVER_CLASSES:
+                available_ids.append(screensaver_id)
+
+        # Fall back to game of life if nothing enabled
+        if not available_ids:
+            available_ids.append('game_of_life')
+
+        return available_ids
+
+    def __pick_next_screensaver(self, available_ids, exclude_id=None):
+        """Pick a random screensaver, avoiding back-to-back repeats."""
+        n = len(available_ids)
+        if n <= 1:
+            next_id = random.choice(available_ids)
+        else:
+            idx = random.randrange(n)
+            if available_ids[idx] == exclude_id:
+                idx = random.randrange(n - 1)
+                if available_ids[idx] == exclude_id:
+                    idx = n - 1
+            next_id = available_ids[idx]
+        next_cls = self.SCREENSAVER_CLASSES[next_id]
+        return next_cls(led_frame_player=self.__led_frame_player)

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -149,9 +149,13 @@ class ScreensaverManager:
                 screensaver = screensaver_cls(led_frame_player=self.__led_frame_player)
 
             transitions_enabled = Config.get('screensavers.transitions.enabled', True)
-            screensaver.play(auto_teardown=not transitions_enabled)
+            can_live_transition = (
+                transitions_enabled
+                and screensaver.supports_live_transition()
+            )
+            screensaver.play(auto_teardown=not can_live_transition)
 
-            if transitions_enabled:
+            if can_live_transition:
                 # Pick next screensaver. Warm-up is handled inside the
                 # transition so the from_screensaver keeps animating.
                 # Avoid repeating the same screensaver back-to-back.
@@ -163,16 +167,25 @@ class ScreensaverManager:
                 next_cls = self.SCREENSAVER_CLASSES[next_id]
                 next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
 
+                # Skip live transition if the next screensaver doesn't support it
+                if not next_screensaver.supports_live_transition():
+                    screensaver._teardown()
+                    next_screensaver = None
+                    continue
+
                 # Live transition: both screensavers animate during the blend.
                 # The transition handles _setup() and warm-up of the next
                 # screensaver internally, spread across transition steps.
-                self.__transition_player.play_transition(
-                    from_screensaver=screensaver,
-                    to_screensaver=next_screensaver,
-                )
-                screensaver._teardown()
+                try:
+                    self.__transition_player.play_transition(
+                        from_screensaver=screensaver,
+                        to_screensaver=next_screensaver,
+                    )
+                finally:
+                    screensaver._teardown()
 
                 # If the next screensaver failed during warm-up (e.g. missing
                 # dependency), discard it so we don't immediately exit in play()
                 if not next_screensaver._warmed_up:
+                    next_screensaver._teardown()
                     next_screensaver = None

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -144,15 +144,16 @@ class ScreensaverManager:
             if not transitions_enabled:
                 continue
 
-            next_screensaver = self.__pick_next_screensaver(
-                available_ids, exclude_id=screensaver.get_id()
-            )
-            can_live_transition = (
-                screensaver.supports_live_transition()
-                and next_screensaver.supports_live_transition()
-            )
-
+            can_live_transition = False
             try:
+                next_screensaver = self.__pick_next_screensaver(
+                    available_ids, exclude_id=screensaver.get_id()
+                )
+                can_live_transition = (
+                    screensaver.supports_live_transition()
+                    and next_screensaver.supports_live_transition()
+                )
+
                 if can_live_transition:
                     self.__transition_player.play_transition(
                         from_screensaver=screensaver,

--- a/pifi/screensaver/screensavermanager.py
+++ b/pifi/screensaver/screensavermanager.py
@@ -153,8 +153,13 @@ class ScreensaverManager:
 
             if transitions_enabled:
                 # Pick and pre-render the next screensaver so the transition
-                # moves into an already-running visual instead of a blank frame
-                next_id = random.choice(available_ids)
+                # moves into an already-running visual instead of a blank frame.
+                # Avoid repeating the same screensaver back-to-back.
+                current_id = screensaver.get_id()
+                candidates = [sid for sid in available_ids if sid != current_id]
+                if not candidates:
+                    candidates = available_ids
+                next_id = random.choice(candidates)
                 next_cls = self.SCREENSAVER_CLASSES[next_id]
                 next_screensaver = next_cls(led_frame_player=self.__led_frame_player)
                 warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -27,12 +27,11 @@ class Shadebobs(Screensaver):
 
         # Bob state
         self.__bobs = []
-        self.__time = 0
 
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         # Fade the buffer
         fade = Config.get('screensavers.configs.shadebobs.fade', 0.92)
         self.__buffer *= fade
@@ -43,7 +42,7 @@ class Shadebobs(Screensaver):
             bob['hue'] = (bob['hue'] + bob['hue_speed']) % 1.0
 
             # Calculate position using Lissajous curves
-            t = self.__time * bob['speed'] * 0.05
+            t = self.get_last_tick() * bob['speed'] * 0.05
             x = math.sin(bob['freq_x'] * t + bob['phase_x'])
             y = math.sin(bob['freq_y'] * t + bob['phase_y'])
 
@@ -56,12 +55,10 @@ class Shadebobs(Screensaver):
 
         # Render to display
         self.__render()
-        self.__time += 1
 
     def __reset(self):
         # Float buffer for smooth color accumulation
         self.__buffer = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
-        self.__time = 0
 
         # Create bobs with different Lissajous parameters
         num_bobs = Config.get('screensavers.configs.shadebobs.num_bobs', 5)

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -31,7 +31,7 @@ class Spirograph(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         time_speed = Config.get('screensavers.configs.spirograph.time_speed', 1.0)
         self.__time += time_speed
 

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -27,7 +27,7 @@ class Starfield(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         speed = Config.get('screensavers.configs.starfield.speed', 0.02)
 
         # Move stars toward viewer (decrease z)

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -36,7 +36,6 @@ class StringArt(Screensaver):
         self.__multiplier = 2.0  # Connection multiplier (creates different patterns)
         self.__rotation = 0.0
         self.__hue = 0.0
-        self.__tick = 0
 
     def __init_pattern(self):
         """Initialize the pattern."""
@@ -44,7 +43,6 @@ class StringArt(Screensaver):
         self.__rotation = 0.0
         self.__hue = np.random.random()
         self.__canvas.fill(0)
-        self.__tick = 0
 
     def __get_circle_point(self, index, radius, center_x, center_y):
         """Get a point on the circle."""
@@ -150,13 +148,12 @@ class StringArt(Screensaver):
 
         self.__rotation += self.__rotation_speed
         self.__hue = (self.__hue + 0.001) % 1.0
-        self.__tick += 1
 
     def _setup(self):
         """Initialize the pattern."""
         self.__init_pattern()
 
-    def _tick(self, tick):
+    def _tick(self):
         """Update pattern and render one frame."""
         self.__update()
 

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -155,7 +155,6 @@ class TransitionPlayer:
         height = Config.get_or_throw('leds.display_height')
         duration = Config.get('screensavers.transitions.duration', 1.0)
         tick_sleep = Config.get('screensavers.transitions.tick_sleep', 0.03)
-        warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
         num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
 
         if from_frame is None:
@@ -191,20 +190,9 @@ class TransitionPlayer:
 
         if to_alive:
             to_capture = FrameCapture()
+            to_capture.play_frame(to_frame)
+            to_tick = to_screensaver._warm_up_ticks
             to_screensaver._led_frame_player = to_capture
-            # If not warmed up, run _setup() here (renders to capture, not
-            # the real display). Warm-up ticks are spread across transition
-            # steps below so the from_screensaver keeps animating.
-            if not to_screensaver._warmed_up:
-                to_screensaver._setup()
-                to_screensaver._warmed_up = True
-            else:
-                to_capture.play_frame(to_frame)
-                warm_up_ticks = 0  # already warmed up
-
-        # How many warm-up ticks to fast-forward per transition step.
-        # Spread evenly so the computation doesn't cause a single big hitch.
-        ticks_per_step = (warm_up_ticks + num_steps - 1) // num_steps if to_alive and warm_up_ticks > 0 else 0
 
         # Accumulators for rate-matching each screensaver's tick_sleep to the
         # transition frame rate. Initialized at the threshold so the first
@@ -219,7 +207,7 @@ class TransitionPlayer:
                 from_accum += tick_sleep
                 to_accum += tick_sleep
 
-                # Tick from_screensaver at its natural rate
+                # Tick each screensaver at its natural rate
                 if from_alive and from_accum >= from_screensaver._tick_sleep:
                     from_accum -= from_screensaver._tick_sleep
                     if from_screensaver._tick(from_tick) is not False:
@@ -228,30 +216,13 @@ class TransitionPlayer:
                     else:
                         from_alive = False
 
-                if to_alive:
-                    if to_tick < warm_up_ticks:
-                        # Warm-up phase: fast-forward multiple ticks to build
-                        # state, but only update the displayed frame at the
-                        # screensaver's natural rate so it doesn't look sped up.
-                        for _ in range(ticks_per_step):
-                            if to_tick >= warm_up_ticks:
-                                break
-                            if to_screensaver._tick(to_tick) is not False:
-                                to_tick += 1
-                            else:
-                                to_alive = False
-                                break
-                        if to_alive and to_accum >= to_screensaver._tick_sleep:
-                            to_accum -= to_screensaver._tick_sleep
-                            to_frame = to_capture.get_current_frame()
-                    elif to_accum >= to_screensaver._tick_sleep:
-                        # Post warm-up: tick at natural rate
-                        to_accum -= to_screensaver._tick_sleep
-                        if to_screensaver._tick(to_tick) is not False:
-                            to_tick += 1
-                            to_frame = to_capture.get_current_frame()
-                        else:
-                            to_alive = False
+                if to_alive and to_accum >= to_screensaver._tick_sleep:
+                    to_accum -= to_screensaver._tick_sleep
+                    if to_screensaver._tick(to_tick) is not False:
+                        to_tick += 1
+                        to_frame = to_capture.get_current_frame()
+                    else:
+                        to_alive = False
 
                 from_float = from_frame.astype(np.float32)
                 to_float = to_frame.astype(np.float32)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -161,10 +161,7 @@ class TransitionPlayer:
         """
         width = Config.get_or_throw('leds.display_width')
         height = Config.get_or_throw('leds.display_height')
-        duration = Config.get('screensavers.transitions.duration', 1.0)
         tick_sleep = Config.get('screensavers.transitions.tick_sleep', 0.03)
-        warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
-        num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
 
         from_frame = self.__led_frame_player.get_current_frame()
         if from_frame is None:
@@ -186,7 +183,7 @@ class TransitionPlayer:
         from_frame, to_frame, from_alive, to_alive = self.__run_warm_up(
             from_screensaver, to_screensaver,
             from_frame, from_alive, to_alive,
-            warm_up_ticks, tick_sleep,
+            tick_sleep,
         )
 
         if to_alive:
@@ -196,19 +193,18 @@ class TransitionPlayer:
         self.__run_blend(
             from_screensaver, to_screensaver,
             from_frame, to_frame, effect,
-            from_alive, to_alive,
-            num_steps, tick_sleep,
+            from_alive, to_alive, tick_sleep,
         )
 
     def __run_warm_up(self, from_screensaver, to_screensaver,
                       from_frame, from_alive, to_alive,
-                      warm_up_ticks, tick_sleep):
+                      tick_sleep):
         """Warm up the to_screensaver while from_screensaver keeps playing.
 
         Returns (from_frame, to_frame, from_alive, to_alive).
         """
+        warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
         to_frame = np.zeros_like(from_frame)
-
         if not (to_alive and warm_up_ticks > 0):
             # No warm-up needed — grab initial frame if setup rendered one
             if to_alive:
@@ -250,9 +246,10 @@ class TransitionPlayer:
 
     def __run_blend(self, from_screensaver, to_screensaver,
                     from_frame, to_frame, effect,
-                    from_alive, to_alive,
-                    num_steps, tick_sleep):
+                    from_alive, to_alive, tick_sleep):
         """Blend both screensavers together over num_steps."""
+        duration = Config.get('screensavers.transitions.duration', 1.0)
+        num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
         to_sleep = to_screensaver.get_tick_sleep() if to_alive else tick_sleep
         # Prime accumulators so both screensavers tick on the first step,

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -171,8 +171,6 @@ class TransitionPlayer:
         if from_frame.ndim == 2:
             from_frame = np.stack([from_frame] * 3, axis=-1)
 
-        to_frame = np.zeros([height, width, 3], np.uint8)
-
         effect = self.__pick_effect(width, height)
         self.__logger.info(f"Playing transition: {effect.__name__}")
 

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -192,7 +192,7 @@ class TransitionPlayer:
         )
 
         if to_alive:
-            to_screensaver.transition_warmed_up = True
+            to_screensaver.live_transition_warmed_up = True
 
         # --- Transition blend ---
         self.__run_blend(
@@ -203,7 +203,7 @@ class TransitionPlayer:
         )
 
         if to_screensaver is not None:
-            to_screensaver.transition_warm_up_ticks = to_tick
+            to_screensaver.live_transition_warm_up_ticks = to_tick
 
     def __run_warm_up(self, from_screensaver, to_screensaver,
                       from_frame, from_tick, to_tick, from_alive, to_alive,

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from pifi.config import Config
 from pifi.logger import Logger
+from pifi.screensaver.screensaver import FrameCapture
 
 
 # Transition effect functions.
@@ -148,7 +149,8 @@ class TransitionPlayer:
         self.__led_frame_player = led_frame_player
         self.__logger = Logger().set_namespace(self.__class__.__name__)
 
-    def play_transition(self, from_frame=None, to_frame=None):
+    def play_transition(self, from_frame=None, to_frame=None,
+                        from_screensaver=None, to_screensaver=None):
         width = Config.get_or_throw('leds.display_width')
         height = Config.get_or_throw('leds.display_height')
         duration = Config.get('screensavers.transitions.duration', 1.0)
@@ -159,8 +161,6 @@ class TransitionPlayer:
             from_frame = self.__led_frame_player.get_current_frame()
         if from_frame is None:
             from_frame = np.zeros([height, width, 3], np.uint8)
-        # Monochrome video modes produce (H, W) frames. Expand to (H, W, 3)
-        # so blending math works with consistent shapes.
         if from_frame.ndim == 2:
             from_frame = np.stack([from_frame] * 3, axis=-1)
 
@@ -169,20 +169,61 @@ class TransitionPlayer:
         if to_frame.ndim == 2:
             to_frame = np.stack([to_frame] * 3, axis=-1)
 
-        # Convert to float32 for blending math
-        from_float = from_frame.astype(np.float32)
-        to_float = to_frame.astype(np.float32)
-
         # Pick a random effect - include factory-generated effects
         effect = self.__pick_effect(width, height)
 
         self.__logger.info(f"Playing transition: {effect.__name__}")
 
-        for step in range(1, num_steps + 1):
-            progress = step / num_steps
-            blended = effect(from_float, to_float, progress, width, height)
-            self.__led_frame_player.play_frame(blended.astype(np.uint8))
-            time.sleep(tick_sleep)
+        # Set up live ticking if screensaver objects are provided
+        from_capture = None
+        to_capture = None
+        from_tick = 0
+        to_tick = 0
+        from_alive = from_screensaver is not None
+        to_alive = to_screensaver is not None
+
+        if from_alive:
+            from_capture = FrameCapture()
+            from_capture.play_frame(from_frame)
+            from_tick = getattr(from_screensaver, '_last_tick', 0)
+            from_screensaver._led_frame_player = from_capture
+
+        if to_alive:
+            to_capture = FrameCapture()
+            to_capture.play_frame(to_frame)
+            to_tick = to_screensaver._warm_up_ticks
+            to_screensaver._led_frame_player = to_capture
+
+        try:
+            for step in range(1, num_steps + 1):
+                # Tick live screensavers and grab their latest frames
+                if from_alive:
+                    if from_screensaver._tick(from_tick) is not False:
+                        from_tick += 1
+                        from_frame = from_capture.get_current_frame()
+                    else:
+                        from_alive = False
+
+                if to_alive:
+                    if to_screensaver._tick(to_tick) is not False:
+                        to_tick += 1
+                        to_frame = to_capture.get_current_frame()
+                    else:
+                        to_alive = False
+
+                from_float = from_frame.astype(np.float32)
+                to_float = to_frame.astype(np.float32)
+                progress = step / num_steps
+                blended = effect(from_float, to_float, progress, width, height)
+                self.__led_frame_player.play_frame(blended.astype(np.uint8))
+                time.sleep(tick_sleep)
+        finally:
+            # Restore real frame player so play() works after transition
+            if from_screensaver is not None:
+                from_screensaver._led_frame_player = self.__led_frame_player
+            if to_screensaver is not None:
+                to_screensaver._led_frame_player = self.__led_frame_player
+                to_screensaver._warm_up_ticks = to_tick
 
     def __pick_effect(self, width, height):
         # Build the full list including factory effects

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -171,17 +171,11 @@ class TransitionPlayer:
         if from_frame.ndim == 2:
             from_frame = np.stack([from_frame] * 3, axis=-1)
 
-        effect = self.__pick_effect(width, height)
-        self.__logger.info(f"Playing transition: {effect.__name__}")
-
-        from_alive = from_screensaver is not None
-        to_alive = to_screensaver is not None
 
         # --- Warm-up phase ---
         from_frame, to_frame, from_alive, to_alive = self.__run_warm_up(
             from_screensaver, to_screensaver,
-            from_frame, from_alive, to_alive,
-            tick_sleep,
+            from_frame, tick_sleep,
         )
 
         if to_alive:
@@ -190,19 +184,19 @@ class TransitionPlayer:
         # --- Transition blend ---
         self.__run_blend(
             from_screensaver, to_screensaver,
-            from_frame, to_frame, effect,
+            from_frame, to_frame,
             from_alive, to_alive, tick_sleep,
         )
 
-    def __run_warm_up(self, from_screensaver, to_screensaver,
-                      from_frame, from_alive, to_alive,
-                      tick_sleep):
+    def __run_warm_up(self, from_screensaver, to_screensaver, from_frame, tick_sleep):
         """Warm up the to_screensaver while from_screensaver keeps playing.
 
         Returns (from_frame, to_frame, from_alive, to_alive).
         """
         warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
         to_frame = np.zeros_like(from_frame)
+        from_alive = from_screensaver is not None
+        to_alive = to_screensaver is not None
         if not (to_alive and warm_up_ticks > 0):
             # No warm-up needed — grab initial frame if setup rendered one
             if to_alive:
@@ -243,9 +237,12 @@ class TransitionPlayer:
         return from_frame, to_frame, from_alive, to_alive
 
     def __run_blend(self, from_screensaver, to_screensaver,
-                    from_frame, to_frame, effect,
+                    from_frame, to_frame,
                     from_alive, to_alive, tick_sleep):
         """Blend both screensavers together over num_steps."""
+        width, height = from_frame.shape[1], from_frame.shape[0]
+        effect = self.__pick_effect(width, height)
+        self.__logger.info(f"Playing transition: {effect.__name__}")
         duration = Config.get('screensavers.transitions.duration', 1.0)
         num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
@@ -284,8 +281,7 @@ class TransitionPlayer:
 
             from_float = from_frame.astype(np.float32)
             to_float = to_frame.astype(np.float32)
-            blended = effect(from_float, to_float, progress,
-                             from_frame.shape[1], from_frame.shape[0])
+            blended = effect(from_float, to_float, progress, width, height)
             self.__led_frame_player.play_frame(blended.astype(np.uint8))
 
             remaining = tick_sleep - (time.time() - step_start)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -228,19 +228,18 @@ class TransitionPlayer:
 
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
 
-        while to_tick < warm_up_ticks and to_alive:
+        while to_tick < warm_up_ticks and to_alive and from_alive:
             step_start = time.time()
 
             # Keep from_screensaver animating on the real display
-            if from_alive:
-                frame, alive = from_screensaver.render_tick(from_tick)
-                if alive:
-                    from_tick += 1
-                    if frame is not None:
-                        from_frame = frame
-                        self.__led_frame_player.play_frame(frame)
-                else:
-                    from_alive = False
+            frame, alive = from_screensaver.render_tick(from_tick)
+            if alive:
+                from_tick += 1
+                if frame is not None:
+                    from_frame = frame
+                    self.__led_frame_player.play_frame(frame)
+            else:
+                from_alive = False
 
             # One warm-up tick per frame to stay within CPU budget
             frame, alive = to_screensaver.render_tick(to_tick)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -184,9 +184,6 @@ class TransitionPlayer:
         from_alive = from_screensaver is not None
         to_alive = to_screensaver is not None
 
-        if to_alive and to_screensaver.warmed_up:
-            warm_up_ticks = 0
-
         # --- Warm-up phase ---
         to_frame, from_tick, to_tick, from_alive, to_alive = self.__run_warm_up(
             from_screensaver, to_screensaver,

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -151,13 +151,13 @@ class TransitionPlayer:
     def play_transition(self, from_screensaver=None, to_screensaver=None):
         """Play a transition between two screensavers.
 
-        Both screensavers stay alive and animate during the transition.
-        The to_screensaver is warmed up (setup + N ticks) while the
-        from_screensaver keeps playing on the real display, then both
-        frames are blended together for the visual transition.
+        Live transition (both screensavers provided): both screensavers
+        stay alive and animate during the blend. The to_screensaver is
+        warmed up (setup + N ticks) while the from_screensaver keeps
+        playing on the real display.
 
-        Can also be called with no screensavers for a static-frame
-        transition (crossfade from the current display to black).
+        Static transition (no screensavers provided): crossfade from the
+        current display to black.
         """
         width = Config.get_or_throw('leds.display_width')
         height = Config.get_or_throw('leds.display_height')

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -155,6 +155,7 @@ class TransitionPlayer:
         height = Config.get_or_throw('leds.display_height')
         duration = Config.get('screensavers.transitions.duration', 1.0)
         tick_sleep = Config.get('screensavers.transitions.tick_sleep', 0.03)
+        warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
         num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
 
         if from_frame is None:
@@ -190,9 +191,20 @@ class TransitionPlayer:
 
         if to_alive:
             to_capture = FrameCapture()
-            to_capture.play_frame(to_frame)
-            to_tick = to_screensaver._warm_up_ticks
             to_screensaver._led_frame_player = to_capture
+            # If not warmed up, run _setup() here (renders to capture, not
+            # the real display). Warm-up ticks are spread across transition
+            # steps below so the from_screensaver keeps animating.
+            if not to_screensaver._warmed_up:
+                to_screensaver._setup()
+                to_screensaver._warmed_up = True
+            else:
+                to_capture.play_frame(to_frame)
+                warm_up_ticks = 0  # already warmed up
+
+        # How many warm-up ticks to fast-forward per transition step.
+        # Spread evenly so the computation doesn't cause a single big hitch.
+        ticks_per_step = (warm_up_ticks + num_steps - 1) // num_steps if to_alive and warm_up_ticks > 0 else 0
 
         # Accumulators for rate-matching each screensaver's tick_sleep to the
         # transition frame rate. Initialized at the threshold so the first
@@ -207,7 +219,7 @@ class TransitionPlayer:
                 from_accum += tick_sleep
                 to_accum += tick_sleep
 
-                # Tick each screensaver at its natural rate
+                # Tick from_screensaver at its natural rate
                 if from_alive and from_accum >= from_screensaver._tick_sleep:
                     from_accum -= from_screensaver._tick_sleep
                     if from_screensaver._tick(from_tick) is not False:
@@ -216,13 +228,27 @@ class TransitionPlayer:
                     else:
                         from_alive = False
 
-                if to_alive and to_accum >= to_screensaver._tick_sleep:
-                    to_accum -= to_screensaver._tick_sleep
-                    if to_screensaver._tick(to_tick) is not False:
-                        to_tick += 1
-                        to_frame = to_capture.get_current_frame()
-                    else:
-                        to_alive = False
+                if to_alive:
+                    if to_tick < warm_up_ticks:
+                        # Warm-up phase: fast-forward multiple ticks per step
+                        for _ in range(ticks_per_step):
+                            if to_tick >= warm_up_ticks:
+                                break
+                            if to_screensaver._tick(to_tick) is not False:
+                                to_tick += 1
+                            else:
+                                to_alive = False
+                                break
+                        if to_alive:
+                            to_frame = to_capture.get_current_frame()
+                    elif to_accum >= to_screensaver._tick_sleep:
+                        # Post warm-up: tick at natural rate
+                        to_accum -= to_screensaver._tick_sleep
+                        if to_screensaver._tick(to_tick) is not False:
+                            to_tick += 1
+                            to_frame = to_capture.get_current_frame()
+                        else:
+                            to_alive = False
 
                 from_float = from_frame.astype(np.float32)
                 to_float = to_frame.astype(np.float32)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -185,14 +185,14 @@ class TransitionPlayer:
         to_alive = to_screensaver is not None
 
         # --- Warm-up phase ---
-        to_frame, from_tick, to_tick, from_alive, to_alive = self.__run_warm_up(
+        from_frame, to_frame, from_tick, to_tick, from_alive, to_alive = self.__run_warm_up(
             from_screensaver, to_screensaver,
             from_frame, from_tick, to_tick, from_alive, to_alive,
             warm_up_ticks, tick_sleep,
         )
 
         if to_alive:
-            to_screensaver.warmed_up = True
+            to_screensaver.transition_warmed_up = True
 
         # --- Transition blend ---
         self.__run_blend(
@@ -203,14 +203,14 @@ class TransitionPlayer:
         )
 
         if to_screensaver is not None:
-            to_screensaver.warm_up_ticks = to_tick
+            to_screensaver.transition_warm_up_ticks = to_tick
 
     def __run_warm_up(self, from_screensaver, to_screensaver,
                       from_frame, from_tick, to_tick, from_alive, to_alive,
                       warm_up_ticks, tick_sleep):
         """Warm up the to_screensaver while from_screensaver keeps playing.
 
-        Returns (to_frame, from_tick, to_tick, from_alive, to_alive).
+        Returns (from_frame, to_frame, from_tick, to_tick, from_alive, to_alive).
         """
         to_frame = np.zeros_like(from_frame)
 
@@ -221,7 +221,7 @@ class TransitionPlayer:
                 if frame is not None:
                     to_frame = frame
                 to_tick += 1
-            return to_frame, from_tick, to_tick, from_alive, to_alive
+            return from_frame, to_frame, from_tick, to_tick, from_alive, to_alive
 
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
 
@@ -251,7 +251,7 @@ class TransitionPlayer:
             if remaining > 0:
                 time.sleep(remaining)
 
-        return to_frame, from_tick, to_tick, from_alive, to_alive
+        return from_frame, to_frame, from_tick, to_tick, from_alive, to_alive
 
     def __run_blend(self, from_screensaver, to_screensaver,
                     from_frame, to_frame, effect,

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -217,10 +217,13 @@ class TransitionPlayer:
         if not (to_alive and warm_up_ticks > 0):
             # No warm-up needed — grab initial frame if setup rendered one
             if to_alive:
-                frame, _ = to_screensaver.render_tick(to_tick)
-                if frame is not None:
-                    to_frame = frame
-                to_tick += 1
+                frame, alive = to_screensaver.render_tick(to_tick)
+                if alive:
+                    to_tick += 1
+                    if frame is not None:
+                        to_frame = frame
+                else:
+                    to_alive = False
             return from_frame, to_frame, from_tick, to_tick, from_alive, to_alive
 
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -193,8 +193,8 @@ class TransitionPlayer:
             to_capture = FrameCapture()
             to_screensaver._led_frame_player = to_capture
             # If not warmed up, run _setup() here (renders to capture, not
-            # the real display). Warm-up ticks are spread across transition
-            # steps below so the from_screensaver keeps animating.
+            # the real display). Warm-up ticks happen below while the
+            # from_screensaver keeps playing on screen.
             if not to_screensaver._warmed_up:
                 to_screensaver._setup()
                 to_screensaver._warmed_up = True
@@ -202,13 +202,46 @@ class TransitionPlayer:
                 to_capture.play_frame(to_frame)
                 warm_up_ticks = 0  # already warmed up
 
-        # How many warm-up ticks to fast-forward per transition step.
-        # Spread evenly so the computation doesn't cause a single big hitch.
-        ticks_per_step = (warm_up_ticks + num_steps - 1) // num_steps if to_alive and warm_up_ticks > 0 else 0
+        # --- Warm-up phase ---
+        # Keep the from_screensaver playing on screen at its natural rate
+        # while fast-forwarding the to_screensaver silently. This finishes
+        # all warm-up BEFORE the transition blend starts.
+        if to_alive and warm_up_ticks > 0:
+            from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
+            # Target finishing warm-up in ~0.5s of wall time
+            num_warm_up_frames = max(1, int(0.5 / from_sleep))
+            wu_per_frame = max(1, (warm_up_ticks + num_warm_up_frames - 1) // num_warm_up_frames)
 
-        # Accumulators for rate-matching each screensaver's tick_sleep to the
-        # transition frame rate. Initialized at the threshold so the first
-        # step ticks immediately (continues the natural rhythm).
+            while to_tick < warm_up_ticks and to_alive:
+                step_start = time.time()
+
+                # Keep from_screensaver animating on the real display
+                if from_alive:
+                    if from_screensaver._tick(from_tick) is not False:
+                        from_tick += 1
+                        self.__led_frame_player.play_frame(from_capture.get_current_frame())
+                    else:
+                        from_alive = False
+
+                # Fast-forward to_screensaver (no display, no sleep)
+                for _ in range(wu_per_frame):
+                    if to_tick >= warm_up_ticks:
+                        break
+                    if to_screensaver._tick(to_tick) is not False:
+                        to_tick += 1
+                    else:
+                        to_alive = False
+                        break
+
+                remaining = from_sleep - (time.time() - step_start)
+                if remaining > 0:
+                    time.sleep(remaining)
+
+            if to_alive:
+                to_frame = to_capture.get_current_frame()
+
+        # --- Transition blend ---
+        # Both screensavers are now ready. Tick each at its natural rate.
         from_accum = from_screensaver._tick_sleep if from_alive else 0
         to_accum = to_screensaver._tick_sleep if to_alive else 0
 
@@ -219,7 +252,6 @@ class TransitionPlayer:
                 from_accum += tick_sleep
                 to_accum += tick_sleep
 
-                # Tick from_screensaver at its natural rate
                 if from_alive and from_accum >= from_screensaver._tick_sleep:
                     from_accum -= from_screensaver._tick_sleep
                     if from_screensaver._tick(from_tick) is not False:
@@ -228,31 +260,13 @@ class TransitionPlayer:
                     else:
                         from_alive = False
 
-                if to_alive:
-                    if to_tick < warm_up_ticks:
-                        # Warm-up phase: fast-forward to build internal state
-                        # without updating the displayed frame. Early in the
-                        # transition the to_frame is barely visible (low blend
-                        # progress), so holding it static is imperceptible.
-                        for _ in range(ticks_per_step):
-                            if to_tick >= warm_up_ticks:
-                                break
-                            if to_screensaver._tick(to_tick) is not False:
-                                to_tick += 1
-                            else:
-                                to_alive = False
-                                break
-                        # Grab the warmed-up frame once warm-up completes
-                        if to_alive and to_tick >= warm_up_ticks:
-                            to_frame = to_capture.get_current_frame()
-                    elif to_accum >= to_screensaver._tick_sleep:
-                        # Post warm-up: tick at natural rate
-                        to_accum -= to_screensaver._tick_sleep
-                        if to_screensaver._tick(to_tick) is not False:
-                            to_tick += 1
-                            to_frame = to_capture.get_current_frame()
-                        else:
-                            to_alive = False
+                if to_alive and to_accum >= to_screensaver._tick_sleep:
+                    to_accum -= to_screensaver._tick_sleep
+                    if to_screensaver._tick(to_tick) is not False:
+                        to_tick += 1
+                        to_frame = to_capture.get_current_frame()
+                    else:
+                        to_alive = False
 
                 from_float = from_frame.astype(np.float32)
                 to_float = to_frame.astype(np.float32)
@@ -260,7 +274,6 @@ class TransitionPlayer:
                 blended = effect(from_float, to_float, progress, width, height)
                 self.__led_frame_player.play_frame(blended.astype(np.uint8))
 
-                # Sleep only the remaining time to maintain consistent frame rate
                 remaining = tick_sleep - (time.time() - step_start)
                 if remaining > 0:
                     time.sleep(remaining)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -204,13 +204,10 @@ class TransitionPlayer:
 
         # --- Warm-up phase ---
         # Keep the from_screensaver playing on screen at its natural rate
-        # while fast-forwarding the to_screensaver silently. This finishes
-        # all warm-up BEFORE the transition blend starts.
+        # while building up the to_screensaver's state one tick per frame.
+        # This finishes all warm-up BEFORE the transition blend starts.
         if to_alive and warm_up_ticks > 0:
             from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
-            # Target finishing warm-up in ~0.5s of wall time
-            num_warm_up_frames = max(1, int(0.5 / from_sleep))
-            wu_per_frame = max(1, (warm_up_ticks + num_warm_up_frames - 1) // num_warm_up_frames)
 
             while to_tick < warm_up_ticks and to_alive:
                 step_start = time.time()
@@ -223,15 +220,11 @@ class TransitionPlayer:
                     else:
                         from_alive = False
 
-                # Fast-forward to_screensaver (no display, no sleep)
-                for _ in range(wu_per_frame):
-                    if to_tick >= warm_up_ticks:
-                        break
-                    if to_screensaver._tick(to_tick) is not False:
-                        to_tick += 1
-                    else:
-                        to_alive = False
-                        break
+                # One warm-up tick per frame to stay within CPU budget
+                if to_screensaver._tick(to_tick) is not False:
+                    to_tick += 1
+                else:
+                    to_alive = False
 
                 remaining = from_sleep - (time.time() - step_start)
                 if remaining > 0:
@@ -241,27 +234,34 @@ class TransitionPlayer:
                 to_frame = to_capture.get_current_frame()
 
         # --- Transition blend ---
-        # Both screensavers are now ready. Tick each at its natural rate.
-        from_accum = from_screensaver._tick_sleep if from_alive else 0
-        to_accum = to_screensaver._tick_sleep if to_alive else 0
+        # Both screensavers are now ready. The to_screensaver's tick rate
+        # interpolates from the from_screensaver's rate to its own so the
+        # tempo change is gradual rather than an abrupt shift.
+        from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
+        to_sleep = to_screensaver._tick_sleep if to_alive else tick_sleep
+        from_accum = from_sleep if from_alive else 0
+        to_accum = from_sleep if to_alive else 0  # start at from's rhythm
 
         try:
             for step in range(1, num_steps + 1):
                 step_start = time.time()
+                progress = step / num_steps
 
                 from_accum += tick_sleep
                 to_accum += tick_sleep
 
-                if from_alive and from_accum >= from_screensaver._tick_sleep:
-                    from_accum -= from_screensaver._tick_sleep
+                if from_alive and from_accum >= from_sleep:
+                    from_accum -= from_sleep
                     if from_screensaver._tick(from_tick) is not False:
                         from_tick += 1
                         from_frame = from_capture.get_current_frame()
                     else:
                         from_alive = False
 
-                if to_alive and to_accum >= to_screensaver._tick_sleep:
-                    to_accum -= to_screensaver._tick_sleep
+                # Interpolate tick rate: from_sleep at start → to_sleep at end
+                effective_to_sleep = from_sleep + (to_sleep - from_sleep) * progress
+                if to_alive and to_accum >= effective_to_sleep:
+                    to_accum -= effective_to_sleep
                     if to_screensaver._tick(to_tick) is not False:
                         to_tick += 1
                         to_frame = to_capture.get_current_frame()
@@ -270,7 +270,6 @@ class TransitionPlayer:
 
                 from_float = from_frame.astype(np.float32)
                 to_float = to_frame.astype(np.float32)
-                progress = step / num_steps
                 blended = effect(from_float, to_float, progress, width, height)
                 self.__led_frame_player.play_frame(blended.astype(np.uint8))
 

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from pifi.config import Config
 from pifi.logger import Logger
-from pifi.screensaver.screensaver import FrameCapture
 
 
 # Transition effect functions.
@@ -149,8 +148,17 @@ class TransitionPlayer:
         self.__led_frame_player = led_frame_player
         self.__logger = Logger().set_namespace(self.__class__.__name__)
 
-    def play_transition(self, from_frame=None, to_frame=None,
-                        from_screensaver=None, to_screensaver=None):
+    def play_transition(self, from_screensaver=None, to_screensaver=None):
+        """Play a transition between two screensavers.
+
+        Both screensavers stay alive and animate during the transition.
+        The to_screensaver is warmed up (setup + N ticks) while the
+        from_screensaver keeps playing on the real display, then both
+        frames are blended together for the visual transition.
+
+        Can also be called with no screensavers for a static-frame
+        transition (crossfade from the current display to black).
+        """
         width = Config.get_or_throw('leds.display_width')
         height = Config.get_or_throw('leds.display_height')
         duration = Config.get('screensavers.transitions.duration', 1.0)
@@ -158,8 +166,7 @@ class TransitionPlayer:
         warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
         num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
 
-        if from_frame is None:
-            from_frame = self.__led_frame_player.get_current_frame()
+        from_frame = self.__led_frame_player.get_current_frame()
         if from_frame is None:
             from_frame = np.zeros([height, width, 3], np.uint8)
         # Monochrome video modes produce (H, W) frames. Expand to (H, W, 3)
@@ -167,126 +174,139 @@ class TransitionPlayer:
         if from_frame.ndim == 2:
             from_frame = np.stack([from_frame] * 3, axis=-1)
 
-        if to_frame is None:
-            to_frame = np.zeros([height, width, 3], np.uint8)
-        if to_frame.ndim == 2:
-            to_frame = np.stack([to_frame] * 3, axis=-1)
+        to_frame = np.zeros([height, width, 3], np.uint8)
 
-        # Pick a random effect - include factory-generated effects
         effect = self.__pick_effect(width, height)
-
         self.__logger.info(f"Playing transition: {effect.__name__}")
 
-        # Set up live ticking if screensaver objects are provided
-        from_capture = None
-        to_capture = None
-        from_tick = 0
+        from_tick = from_screensaver.last_tick() if from_screensaver else 0
         to_tick = 0
         from_alive = from_screensaver is not None
         to_alive = to_screensaver is not None
 
-        if from_alive:
-            from_capture = FrameCapture()
-            from_capture.play_frame(from_frame)
-            from_tick = from_screensaver._last_tick
-            from_screensaver.set_led_frame_player(from_capture)
+        if to_alive and to_screensaver.warmed_up:
+            warm_up_ticks = 0
+
+        # --- Warm-up phase ---
+        to_frame, from_tick, to_tick, from_alive, to_alive = self.__run_warm_up(
+            from_screensaver, to_screensaver,
+            from_frame, from_tick, to_tick, from_alive, to_alive,
+            warm_up_ticks, tick_sleep,
+        )
 
         if to_alive:
-            to_capture = FrameCapture()
-            to_screensaver.set_led_frame_player(to_capture)
-            # If not warmed up, run _setup() here (renders to capture, not
-            # the real display). Warm-up ticks happen below while the
-            # from_screensaver keeps playing on screen.
-            if not to_screensaver._warmed_up:
-                to_screensaver._setup()
-            else:
-                to_capture.play_frame(to_frame)
-                warm_up_ticks = 0  # already warmed up
+            to_screensaver.warmed_up = True
 
-        try:
-            # --- Warm-up phase ---
-            # Keep the from_screensaver playing on screen at its natural rate
-            # while building up the to_screensaver's state one tick per frame.
-            # This finishes all warm-up BEFORE the transition blend starts.
-            if to_alive and warm_up_ticks > 0:
-                from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
+        # --- Transition blend ---
+        self.__run_blend(
+            from_screensaver, to_screensaver,
+            from_frame, to_frame, effect,
+            from_tick, to_tick, from_alive, to_alive,
+            num_steps, tick_sleep,
+        )
 
-                while to_tick < warm_up_ticks and to_alive:
-                    step_start = time.time()
+        if to_screensaver is not None:
+            to_screensaver.warm_up_ticks = to_tick
 
-                    # Keep from_screensaver animating on the real display
-                    if from_alive:
-                        if from_screensaver._tick(from_tick) is not False:
-                            from_tick += 1
-                            self.__led_frame_player.play_frame(from_capture.get_current_frame())
-                        else:
-                            from_alive = False
+    def __run_warm_up(self, from_screensaver, to_screensaver,
+                      from_frame, from_tick, to_tick, from_alive, to_alive,
+                      warm_up_ticks, tick_sleep):
+        """Warm up the to_screensaver while from_screensaver keeps playing.
 
-                    # One warm-up tick per frame to stay within CPU budget
-                    if to_screensaver._tick(to_tick) is not False:
-                        to_tick += 1
-                    else:
-                        to_alive = False
+        Returns (to_frame, from_tick, to_tick, from_alive, to_alive).
+        """
+        to_frame = np.zeros_like(from_frame)
 
-                    remaining = from_sleep - (time.time() - step_start)
-                    if remaining > 0:
-                        time.sleep(remaining)
-
+        if not (to_alive and warm_up_ticks > 0):
+            # No warm-up needed — grab initial frame if setup rendered one
             if to_alive:
-                captured = to_capture.get_current_frame()
-                if captured is not None:
-                    to_frame = captured
-                to_screensaver._warmed_up = True
+                frame, _ = to_screensaver.render_tick(to_tick)
+                if frame is not None:
+                    to_frame = frame
+                to_tick += 1
+            return to_frame, from_tick, to_tick, from_alive, to_alive
 
-            # --- Transition blend ---
-            # Both screensavers are now ready. The to_screensaver's tick rate
-            # interpolates from the from_screensaver's rate to its own so the
-            # tempo change is gradual rather than an abrupt shift.
-            from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
-            to_sleep = to_screensaver._tick_sleep if to_alive else tick_sleep
-            from_accum = from_sleep if from_alive else 0
-            to_accum = from_sleep if to_alive else 0  # start at from's rhythm
+        from_sleep = from_screensaver.tick_sleep() if from_alive else tick_sleep
 
-            for step in range(1, num_steps + 1):
-                step_start = time.time()
-                progress = step / num_steps
+        while to_tick < warm_up_ticks and to_alive:
+            step_start = time.time()
 
-                from_accum += tick_sleep
-                to_accum += tick_sleep
+            # Keep from_screensaver animating on the real display
+            if from_alive:
+                frame, alive = from_screensaver.render_tick(from_tick)
+                if alive:
+                    from_tick += 1
+                    if frame is not None:
+                        from_frame = frame
+                        self.__led_frame_player.play_frame(frame)
+                else:
+                    from_alive = False
 
-                if from_alive and from_accum >= from_sleep:
-                    from_accum -= from_sleep
-                    if from_screensaver._tick(from_tick) is not False:
-                        from_tick += 1
-                        from_frame = from_capture.get_current_frame()
-                    else:
-                        from_alive = False
+            # One warm-up tick per frame to stay within CPU budget
+            frame, alive = to_screensaver.render_tick(to_tick)
+            if alive:
+                to_tick += 1
+                if frame is not None:
+                    to_frame = frame
+            else:
+                to_alive = False
 
-                # Interpolate tick rate: from_sleep at start → to_sleep at end
-                effective_to_sleep = from_sleep + (to_sleep - from_sleep) * progress
-                if to_alive and to_accum >= effective_to_sleep:
-                    to_accum -= effective_to_sleep
-                    if to_screensaver._tick(to_tick) is not False:
-                        to_tick += 1
-                        to_frame = to_capture.get_current_frame()
-                    else:
-                        to_alive = False
+            remaining = from_sleep - (time.time() - step_start)
+            if remaining > 0:
+                time.sleep(remaining)
 
-                from_float = from_frame.astype(np.float32)
-                to_float = to_frame.astype(np.float32)
-                blended = effect(from_float, to_float, progress, width, height)
-                self.__led_frame_player.play_frame(blended.astype(np.uint8))
+        return to_frame, from_tick, to_tick, from_alive, to_alive
 
-                remaining = tick_sleep - (time.time() - step_start)
-                if remaining > 0:
-                    time.sleep(remaining)
-        finally:
-            # Restore real frame player so play() works after transition
-            if from_screensaver is not None:
-                from_screensaver.set_led_frame_player(self.__led_frame_player)
-            if to_screensaver is not None:
-                to_screensaver.set_led_frame_player(self.__led_frame_player)
-                to_screensaver._warm_up_ticks = to_tick
+    def __run_blend(self, from_screensaver, to_screensaver,
+                    from_frame, to_frame, effect,
+                    from_tick, to_tick, from_alive, to_alive,
+                    num_steps, tick_sleep):
+        """Blend both screensavers together over num_steps."""
+        from_sleep = from_screensaver.tick_sleep() if from_alive else tick_sleep
+        to_sleep = to_screensaver.tick_sleep() if to_alive else tick_sleep
+        # Prime accumulators so both screensavers tick on the first step,
+        # maintaining continuity from the warm-up phase.
+        from_accum = from_sleep if from_alive else 0
+        to_accum = from_sleep if to_alive else 0  # start at from's rhythm
+
+        for step in range(1, num_steps + 1):
+            step_start = time.time()
+            progress = step / num_steps
+
+            from_accum += tick_sleep
+            to_accum += tick_sleep
+
+            if from_alive and from_accum >= from_sleep:
+                from_accum -= from_sleep
+                frame, alive = from_screensaver.render_tick(from_tick)
+                if alive:
+                    from_tick += 1
+                    if frame is not None:
+                        from_frame = frame
+                else:
+                    from_alive = False
+
+            # Interpolate tick rate: from_sleep at start → to_sleep at end
+            effective_to_sleep = from_sleep + (to_sleep - from_sleep) * progress
+            if to_alive and to_accum >= effective_to_sleep:
+                to_accum -= effective_to_sleep
+                frame, alive = to_screensaver.render_tick(to_tick)
+                if alive:
+                    to_tick += 1
+                    if frame is not None:
+                        to_frame = frame
+                else:
+                    to_alive = False
+
+            from_float = from_frame.astype(np.float32)
+            to_float = to_frame.astype(np.float32)
+            blended = effect(from_float, to_float, progress,
+                             from_frame.shape[1], from_frame.shape[0])
+            self.__led_frame_player.play_frame(blended.astype(np.uint8))
+
+            remaining = tick_sleep - (time.time() - step_start)
+            if remaining > 0:
+                time.sleep(remaining)
 
     def __pick_effect(self, width, height):
         # Build the full list including factory effects

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -195,7 +195,7 @@ class TransitionPlayer:
             to_screensaver.live_transition_warmed_up = True
 
         # --- Transition blend ---
-        self.__run_blend(
+        to_tick = self.__run_blend(
             from_screensaver, to_screensaver,
             from_frame, to_frame, effect,
             from_tick, to_tick, from_alive, to_alive,
@@ -260,7 +260,10 @@ class TransitionPlayer:
                     from_frame, to_frame, effect,
                     from_tick, to_tick, from_alive, to_alive,
                     num_steps, tick_sleep):
-        """Blend both screensavers together over num_steps."""
+        """Blend both screensavers together over num_steps.
+
+        Returns to_tick so the caller can record the final tick count.
+        """
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
         to_sleep = to_screensaver.get_tick_sleep() if to_alive else tick_sleep
         # Prime accumulators so both screensavers tick on the first step,
@@ -306,6 +309,8 @@ class TransitionPlayer:
             remaining = tick_sleep - (time.time() - step_start)
             if remaining > 0:
                 time.sleep(remaining)
+
+        return to_tick
 
     def __pick_effect(self, width, height):
         # Build the full list including factory effects

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -179,7 +179,7 @@ class TransitionPlayer:
         effect = self.__pick_effect(width, height)
         self.__logger.info(f"Playing transition: {effect.__name__}")
 
-        from_tick = from_screensaver.last_tick() if from_screensaver else 0
+        from_tick = from_screensaver.get_last_tick() if from_screensaver else 0
         to_tick = 0
         from_alive = from_screensaver is not None
         to_alive = to_screensaver is not None
@@ -226,7 +226,7 @@ class TransitionPlayer:
                 to_tick += 1
             return to_frame, from_tick, to_tick, from_alive, to_alive
 
-        from_sleep = from_screensaver.tick_sleep() if from_alive else tick_sleep
+        from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
 
         while to_tick < warm_up_ticks and to_alive:
             step_start = time.time()
@@ -262,8 +262,8 @@ class TransitionPlayer:
                     from_tick, to_tick, from_alive, to_alive,
                     num_steps, tick_sleep):
         """Blend both screensavers together over num_steps."""
-        from_sleep = from_screensaver.tick_sleep() if from_alive else tick_sleep
-        to_sleep = to_screensaver.tick_sleep() if to_alive else tick_sleep
+        from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
+        to_sleep = to_screensaver.get_tick_sleep() if to_alive else tick_sleep
         # Prime accumulators so both screensavers tick on the first step,
         # maintaining continuity from the warm-up phase.
         from_accum = from_sleep if from_alive else 0

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -155,6 +155,7 @@ class TransitionPlayer:
         height = Config.get_or_throw('leds.display_height')
         duration = Config.get('screensavers.transitions.duration', 1.0)
         tick_sleep = Config.get('screensavers.transitions.tick_sleep', 0.03)
+        warm_up_ticks = Config.get('screensavers.transitions.warm_up_ticks', 60)
         num_steps = max(1, int(duration / tick_sleep)) if tick_sleep > 0 else 1
 
         if from_frame is None:
@@ -190,9 +191,20 @@ class TransitionPlayer:
 
         if to_alive:
             to_capture = FrameCapture()
-            to_capture.play_frame(to_frame)
-            to_tick = to_screensaver._warm_up_ticks
             to_screensaver._led_frame_player = to_capture
+            # If not warmed up, run _setup() here (renders to capture, not
+            # the real display). Warm-up ticks are spread across transition
+            # steps below so the from_screensaver keeps animating.
+            if not to_screensaver._warmed_up:
+                to_screensaver._setup()
+                to_screensaver._warmed_up = True
+            else:
+                to_capture.play_frame(to_frame)
+                warm_up_ticks = 0  # already warmed up
+
+        # How many warm-up ticks to fast-forward per transition step.
+        # Spread evenly so the computation doesn't cause a single big hitch.
+        ticks_per_step = (warm_up_ticks + num_steps - 1) // num_steps if to_alive and warm_up_ticks > 0 else 0
 
         # Accumulators for rate-matching each screensaver's tick_sleep to the
         # transition frame rate. Initialized at the threshold so the first
@@ -207,7 +219,7 @@ class TransitionPlayer:
                 from_accum += tick_sleep
                 to_accum += tick_sleep
 
-                # Tick each screensaver at its natural rate
+                # Tick from_screensaver at its natural rate
                 if from_alive and from_accum >= from_screensaver._tick_sleep:
                     from_accum -= from_screensaver._tick_sleep
                     if from_screensaver._tick(from_tick) is not False:
@@ -216,13 +228,30 @@ class TransitionPlayer:
                     else:
                         from_alive = False
 
-                if to_alive and to_accum >= to_screensaver._tick_sleep:
-                    to_accum -= to_screensaver._tick_sleep
-                    if to_screensaver._tick(to_tick) is not False:
-                        to_tick += 1
-                        to_frame = to_capture.get_current_frame()
-                    else:
-                        to_alive = False
+                if to_alive:
+                    if to_tick < warm_up_ticks:
+                        # Warm-up phase: fast-forward multiple ticks to build
+                        # state, but only update the displayed frame at the
+                        # screensaver's natural rate so it doesn't look sped up.
+                        for _ in range(ticks_per_step):
+                            if to_tick >= warm_up_ticks:
+                                break
+                            if to_screensaver._tick(to_tick) is not False:
+                                to_tick += 1
+                            else:
+                                to_alive = False
+                                break
+                        if to_alive and to_accum >= to_screensaver._tick_sleep:
+                            to_accum -= to_screensaver._tick_sleep
+                            to_frame = to_capture.get_current_frame()
+                    elif to_accum >= to_screensaver._tick_sleep:
+                        # Post warm-up: tick at natural rate
+                        to_accum -= to_screensaver._tick_sleep
+                        if to_screensaver._tick(to_tick) is not False:
+                            to_tick += 1
+                            to_frame = to_capture.get_current_frame()
+                        else:
+                            to_alive = False
 
                 from_float = from_frame.astype(np.float32)
                 to_float = to_frame.astype(np.float32)

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -202,6 +202,8 @@ class TransitionPlayer:
 
         try:
             for step in range(1, num_steps + 1):
+                step_start = time.time()
+
                 from_accum += tick_sleep
                 to_accum += tick_sleep
 
@@ -227,7 +229,11 @@ class TransitionPlayer:
                 progress = step / num_steps
                 blended = effect(from_float, to_float, progress, width, height)
                 self.__led_frame_player.play_frame(blended.astype(np.uint8))
-                time.sleep(tick_sleep)
+
+                # Sleep only the remaining time to maintain consistent frame rate
+                remaining = tick_sleep - (time.time() - step_start)
+                if remaining > 0:
+                    time.sleep(remaining)
         finally:
             # Restore real frame player so play() works after transition
             if from_screensaver is not None:

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -179,15 +179,13 @@ class TransitionPlayer:
         effect = self.__pick_effect(width, height)
         self.__logger.info(f"Playing transition: {effect.__name__}")
 
-        from_tick = from_screensaver.get_last_tick() if from_screensaver else 0
-        to_tick = 0
         from_alive = from_screensaver is not None
         to_alive = to_screensaver is not None
 
         # --- Warm-up phase ---
-        from_frame, to_frame, from_tick, to_tick, from_alive, to_alive = self.__run_warm_up(
+        from_frame, to_frame, from_alive, to_alive = self.__run_warm_up(
             from_screensaver, to_screensaver,
-            from_frame, from_tick, to_tick, from_alive, to_alive,
+            from_frame, from_alive, to_alive,
             warm_up_ticks, tick_sleep,
         )
 
@@ -195,46 +193,41 @@ class TransitionPlayer:
             to_screensaver.live_transition_warmed_up = True
 
         # --- Transition blend ---
-        to_tick = self.__run_blend(
+        self.__run_blend(
             from_screensaver, to_screensaver,
             from_frame, to_frame, effect,
-            from_tick, to_tick, from_alive, to_alive,
+            from_alive, to_alive,
             num_steps, tick_sleep,
         )
 
-        if to_screensaver is not None:
-            to_screensaver.live_transition_warm_up_ticks = to_tick
-
     def __run_warm_up(self, from_screensaver, to_screensaver,
-                      from_frame, from_tick, to_tick, from_alive, to_alive,
+                      from_frame, from_alive, to_alive,
                       warm_up_ticks, tick_sleep):
         """Warm up the to_screensaver while from_screensaver keeps playing.
 
-        Returns (from_frame, to_frame, from_tick, to_tick, from_alive, to_alive).
+        Returns (from_frame, to_frame, from_alive, to_alive).
         """
         to_frame = np.zeros_like(from_frame)
 
         if not (to_alive and warm_up_ticks > 0):
             # No warm-up needed — grab initial frame if setup rendered one
             if to_alive:
-                frame, alive = to_screensaver.render_tick(to_tick)
+                frame, alive = to_screensaver.render_tick()
                 if alive:
-                    to_tick += 1
                     if frame is not None:
                         to_frame = frame
                 else:
                     to_alive = False
-            return from_frame, to_frame, from_tick, to_tick, from_alive, to_alive
+            return from_frame, to_frame, from_alive, to_alive
 
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
 
-        while to_tick < warm_up_ticks and to_alive and from_alive:
+        while to_screensaver.get_last_tick() < warm_up_ticks and to_alive and from_alive:
             step_start = time.time()
 
             # Keep from_screensaver animating on the real display
-            frame, alive = from_screensaver.render_tick(from_tick)
+            frame, alive = from_screensaver.render_tick()
             if alive:
-                from_tick += 1
                 if frame is not None:
                     from_frame = frame
                     self.__led_frame_player.play_frame(frame)
@@ -242,9 +235,8 @@ class TransitionPlayer:
                 from_alive = False
 
             # One warm-up tick per frame to stay within CPU budget
-            frame, alive = to_screensaver.render_tick(to_tick)
+            frame, alive = to_screensaver.render_tick()
             if alive:
-                to_tick += 1
                 if frame is not None:
                     to_frame = frame
             else:
@@ -254,16 +246,13 @@ class TransitionPlayer:
             if remaining > 0:
                 time.sleep(remaining)
 
-        return from_frame, to_frame, from_tick, to_tick, from_alive, to_alive
+        return from_frame, to_frame, from_alive, to_alive
 
     def __run_blend(self, from_screensaver, to_screensaver,
                     from_frame, to_frame, effect,
-                    from_tick, to_tick, from_alive, to_alive,
+                    from_alive, to_alive,
                     num_steps, tick_sleep):
-        """Blend both screensavers together over num_steps.
-
-        Returns to_tick so the caller can record the final tick count.
-        """
+        """Blend both screensavers together over num_steps."""
         from_sleep = from_screensaver.get_tick_sleep() if from_alive else tick_sleep
         to_sleep = to_screensaver.get_tick_sleep() if to_alive else tick_sleep
         # Prime accumulators so both screensavers tick on the first step,
@@ -280,9 +269,8 @@ class TransitionPlayer:
 
             if from_alive and from_accum >= from_sleep:
                 from_accum -= from_sleep
-                frame, alive = from_screensaver.render_tick(from_tick)
+                frame, alive = from_screensaver.render_tick()
                 if alive:
-                    from_tick += 1
                     if frame is not None:
                         from_frame = frame
                 else:
@@ -292,9 +280,8 @@ class TransitionPlayer:
             effective_to_sleep = from_sleep + (to_sleep - from_sleep) * progress
             if to_alive and to_accum >= effective_to_sleep:
                 to_accum -= effective_to_sleep
-                frame, alive = to_screensaver.render_tick(to_tick)
+                frame, alive = to_screensaver.render_tick()
                 if alive:
-                    to_tick += 1
                     if frame is not None:
                         to_frame = frame
                 else:
@@ -309,8 +296,6 @@ class TransitionPlayer:
             remaining = tick_sleep - (time.time() - step_start)
             if remaining > 0:
                 time.sleep(remaining)
-
-        return to_tick
 
     def __pick_effect(self, width, height):
         # Build the full list including factory effects

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -162,6 +162,8 @@ class TransitionPlayer:
             from_frame = self.__led_frame_player.get_current_frame()
         if from_frame is None:
             from_frame = np.zeros([height, width, 3], np.uint8)
+        # Monochrome video modes produce (H, W) frames. Expand to (H, W, 3)
+        # so blending math works with consistent shapes.
         if from_frame.ndim == 2:
             from_frame = np.stack([from_frame] * 3, axis=-1)
 
@@ -186,63 +188,65 @@ class TransitionPlayer:
         if from_alive:
             from_capture = FrameCapture()
             from_capture.play_frame(from_frame)
-            from_tick = getattr(from_screensaver, '_last_tick', 0)
-            from_screensaver._led_frame_player = from_capture
+            from_tick = from_screensaver._last_tick
+            from_screensaver.set_led_frame_player(from_capture)
 
         if to_alive:
             to_capture = FrameCapture()
-            to_screensaver._led_frame_player = to_capture
+            to_screensaver.set_led_frame_player(to_capture)
             # If not warmed up, run _setup() here (renders to capture, not
             # the real display). Warm-up ticks happen below while the
             # from_screensaver keeps playing on screen.
             if not to_screensaver._warmed_up:
                 to_screensaver._setup()
-                to_screensaver._warmed_up = True
             else:
                 to_capture.play_frame(to_frame)
                 warm_up_ticks = 0  # already warmed up
 
-        # --- Warm-up phase ---
-        # Keep the from_screensaver playing on screen at its natural rate
-        # while building up the to_screensaver's state one tick per frame.
-        # This finishes all warm-up BEFORE the transition blend starts.
-        if to_alive and warm_up_ticks > 0:
-            from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
+        try:
+            # --- Warm-up phase ---
+            # Keep the from_screensaver playing on screen at its natural rate
+            # while building up the to_screensaver's state one tick per frame.
+            # This finishes all warm-up BEFORE the transition blend starts.
+            if to_alive and warm_up_ticks > 0:
+                from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
 
-            while to_tick < warm_up_ticks and to_alive:
-                step_start = time.time()
+                while to_tick < warm_up_ticks and to_alive:
+                    step_start = time.time()
 
-                # Keep from_screensaver animating on the real display
-                if from_alive:
-                    if from_screensaver._tick(from_tick) is not False:
-                        from_tick += 1
-                        self.__led_frame_player.play_frame(from_capture.get_current_frame())
+                    # Keep from_screensaver animating on the real display
+                    if from_alive:
+                        if from_screensaver._tick(from_tick) is not False:
+                            from_tick += 1
+                            self.__led_frame_player.play_frame(from_capture.get_current_frame())
+                        else:
+                            from_alive = False
+
+                    # One warm-up tick per frame to stay within CPU budget
+                    if to_screensaver._tick(to_tick) is not False:
+                        to_tick += 1
                     else:
-                        from_alive = False
+                        to_alive = False
 
-                # One warm-up tick per frame to stay within CPU budget
-                if to_screensaver._tick(to_tick) is not False:
-                    to_tick += 1
-                else:
-                    to_alive = False
-
-                remaining = from_sleep - (time.time() - step_start)
-                if remaining > 0:
-                    time.sleep(remaining)
+                    remaining = from_sleep - (time.time() - step_start)
+                    if remaining > 0:
+                        time.sleep(remaining)
 
             if to_alive:
-                to_frame = to_capture.get_current_frame()
+                captured = to_capture.get_current_frame()
+                if captured is not None:
+                    to_frame = captured
+                to_screensaver._warmed_up = True
 
-        # --- Transition blend ---
-        # Both screensavers are now ready. The to_screensaver's tick rate
-        # interpolates from the from_screensaver's rate to its own so the
-        # tempo change is gradual rather than an abrupt shift.
-        from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
-        to_sleep = to_screensaver._tick_sleep if to_alive else tick_sleep
-        from_accum = from_sleep if from_alive else 0
-        to_accum = from_sleep if to_alive else 0  # start at from's rhythm
+            # --- Transition blend ---
+            # Both screensavers are now ready. The to_screensaver's tick rate
+            # interpolates from the from_screensaver's rate to its own so the
+            # tempo change is gradual rather than an abrupt shift.
+            from_sleep = from_screensaver._tick_sleep if from_alive else tick_sleep
+            to_sleep = to_screensaver._tick_sleep if to_alive else tick_sleep
+            from_accum = from_sleep if from_alive else 0
+            to_accum = from_sleep if to_alive else 0  # start at from's rhythm
 
-        try:
             for step in range(1, num_steps + 1):
                 step_start = time.time()
                 progress = step / num_steps
@@ -279,9 +283,9 @@ class TransitionPlayer:
         finally:
             # Restore real frame player so play() works after transition
             if from_screensaver is not None:
-                from_screensaver._led_frame_player = self.__led_frame_player
+                from_screensaver.set_led_frame_player(self.__led_frame_player)
             if to_screensaver is not None:
-                to_screensaver._led_frame_player = self.__led_frame_player
+                to_screensaver.set_led_frame_player(self.__led_frame_player)
                 to_screensaver._warm_up_ticks = to_tick
 
     def __pick_effect(self, width, height):

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -194,17 +194,28 @@ class TransitionPlayer:
             to_tick = to_screensaver._warm_up_ticks
             to_screensaver._led_frame_player = to_capture
 
+        # Accumulators for rate-matching each screensaver's tick_sleep to the
+        # transition frame rate. Initialized at the threshold so the first
+        # step ticks immediately (continues the natural rhythm).
+        from_accum = from_screensaver._tick_sleep if from_alive else 0
+        to_accum = to_screensaver._tick_sleep if to_alive else 0
+
         try:
             for step in range(1, num_steps + 1):
-                # Tick live screensavers and grab their latest frames
-                if from_alive:
+                from_accum += tick_sleep
+                to_accum += tick_sleep
+
+                # Tick each screensaver at its natural rate
+                if from_alive and from_accum >= from_screensaver._tick_sleep:
+                    from_accum -= from_screensaver._tick_sleep
                     if from_screensaver._tick(from_tick) is not False:
                         from_tick += 1
                         from_frame = from_capture.get_current_frame()
                     else:
                         from_alive = False
 
-                if to_alive:
+                if to_alive and to_accum >= to_screensaver._tick_sleep:
+                    to_accum -= to_screensaver._tick_sleep
                     if to_screensaver._tick(to_tick) is not False:
                         to_tick += 1
                         to_frame = to_capture.get_current_frame()

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -230,7 +230,9 @@ class TransitionPlayer:
 
                 if to_alive:
                     if to_tick < warm_up_ticks:
-                        # Warm-up phase: fast-forward multiple ticks per step
+                        # Warm-up phase: fast-forward multiple ticks to build
+                        # state, but only update the displayed frame at the
+                        # screensaver's natural rate so it doesn't look sped up.
                         for _ in range(ticks_per_step):
                             if to_tick >= warm_up_ticks:
                                 break
@@ -239,7 +241,8 @@ class TransitionPlayer:
                             else:
                                 to_alive = False
                                 break
-                        if to_alive:
+                        if to_alive and to_accum >= to_screensaver._tick_sleep:
+                            to_accum -= to_screensaver._tick_sleep
                             to_frame = to_capture.get_current_frame()
                     elif to_accum >= to_screensaver._tick_sleep:
                         # Post warm-up: tick at natural rate

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -177,15 +177,15 @@ class TransitionPlayer:
             from_frame, tick_sleep,
         )
 
-        if to_alive:
-            to_screensaver.live_transition_warmed_up = True
-
         # --- Transition blend ---
-        self.__run_blend(
+        to_alive = self.__run_blend(
             from_screensaver, to_screensaver,
             from_frame, to_frame,
             from_alive, to_alive, tick_sleep,
         )
+
+        if to_alive:
+            to_screensaver.live_transition_warmed_up = True
 
     def __run_warm_up(self, from_screensaver, to_screensaver, from_frame, tick_sleep):
         """Warm up the to_screensaver while from_screensaver keeps playing.
@@ -286,6 +286,8 @@ class TransitionPlayer:
             remaining = tick_sleep - (time.time() - step_start)
             if remaining > 0:
                 time.sleep(remaining)
+
+        return to_alive
 
     def __pick_effect(self, width, height):
         # Build the full list including factory effects

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -171,7 +171,6 @@ class TransitionPlayer:
         if from_frame.ndim == 2:
             from_frame = np.stack([from_frame] * 3, axis=-1)
 
-
         # --- Warm-up phase ---
         from_frame, to_frame, from_alive, to_alive = self.__run_warm_up(
             from_screensaver, to_screensaver,

--- a/pifi/screensaver/transitionplayer.py
+++ b/pifi/screensaver/transitionplayer.py
@@ -230,9 +230,10 @@ class TransitionPlayer:
 
                 if to_alive:
                     if to_tick < warm_up_ticks:
-                        # Warm-up phase: fast-forward multiple ticks to build
-                        # state, but only update the displayed frame at the
-                        # screensaver's natural rate so it doesn't look sped up.
+                        # Warm-up phase: fast-forward to build internal state
+                        # without updating the displayed frame. Early in the
+                        # transition the to_frame is barely visible (low blend
+                        # progress), so holding it static is imperceptible.
                         for _ in range(ticks_per_step):
                             if to_tick >= warm_up_ticks:
                                 break
@@ -241,8 +242,8 @@ class TransitionPlayer:
                             else:
                                 to_alive = False
                                 break
-                        if to_alive and to_accum >= to_screensaver._tick_sleep:
-                            to_accum -= to_screensaver._tick_sleep
+                        # Grab the warmed-up frame once warm-up completes
+                        if to_alive and to_tick >= warm_up_ticks:
                             to_frame = to_capture.get_current_frame()
                     elif to_accum >= to_screensaver._tick_sleep:
                         # Post warm-up: tick at natural rate

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -176,7 +176,7 @@ class UnknownPleasures(Screensaver):
         self.__init_colors()
         self.__time = 0.0
 
-    def _tick(self, tick):
+    def _tick(self):
         """Advance time and render one frame."""
         self.__time += self.__wave_speed
         self.__render()

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -46,6 +46,5 @@ class VideoScreensaver(Screensaver):
     def get_description(cls) -> str:
         return 'Saved video playback'
 
-    @classmethod
-    def supports_live_transition(cls) -> bool:
+    def supports_live_transition(self) -> bool:
         return False

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -45,3 +45,7 @@ class VideoScreensaver(Screensaver):
     @classmethod
     def get_description(cls) -> str:
         return 'Saved video playback'
+
+    @classmethod
+    def supports_live_transition(cls) -> bool:
+        return False

--- a/pifi/screensaver/videoscreensaver.py
+++ b/pifi/screensaver/videoscreensaver.py
@@ -19,7 +19,7 @@ class VideoScreensaver(Screensaver):
         os.makedirs(save_dir, exist_ok=True)
         return save_dir
 
-    def _tick(self, tick):
+    def _tick(self):
         if not self.video_list:
             return False
 

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -35,7 +35,7 @@ class WaveInterference(Screensaver):
     def _setup(self):
         self.__reset()
 
-    def _tick(self, tick):
+    def _tick(self):
         self.__update_sources()
         self.__render()
 

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -140,7 +140,7 @@ class Wfmu(Screensaver):
         """Start initial data fetch."""
         self.__start_background_fetch()
 
-    def _tick(self, tick):
+    def _tick(self):
         """Fetch new data if needed and render one frame."""
         current_time = time.time()
         if current_time - self.__last_update > self.__update_interval:

--- a/tests/test_screensaver_interface.py
+++ b/tests/test_screensaver_interface.py
@@ -181,13 +181,13 @@ class TestScreensaverInterface(unittest.TestCase):
 
                 # Check if the base class __init__ was called by verifying the flag
                 self.assertTrue(
-                    hasattr(instance, '_screensaver_base_init_called'),
+                    hasattr(instance, '_Screensaver__screensaver_base_init_called'),
                     f"{screensaver_id} does not call super().__init__() - "
-                    f"missing _screensaver_base_init_called attribute"
+                    f"missing __screensaver_base_init_called attribute"
                 )
                 self.assertTrue(
-                    instance._screensaver_base_init_called,
-                    f"{screensaver_id}._screensaver_base_init_called is not True"
+                    instance._Screensaver__screensaver_base_init_called,
+                    f"{screensaver_id}.__screensaver_base_init_called is not True"
                 )
 
 

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -156,17 +156,17 @@ class TestTickSleepResolution(unittest.TestCase):
     def test_default_tick_sleep(self):
         """When tick_sleep is set to 0.05 in config (as in default_config.json), it's used."""
         ss = self._make({'screensavers': {'tick_sleep': 0.05}})
-        self.assertEqual(ss.tick_sleep(), 0.05)
+        self.assertEqual(ss.get_tick_sleep(), 0.05)
 
     def test_tick_sleep_absent_means_zero(self):
         """When tick_sleep key is absent from config entirely, it's 0."""
         ss = self._make({'screensavers': {}})
-        self.assertEqual(ss.tick_sleep(), 0)
+        self.assertEqual(ss.get_tick_sleep(), 0)
 
     def test_global_tick_sleep_overrides_default(self):
         """Global screensavers.tick_sleep overrides the hardcoded default."""
         ss = self._make({'screensavers': {'tick_sleep': 0.1}})
-        self.assertEqual(ss.tick_sleep(), 0.1)
+        self.assertEqual(ss.get_tick_sleep(), 0.1)
 
     def test_per_screensaver_tick_sleep_overrides_global(self):
         """Per-screensaver tick_sleep overrides the global tick_sleep."""
@@ -176,7 +176,7 @@ class TestTickSleepResolution(unittest.TestCase):
                 'configs': {'stub': {'tick_sleep': 0.02}},
             }
         })
-        self.assertEqual(ss.tick_sleep(), 0.02)
+        self.assertEqual(ss.get_tick_sleep(), 0.02)
 
     def test_no_per_screensaver_tick_sleep_falls_back_to_global(self):
         """When per-screensaver tick_sleep is absent, global is used."""
@@ -186,7 +186,7 @@ class TestTickSleepResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': 60}},
             }
         })
-        self.assertEqual(ss.tick_sleep(), 0.08)
+        self.assertEqual(ss.get_tick_sleep(), 0.08)
 
     def test_per_screensaver_tick_sleep_null_falls_back_to_global(self):
         """Per-screensaver tick_sleep of null falls back to global tick_sleep."""
@@ -196,12 +196,12 @@ class TestTickSleepResolution(unittest.TestCase):
                 'configs': {'stub': {'tick_sleep': None}},
             }
         })
-        self.assertEqual(ss.tick_sleep(), 0.08)
+        self.assertEqual(ss.get_tick_sleep(), 0.08)
 
     def test_global_tick_sleep_none_means_zero(self):
         """Global tick_sleep of None means 0 (no sleep between ticks)."""
         ss = self._make({'screensavers': {'tick_sleep': None}})
-        self.assertEqual(ss.tick_sleep(), 0)
+        self.assertEqual(ss.get_tick_sleep(), 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -27,7 +27,7 @@ from pifi.screensaver.screensaver import Screensaver
 
 # Concrete subclass for testing
 class _StubScreensaver(Screensaver):
-    def _tick(self, tick):
+    def _tick(self):
         pass
 
     @classmethod

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -156,17 +156,17 @@ class TestTickSleepResolution(unittest.TestCase):
     def test_default_tick_sleep(self):
         """When tick_sleep is set to 0.05 in config (as in default_config.json), it's used."""
         ss = self._make({'screensavers': {'tick_sleep': 0.05}})
-        self.assertEqual(ss._tick_sleep, 0.05)
+        self.assertEqual(ss.tick_sleep(), 0.05)
 
     def test_tick_sleep_absent_means_zero(self):
         """When tick_sleep key is absent from config entirely, it's 0."""
         ss = self._make({'screensavers': {}})
-        self.assertEqual(ss._tick_sleep, 0)
+        self.assertEqual(ss.tick_sleep(), 0)
 
     def test_global_tick_sleep_overrides_default(self):
         """Global screensavers.tick_sleep overrides the hardcoded default."""
         ss = self._make({'screensavers': {'tick_sleep': 0.1}})
-        self.assertEqual(ss._tick_sleep, 0.1)
+        self.assertEqual(ss.tick_sleep(), 0.1)
 
     def test_per_screensaver_tick_sleep_overrides_global(self):
         """Per-screensaver tick_sleep overrides the global tick_sleep."""
@@ -176,7 +176,7 @@ class TestTickSleepResolution(unittest.TestCase):
                 'configs': {'stub': {'tick_sleep': 0.02}},
             }
         })
-        self.assertEqual(ss._tick_sleep, 0.02)
+        self.assertEqual(ss.tick_sleep(), 0.02)
 
     def test_no_per_screensaver_tick_sleep_falls_back_to_global(self):
         """When per-screensaver tick_sleep is absent, global is used."""
@@ -186,7 +186,7 @@ class TestTickSleepResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': 60}},
             }
         })
-        self.assertEqual(ss._tick_sleep, 0.08)
+        self.assertEqual(ss.tick_sleep(), 0.08)
 
     def test_per_screensaver_tick_sleep_null_falls_back_to_global(self):
         """Per-screensaver tick_sleep of null falls back to global tick_sleep."""
@@ -196,12 +196,12 @@ class TestTickSleepResolution(unittest.TestCase):
                 'configs': {'stub': {'tick_sleep': None}},
             }
         })
-        self.assertEqual(ss._tick_sleep, 0.08)
+        self.assertEqual(ss.tick_sleep(), 0.08)
 
     def test_global_tick_sleep_none_means_zero(self):
         """Global tick_sleep of None means 0 (no sleep between ticks)."""
         ss = self._make({'screensavers': {'tick_sleep': None}})
-        self.assertEqual(ss._tick_sleep, 0)
+        self.assertEqual(ss.tick_sleep(), 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -62,17 +62,17 @@ class TestTimeoutResolution(unittest.TestCase):
     def test_default_timeout_is_120(self):
         """When timeout is set to 120 in config (as in default_config.json), it's used."""
         ss = self._make({'screensavers': {'timeout': 120}})
-        self.assertEqual(ss._timeout, 120)
+        self.assertEqual(ss._Screensaver__timeout, 120)
 
     def test_timeout_absent_means_unlimited(self):
         """When timeout key is absent from config entirely, it's unlimited."""
         ss = self._make({'screensavers': {}})
-        self.assertEqual(ss._timeout, 0)
+        self.assertEqual(ss._Screensaver__timeout, 0)
 
     def test_global_timeout_overrides_default(self):
         """Global screensavers.timeout overrides the hardcoded default."""
         ss = self._make({'screensavers': {'timeout': 60}})
-        self.assertEqual(ss._timeout, 60)
+        self.assertEqual(ss._Screensaver__timeout, 60)
 
     def test_per_screensaver_timeout_overrides_global(self):
         """Per-screensaver timeout overrides the global timeout."""
@@ -82,7 +82,7 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': 30}},
             }
         })
-        self.assertEqual(ss._timeout, 30)
+        self.assertEqual(ss._Screensaver__timeout, 30)
 
     def test_no_per_screensaver_timeout_falls_back_to_global(self):
         """When per-screensaver timeout is absent, global timeout is used."""
@@ -92,20 +92,20 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'tick_sleep': 0.01}},
             }
         })
-        self.assertEqual(ss._timeout, 90)
+        self.assertEqual(ss._Screensaver__timeout, 90)
 
     def test_timeout_zero_means_unlimited(self):
         """Timeout of 0 means unlimited — _is_past_timeout always returns False."""
         ss = self._make({'screensavers': {'timeout': 0}})
-        self.assertEqual(ss._timeout, 0)
-        ss._start_time = time.time() - 99999
+        self.assertEqual(ss._Screensaver__timeout, 0)
+        ss._Screensaver__start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
     def test_global_timeout_none_means_unlimited(self):
         """Global timeout of None means unlimited (same as 0)."""
         ss = self._make({'screensavers': {'timeout': None}})
-        self.assertEqual(ss._timeout, 0)
-        ss._start_time = time.time() - 99999
+        self.assertEqual(ss._Screensaver__timeout, 0)
+        ss._Screensaver__start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
     def test_per_screensaver_timeout_null_falls_back_to_global(self):
@@ -116,7 +116,7 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': None}},
             }
         })
-        self.assertEqual(ss._timeout, 60)
+        self.assertEqual(ss._Screensaver__timeout, 60)
 
     def test_per_screensaver_timeout_zero_means_unlimited(self):
         """Per-screensaver timeout of 0 means unlimited, not fallback."""
@@ -126,20 +126,20 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': 0}},
             }
         })
-        self.assertEqual(ss._timeout, 0)
-        ss._start_time = time.time() - 99999
+        self.assertEqual(ss._Screensaver__timeout, 0)
+        ss._Screensaver__start_time = time.time() - 99999
         self.assertFalse(ss._is_past_timeout())
 
     def test_positive_timeout_expires(self):
         """A positive timeout causes _is_past_timeout to return True after elapsed time."""
         ss = self._make({'screensavers': {'timeout': 10}})
-        ss._start_time = time.time() - 11
+        ss._Screensaver__start_time = time.time() - 11
         self.assertTrue(ss._is_past_timeout())
 
     def test_positive_timeout_not_expired(self):
         """A positive timeout returns False before the time elapses."""
         ss = self._make({'screensavers': {'timeout': 10}})
-        ss._start_time = time.time()
+        ss._Screensaver__start_time = time.time()
         self.assertFalse(ss._is_past_timeout())
 
 

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -417,8 +417,8 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
         Config._Config__config = copy.deepcopy(BASE_CONFIG)
 
     def test_to_still_warms_up(self):
-        """If from_screensaver dies during warm-up, the to_screensaver
-        should still complete warm-up successfully."""
+        """If from_screensaver dies during warm-up, warm-up ends early
+        and jumps straight to the blend phase."""
         player = MagicMock()
         player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
         tp = TransitionPlayer(player)
@@ -429,6 +429,9 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
         self.assertTrue(to_ss.warmed_up)
+        # Warm-up should have ended early — to_ss should have far fewer
+        # warm-up ticks than the configured 60.
+        self.assertLess(to_ss.warm_up_ticks, 10)
 
 
 class TestStaticTransition(unittest.TestCase):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -197,12 +197,12 @@ class TestLastTick(unittest.TestCase):
 
     def test_initialized_to_zero(self):
         ss = _StubScreensaver(led_frame_player=None)
-        self.assertEqual(ss.last_tick(), 0)
+        self.assertEqual(ss.get_last_tick(), 0)
 
     def test_updated_after_play(self):
         ss = _FailingTickScreensaver(led_frame_player=None, fail_after=5)
         ss.play()
-        self.assertEqual(ss.last_tick(), 5)
+        self.assertEqual(ss.get_last_tick(), 5)
 
 
 class TestAutoTeardown(unittest.TestCase):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -6,7 +6,7 @@ Covers:
 - supports_live_transition() contract
 - last_tick initialization and updates
 - Frame player restoration after transition (including on exception)
-- transition_warmed_up state when warm-up fails
+- live_transition_warmed_up state when warm-up fails
 - auto_teardown=False skips teardown
 - warm_up_ticks=0 captures to_frame from _setup()
 - render_tick() captures frames without displaying
@@ -315,7 +315,7 @@ class TestTransitionFramePlayerIntegrity(unittest.TestCase):
 
 
 class TestWarmedUpState(unittest.TestCase):
-    """Test that transition_warmed_up reflects whether warm-up actually succeeded."""
+    """Test that live_transition_warmed_up reflects whether warm-up actually succeeded."""
 
     def setUp(self):
         Config._Config__is_loaded = True
@@ -326,19 +326,19 @@ class TestWarmedUpState(unittest.TestCase):
         player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
         return player
 
-    def test_transition_warmed_up_true_after_successful_warmup(self):
+    def test_live_transition_warmed_up_true_after_successful_warmup(self):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
         from_ss = _StubScreensaver(led_frame_player=None)
         to_ss = _StubScreensaver(led_frame_player=None)
-        self.assertFalse(to_ss.transition_warmed_up)
+        self.assertFalse(to_ss.live_transition_warmed_up)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-        self.assertTrue(to_ss.transition_warmed_up)
+        self.assertTrue(to_ss.live_transition_warmed_up)
 
-    def test_transition_warmed_up_false_when_tick_returns_false_during_warmup(self):
-        """If _tick() returns False during warm-up, transition_warmed_up stays False."""
+    def test_live_transition_warmed_up_false_when_tick_returns_false_during_warmup(self):
+        """If _tick() returns False during warm-up, live_transition_warmed_up stays False."""
         player = self._make_player()
         tp = TransitionPlayer(player)
 
@@ -348,7 +348,7 @@ class TestWarmedUpState(unittest.TestCase):
         to_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-        self.assertFalse(to_ss.transition_warmed_up)
+        self.assertFalse(to_ss.live_transition_warmed_up)
 
 
 class TestWarmUpTicksZero(unittest.TestCase):
@@ -409,10 +409,10 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
-        self.assertTrue(to_ss.transition_warmed_up)
+        self.assertTrue(to_ss.live_transition_warmed_up)
         # Warm-up should have ended early — to_ss should have far fewer
         # warm-up ticks than the configured warm_up_ticks.
-        self.assertLess(to_ss.transition_warm_up_ticks, 10)
+        self.assertLess(to_ss.live_transition_warm_up_ticks, 10)
 
 
 class TestStaticTransition(unittest.TestCase):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
-from pifi.screensaver.screensaver import Screensaver, FrameCapture
+from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver.transitionplayer import TransitionPlayer
 
 

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -16,7 +16,7 @@ import copy
 import unittest
 import sys
 import os
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock
 
 import numpy as np
 

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -394,8 +394,10 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
     """Test that to_screensaver still warms up when from dies during warm-up."""
 
     def setUp(self):
+        config = copy.deepcopy(BASE_CONFIG)
+        config['screensavers']['transitions']['warm_up_ticks'] = 60
         Config._Config__is_loaded = True
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+        Config._Config__config = config
 
     def test_to_still_warms_up(self):
         """If from_screensaver dies during warm-up, warm-up ends early
@@ -410,9 +412,9 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
         self.assertTrue(to_ss.live_transition_warmed_up)
-        # Warm-up should have ended early — to_ss should have far fewer
-        # warm-up ticks than the configured warm_up_ticks.
-        self.assertLess(to_ss.live_transition_warm_up_ticks, 10)
+        # Warm-up should have ended early (from died after 1 tick), so
+        # total ticks (warm-up + blend) should be far less than 60.
+        self.assertLess(to_ss.live_transition_warm_up_ticks, 30)
 
 
 class TestStaticTransition(unittest.TestCase):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -167,25 +167,10 @@ class TestSupportsLiveTransition(unittest.TestCase):
         Config._Config__is_loaded = True
         Config._Config__config = copy.deepcopy(BASE_CONFIG)
 
-    def test_default_is_true(self):
-        ss = _StubScreensaver(led_frame_player=None)
-        self.assertTrue(ss.supports_live_transition())
-
     def test_video_screensaver_returns_false(self):
         from pifi.screensaver.videoscreensaver import VideoScreensaver
         ss = VideoScreensaver(led_frame_player=None)
         self.assertFalse(ss.supports_live_transition())
-
-    def test_regular_screensavers_return_true(self):
-        from pifi.screensaver.screensavermanager import ScreensaverManager
-        from pifi.screensaver.videoscreensaver import VideoScreensaver
-        for sid, cls in ScreensaverManager.SCREENSAVER_CLASSES.items():
-            with self.subTest(screensaver=sid):
-                instance = cls(led_frame_player=None)
-                if cls is VideoScreensaver:
-                    self.assertFalse(instance.supports_live_transition())
-                else:
-                    self.assertTrue(instance.supports_live_transition())
 
 
 class TestLastTick(unittest.TestCase):
@@ -194,10 +179,6 @@ class TestLastTick(unittest.TestCase):
     def setUp(self):
         Config._Config__is_loaded = True
         Config._Config__config = copy.deepcopy(BASE_CONFIG)
-
-    def test_initialized_to_zero(self):
-        ss = _StubScreensaver(led_frame_player=None)
-        self.assertEqual(ss.get_last_tick(), 0)
 
     def test_updated_after_play(self):
         ss = _FailingTickScreensaver(led_frame_player=None, fail_after=5)

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+Unit tests for screensaver transition behavior.
+
+Covers:
+- supports_live_transition() contract
+- _last_tick initialization and updates
+- Frame player restoration after transition (including on exception)
+- _warmed_up state when warm-up fails
+- auto_teardown=False skips teardown
+- warm_up_ticks=0 captures to_frame from _setup()
+"""
+
+import copy
+import unittest
+import sys
+import os
+from unittest.mock import MagicMock, patch, call
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pifi.config import Config
+from pifi.led.ledframeplayer import LedFramePlayer
+from pifi.screensaver.screensaver import Screensaver, FrameCapture
+from pifi.screensaver.transitionplayer import TransitionPlayer
+
+
+# --- Stub screensavers with controllable behavior ---
+
+def _render_frame(screensaver, value=128):
+    """Helper: render a solid-color frame to the screensaver's frame player."""
+    w = Config.get_or_throw('leds.display_width')
+    h = Config.get_or_throw('leds.display_height')
+    screensaver._led_frame_player.play_frame(
+        np.full([h, w, 3], value, dtype=np.uint8)
+    )
+
+
+class _StubScreensaver(Screensaver):
+    """Basic stub that renders a frame each tick."""
+
+    def _tick(self, tick):
+        _render_frame(self)
+
+    @classmethod
+    def get_id(cls):
+        return 'stub'
+
+    @classmethod
+    def get_name(cls):
+        return 'Stub'
+
+    @classmethod
+    def get_description(cls):
+        return 'Test stub'
+
+
+class _FailingTickScreensaver(Screensaver):
+    """Stub whose _tick() returns False after a set number of ticks."""
+
+    def __init__(self, led_frame_player=None, fail_after=0):
+        super().__init__(led_frame_player)
+        self._fail_after = fail_after
+
+    def _tick(self, tick):
+        if tick >= self._fail_after:
+            return False
+        _render_frame(self)
+
+    @classmethod
+    def get_id(cls):
+        return 'failing_tick'
+
+    @classmethod
+    def get_name(cls):
+        return 'FailingTick'
+
+    @classmethod
+    def get_description(cls):
+        return 'Fails after N ticks'
+
+
+class _ExplodingTickScreensaver(Screensaver):
+    """Stub whose _tick() raises an exception after a set number of ticks."""
+
+    def __init__(self, led_frame_player=None, explode_after=0):
+        super().__init__(led_frame_player)
+        self._explode_after = explode_after
+
+    def _tick(self, tick):
+        if tick >= self._explode_after:
+            raise RuntimeError("boom")
+        _render_frame(self)
+
+    @classmethod
+    def get_id(cls):
+        return 'exploding_tick'
+
+    @classmethod
+    def get_name(cls):
+        return 'ExplodingTick'
+
+    @classmethod
+    def get_description(cls):
+        return 'Raises after N ticks'
+
+
+class _RenderingSetupScreensaver(Screensaver):
+    """Stub that renders a frame during _setup()."""
+
+    def _setup(self):
+        frame = np.full([self._height, self._width, 3], 42, dtype=np.uint8)
+        self._led_frame_player.play_frame(frame)
+
+    def __init__(self, led_frame_player=None):
+        super().__init__(led_frame_player)
+        self._width = Config.get_or_throw('leds.display_width')
+        self._height = Config.get_or_throw('leds.display_height')
+
+    def _tick(self, tick):
+        pass
+
+    @classmethod
+    def get_id(cls):
+        return 'rendering_setup'
+
+    @classmethod
+    def get_name(cls):
+        return 'RenderingSetup'
+
+    @classmethod
+    def get_description(cls):
+        return 'Renders during _setup()'
+
+
+BASE_CONFIG = {
+    'leds': {
+        'driver': 'apa102',
+        'display_width': 4,
+        'display_height': 4,
+    },
+    'screensavers': {
+        'transitions': {
+            'enabled': True,
+            'duration': 0.1,
+            'tick_sleep': 0.01,
+            'warm_up_ticks': 3,
+        },
+    },
+}
+
+
+def setUpModule():
+    LedFramePlayer.__init__ = lambda self: None
+    LedFramePlayer.play_frame = MagicMock()
+    LedFramePlayer.fade_to_frame = MagicMock()
+    LedFramePlayer.get_current_frame = MagicMock(return_value=np.zeros([4, 4, 3], np.uint8))
+
+
+class TestSupportsLiveTransition(unittest.TestCase):
+    """Test the supports_live_transition() class method."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def test_default_is_true(self):
+        self.assertTrue(_StubScreensaver.supports_live_transition())
+
+    def test_video_screensaver_returns_false(self):
+        from pifi.screensaver.videoscreensaver import VideoScreensaver
+        self.assertFalse(VideoScreensaver.supports_live_transition())
+
+    def test_regular_screensavers_return_true(self):
+        from pifi.screensaver.screensavermanager import ScreensaverManager
+        from pifi.screensaver.videoscreensaver import VideoScreensaver
+        for sid, cls in ScreensaverManager.SCREENSAVER_CLASSES.items():
+            with self.subTest(screensaver=sid):
+                if cls is VideoScreensaver:
+                    self.assertFalse(cls.supports_live_transition())
+                else:
+                    self.assertTrue(cls.supports_live_transition())
+
+
+class TestLastTick(unittest.TestCase):
+    """Test _last_tick initialization and updates."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def test_initialized_to_zero(self):
+        ss = _StubScreensaver(led_frame_player=None)
+        self.assertEqual(ss._last_tick, 0)
+
+    def test_updated_after_play(self):
+        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=5)
+        ss.play()
+        self.assertEqual(ss._last_tick, 5)
+
+
+class TestAutoTeardown(unittest.TestCase):
+    """Test auto_teardown parameter of play()."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def test_auto_teardown_true_calls_teardown(self):
+        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        ss._teardown = MagicMock()
+        ss.play(auto_teardown=True)
+        ss._teardown.assert_called_once()
+
+    def test_auto_teardown_false_skips_teardown(self):
+        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        ss._teardown = MagicMock()
+        ss.play(auto_teardown=False)
+        ss._teardown.assert_not_called()
+
+
+class TestFramePlayerRestoration(unittest.TestCase):
+    """Test that frame players are restored after transition, even on exception."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def _make_player(self):
+        player = MagicMock()
+        player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
+        return player
+
+    def test_restored_after_normal_transition(self):
+        player = self._make_player()
+        tp = TransitionPlayer(player)
+
+        from_ss = _StubScreensaver(led_frame_player=None)
+        to_ss = _StubScreensaver(led_frame_player=None)
+
+        tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
+
+        # Both should have the real player restored
+        self.assertIs(from_ss._led_frame_player, player)
+        self.assertIs(to_ss._led_frame_player, player)
+
+    def test_restored_after_exception_in_warmup(self):
+        """If to_screensaver raises during warm-up, frame players are still restored."""
+        player = self._make_player()
+        tp = TransitionPlayer(player)
+
+        from_ss = _StubScreensaver(led_frame_player=None)
+
+        # Explodes on tick 0 — during warm-up phase
+        to_ss = _ExplodingTickScreensaver(led_frame_player=None, explode_after=0)
+
+        with self.assertRaises(RuntimeError):
+            tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
+
+        self.assertIs(from_ss._led_frame_player, player)
+        self.assertIs(to_ss._led_frame_player, player)
+
+    def test_restored_after_exception_in_blend(self):
+        """If to_screensaver raises during blend, frame players are still restored."""
+        player = self._make_player()
+        tp = TransitionPlayer(player)
+
+        from_ss = _StubScreensaver(led_frame_player=None)
+
+        # Survives warm-up (3 ticks) but explodes during blend
+        to_ss = _ExplodingTickScreensaver(led_frame_player=None, explode_after=5)
+
+        with self.assertRaises(RuntimeError):
+            tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
+
+        self.assertIs(from_ss._led_frame_player, player)
+        self.assertIs(to_ss._led_frame_player, player)
+
+
+class TestWarmedUpState(unittest.TestCase):
+    """Test that _warmed_up reflects whether warm-up actually succeeded."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def _make_player(self):
+        player = MagicMock()
+        player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
+        return player
+
+    def test_warmed_up_true_after_successful_warmup(self):
+        player = self._make_player()
+        tp = TransitionPlayer(player)
+
+        from_ss = _StubScreensaver(led_frame_player=None)
+        to_ss = _StubScreensaver(led_frame_player=None)
+        self.assertFalse(to_ss._warmed_up)
+
+        tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
+        self.assertTrue(to_ss._warmed_up)
+
+    def test_warmed_up_false_when_tick_returns_false_during_warmup(self):
+        """If _tick() returns False during warm-up, _warmed_up stays False."""
+        player = self._make_player()
+        tp = TransitionPlayer(player)
+
+        from_ss = _StubScreensaver(led_frame_player=None)
+
+        # Fails immediately during warm-up
+        to_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+
+        tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
+        self.assertFalse(to_ss._warmed_up)
+
+
+class TestWarmUpTicksZero(unittest.TestCase):
+    """Test that warm_up_ticks=0 still captures to_frame from _setup()."""
+
+    def setUp(self):
+        config = copy.deepcopy(BASE_CONFIG)
+        config['screensavers']['transitions']['warm_up_ticks'] = 0
+        Config._Config__is_loaded = True
+        Config._Config__config = config
+
+    def _make_player(self):
+        player = MagicMock()
+        player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
+        return player
+
+    def test_setup_frame_used_in_blend(self):
+        """When warm_up_ticks=0, the frame rendered by _setup() should be
+        used as to_frame in the blend, not a black frame."""
+        player = self._make_player()
+        tp = TransitionPlayer(player)
+
+        to_ss = _RenderingSetupScreensaver(led_frame_player=None)
+
+        # Run transition with only to_screensaver (from_frame will be black)
+        tp.play_transition(to_screensaver=to_ss)
+
+        # Check that play_frame was called with non-zero blended frames.
+        # _RenderingSetupScreensaver renders value 42 in _setup(), so the
+        # blended frames should contain non-zero values (progress > 0).
+        frames_played = [
+            c.args[0] for c in player.play_frame.call_args_list
+        ]
+        # The last frame (progress=1.0) should be entirely the to_frame
+        last_frame = frames_played[-1]
+        np.testing.assert_array_equal(
+            last_frame,
+            np.full([4, 4, 3], 42, dtype=np.uint8),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -409,6 +409,28 @@ class TestWarmUpTicksZero(unittest.TestCase):
         )
 
 
+class TestFromDiesDuringWarmup(unittest.TestCase):
+    """Test that to_screensaver still warms up when from dies during warm-up."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def test_to_still_warms_up(self):
+        """If from_screensaver dies during warm-up, the to_screensaver
+        should still complete warm-up successfully."""
+        player = MagicMock()
+        player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
+        tp = TransitionPlayer(player)
+
+        from_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=1)
+        to_ss = _StubScreensaver(led_frame_player=None)
+
+        tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
+
+        self.assertTrue(to_ss.warmed_up)
+
+
 class TestStaticTransition(unittest.TestCase):
     """Test static-frame transitions (no live screensavers)."""
 
@@ -426,6 +448,35 @@ class TestStaticTransition(unittest.TestCase):
 
         # Should have called play_frame for each blend step
         self.assertGreater(player.play_frame.call_count, 0)
+
+    def test_static_transition_ends_at_black(self):
+        """The last frame of a static transition should be black."""
+        player = MagicMock()
+        player.get_current_frame.return_value = np.full([4, 4, 3], 200, np.uint8)
+        tp = TransitionPlayer(player)
+
+        tp.play_transition()
+
+        last_frame = player.play_frame.call_args_list[-1].args[0]
+        np.testing.assert_array_equal(
+            last_frame,
+            np.zeros([4, 4, 3], dtype=np.uint8),
+        )
+
+    def test_static_transition_from_none(self):
+        """Static transition when get_current_frame returns None should not crash."""
+        player = MagicMock()
+        player.get_current_frame.return_value = None
+        tp = TransitionPlayer(player)
+
+        tp.play_transition()
+
+        self.assertGreater(player.play_frame.call_count, 0)
+        last_frame = player.play_frame.call_args_list[-1].args[0]
+        np.testing.assert_array_equal(
+            last_frame,
+            np.zeros([4, 4, 3], dtype=np.uint8),
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -4,11 +4,12 @@ Unit tests for screensaver transition behavior.
 
 Covers:
 - supports_live_transition() contract
-- _last_tick initialization and updates
+- last_tick initialization and updates
 - Frame player restoration after transition (including on exception)
-- _warmed_up state when warm-up fails
+- warmed_up state when warm-up fails
 - auto_teardown=False skips teardown
 - warm_up_ticks=0 captures to_frame from _setup()
+- render_tick() captures frames without displaying
 """
 
 import copy
@@ -120,7 +121,7 @@ class _RenderingSetupScreensaver(Screensaver):
         self._height = Config.get_or_throw('leds.display_height')
 
     def _tick(self, tick):
-        pass
+        _render_frame(self, value=42)
 
     @classmethod
     def get_id(cls):
@@ -160,32 +161,35 @@ def setUpModule():
 
 
 class TestSupportsLiveTransition(unittest.TestCase):
-    """Test the supports_live_transition() class method."""
+    """Test the supports_live_transition() method."""
 
     def setUp(self):
         Config._Config__is_loaded = True
         Config._Config__config = copy.deepcopy(BASE_CONFIG)
 
     def test_default_is_true(self):
-        self.assertTrue(_StubScreensaver.supports_live_transition())
+        ss = _StubScreensaver(led_frame_player=None)
+        self.assertTrue(ss.supports_live_transition())
 
     def test_video_screensaver_returns_false(self):
         from pifi.screensaver.videoscreensaver import VideoScreensaver
-        self.assertFalse(VideoScreensaver.supports_live_transition())
+        ss = VideoScreensaver(led_frame_player=None)
+        self.assertFalse(ss.supports_live_transition())
 
     def test_regular_screensavers_return_true(self):
         from pifi.screensaver.screensavermanager import ScreensaverManager
         from pifi.screensaver.videoscreensaver import VideoScreensaver
         for sid, cls in ScreensaverManager.SCREENSAVER_CLASSES.items():
             with self.subTest(screensaver=sid):
+                instance = cls(led_frame_player=None)
                 if cls is VideoScreensaver:
-                    self.assertFalse(cls.supports_live_transition())
+                    self.assertFalse(instance.supports_live_transition())
                 else:
-                    self.assertTrue(cls.supports_live_transition())
+                    self.assertTrue(instance.supports_live_transition())
 
 
 class TestLastTick(unittest.TestCase):
-    """Test _last_tick initialization and updates."""
+    """Test last_tick initialization and updates."""
 
     def setUp(self):
         Config._Config__is_loaded = True
@@ -193,12 +197,12 @@ class TestLastTick(unittest.TestCase):
 
     def test_initialized_to_zero(self):
         ss = _StubScreensaver(led_frame_player=None)
-        self.assertEqual(ss._last_tick, 0)
+        self.assertEqual(ss.last_tick(), 0)
 
     def test_updated_after_play(self):
         ss = _FailingTickScreensaver(led_frame_player=None, fail_after=5)
         ss.play()
-        self.assertEqual(ss._last_tick, 5)
+        self.assertEqual(ss.last_tick(), 5)
 
 
 class TestAutoTeardown(unittest.TestCase):
@@ -221,8 +225,72 @@ class TestAutoTeardown(unittest.TestCase):
         ss._teardown.assert_not_called()
 
 
-class TestFramePlayerRestoration(unittest.TestCase):
-    """Test that frame players are restored after transition, even on exception."""
+class TestRenderTick(unittest.TestCase):
+    """Test render_tick() captures frames without displaying."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def test_returns_frame_and_alive(self):
+        ss = _StubScreensaver(led_frame_player=None)
+        frame, alive = ss.render_tick(0)
+        self.assertTrue(alive)
+        self.assertIsNotNone(frame)
+        self.assertEqual(frame.shape, (4, 4, 3))
+
+    def test_does_not_render_to_real_player(self):
+        """render_tick() should not call play_frame on the real LedFramePlayer."""
+        player = MagicMock()
+        player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
+
+        ss = _StubScreensaver(led_frame_player=player)
+        player.play_frame.reset_mock()
+
+        frame, alive = ss.render_tick(0)
+        player.play_frame.assert_not_called()
+
+    def test_restores_frame_player_after_tick(self):
+        player = MagicMock()
+        ss = _StubScreensaver(led_frame_player=player)
+        ss.render_tick(0)
+        self.assertIs(ss._led_frame_player, player)
+
+    def test_restores_frame_player_on_exception(self):
+        player = MagicMock()
+        ss = _ExplodingTickScreensaver(led_frame_player=player, explode_after=0)
+        with self.assertRaises(RuntimeError):
+            ss.render_tick(0)
+        self.assertIs(ss._led_frame_player, player)
+
+    def test_returns_false_alive_when_tick_stops(self):
+        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        frame, alive = ss.render_tick(0)
+        self.assertFalse(alive)
+
+    def test_calls_setup_on_first_invocation(self):
+        ss = _RenderingSetupScreensaver(led_frame_player=None)
+        self.assertFalse(ss._is_set_up)
+        frame, alive = ss.render_tick(0)
+        self.assertTrue(ss._is_set_up)
+
+    def test_setup_frame_captured_not_displayed(self):
+        """Frames rendered during _setup() should be captured, not sent to real display."""
+        player = MagicMock()
+        player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
+
+        ss = _RenderingSetupScreensaver(led_frame_player=player)
+        player.play_frame.reset_mock()
+
+        frame, alive = ss.render_tick(0)
+        # The real player should NOT have received any frames
+        player.play_frame.assert_not_called()
+        # But we should have captured a frame
+        self.assertIsNotNone(frame)
+
+
+class TestTransitionFramePlayerIntegrity(unittest.TestCase):
+    """Test that frame players are never corrupted by transitions."""
 
     def setUp(self):
         Config._Config__is_loaded = True
@@ -233,54 +301,40 @@ class TestFramePlayerRestoration(unittest.TestCase):
         player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
         return player
 
-    def test_restored_after_normal_transition(self):
+    def test_screensaver_player_unchanged_after_transition(self):
+        """Both screensavers should still have their original _led_frame_player
+        after the transition completes (render_tick restores per-call)."""
         player = self._make_player()
         tp = TransitionPlayer(player)
 
         from_ss = _StubScreensaver(led_frame_player=None)
         to_ss = _StubScreensaver(led_frame_player=None)
+        from_original = from_ss._led_frame_player
+        to_original = to_ss._led_frame_player
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
-        # Both should have the real player restored
-        self.assertIs(from_ss._led_frame_player, player)
-        self.assertIs(to_ss._led_frame_player, player)
+        self.assertIs(from_ss._led_frame_player, from_original)
+        self.assertIs(to_ss._led_frame_player, to_original)
 
-    def test_restored_after_exception_in_warmup(self):
-        """If to_screensaver raises during warm-up, frame players are still restored."""
+    def test_screensaver_player_intact_after_exception(self):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
         from_ss = _StubScreensaver(led_frame_player=None)
-
-        # Explodes on tick 0 — during warm-up phase
         to_ss = _ExplodingTickScreensaver(led_frame_player=None, explode_after=0)
+        from_original = from_ss._led_frame_player
+        to_original = to_ss._led_frame_player
 
         with self.assertRaises(RuntimeError):
             tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
-        self.assertIs(from_ss._led_frame_player, player)
-        self.assertIs(to_ss._led_frame_player, player)
-
-    def test_restored_after_exception_in_blend(self):
-        """If to_screensaver raises during blend, frame players are still restored."""
-        player = self._make_player()
-        tp = TransitionPlayer(player)
-
-        from_ss = _StubScreensaver(led_frame_player=None)
-
-        # Survives warm-up (3 ticks) but explodes during blend
-        to_ss = _ExplodingTickScreensaver(led_frame_player=None, explode_after=5)
-
-        with self.assertRaises(RuntimeError):
-            tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-
-        self.assertIs(from_ss._led_frame_player, player)
-        self.assertIs(to_ss._led_frame_player, player)
+        self.assertIs(from_ss._led_frame_player, from_original)
+        self.assertIs(to_ss._led_frame_player, to_original)
 
 
 class TestWarmedUpState(unittest.TestCase):
-    """Test that _warmed_up reflects whether warm-up actually succeeded."""
+    """Test that warmed_up reflects whether warm-up actually succeeded."""
 
     def setUp(self):
         Config._Config__is_loaded = True
@@ -297,13 +351,13 @@ class TestWarmedUpState(unittest.TestCase):
 
         from_ss = _StubScreensaver(led_frame_player=None)
         to_ss = _StubScreensaver(led_frame_player=None)
-        self.assertFalse(to_ss._warmed_up)
+        self.assertFalse(to_ss.warmed_up)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-        self.assertTrue(to_ss._warmed_up)
+        self.assertTrue(to_ss.warmed_up)
 
     def test_warmed_up_false_when_tick_returns_false_during_warmup(self):
-        """If _tick() returns False during warm-up, _warmed_up stays False."""
+        """If _tick() returns False during warm-up, warmed_up stays False."""
         player = self._make_player()
         tp = TransitionPlayer(player)
 
@@ -313,7 +367,7 @@ class TestWarmedUpState(unittest.TestCase):
         to_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-        self.assertFalse(to_ss._warmed_up)
+        self.assertFalse(to_ss.warmed_up)
 
 
 class TestWarmUpTicksZero(unittest.TestCase):
@@ -353,6 +407,25 @@ class TestWarmUpTicksZero(unittest.TestCase):
             last_frame,
             np.full([4, 4, 3], 42, dtype=np.uint8),
         )
+
+
+class TestStaticTransition(unittest.TestCase):
+    """Test static-frame transitions (no live screensavers)."""
+
+    def setUp(self):
+        Config._Config__is_loaded = True
+        Config._Config__config = copy.deepcopy(BASE_CONFIG)
+
+    def test_static_transition_runs(self):
+        """play_transition() with no screensavers should crossfade to black."""
+        player = MagicMock()
+        player.get_current_frame.return_value = np.full([4, 4, 3], 200, np.uint8)
+        tp = TransitionPlayer(player)
+
+        tp.play_transition()
+
+        # Should have called play_frame for each blend step
+        self.assertGreater(player.play_frame.call_count, 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -42,7 +42,7 @@ def _render_frame(screensaver, value=128):
 class _StubScreensaver(Screensaver):
     """Basic stub that renders a frame each tick."""
 
-    def _tick(self, tick):
+    def _tick(self):
         _render_frame(self)
 
     @classmethod
@@ -65,8 +65,8 @@ class _FailingTickScreensaver(Screensaver):
         super().__init__(led_frame_player)
         self._fail_after = fail_after
 
-    def _tick(self, tick):
-        if tick >= self._fail_after:
+    def _tick(self):
+        if self.get_last_tick() >= self._fail_after:
             return False
         _render_frame(self)
 
@@ -90,8 +90,8 @@ class _ExplodingTickScreensaver(Screensaver):
         super().__init__(led_frame_player)
         self._explode_after = explode_after
 
-    def _tick(self, tick):
-        if tick >= self._explode_after:
+    def _tick(self):
+        if self.get_last_tick() >= self._explode_after:
             raise RuntimeError("boom")
         _render_frame(self)
 
@@ -120,7 +120,7 @@ class _RenderingSetupScreensaver(Screensaver):
         self._width = Config.get_or_throw('leds.display_width')
         self._height = Config.get_or_throw('leds.display_height')
 
-    def _tick(self, tick):
+    def _tick(self):
         _render_frame(self, value=42)
 
     @classmethod
@@ -185,6 +185,18 @@ class TestLastTick(unittest.TestCase):
         ss.play()
         self.assertEqual(ss.get_last_tick(), 5)
 
+    def test_updated_after_render_tick(self):
+        ss = _StubScreensaver(led_frame_player=None)
+        ss.render_tick()
+        self.assertEqual(ss.get_last_tick(), 1)
+        ss.render_tick()
+        self.assertEqual(ss.get_last_tick(), 2)
+
+    def test_not_updated_when_tick_fails(self):
+        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        ss.render_tick()
+        self.assertEqual(ss.get_last_tick(), 0)
+
 
 class TestAutoTeardown(unittest.TestCase):
     """Test auto_teardown parameter of play()."""
@@ -215,7 +227,7 @@ class TestRenderTick(unittest.TestCase):
 
     def test_returns_frame_and_alive(self):
         ss = _StubScreensaver(led_frame_player=None)
-        frame, alive = ss.render_tick(0)
+        frame, alive = ss.render_tick()
         self.assertTrue(alive)
         self.assertIsNotNone(frame)
         self.assertEqual(frame.shape, (4, 4, 3))
@@ -228,31 +240,31 @@ class TestRenderTick(unittest.TestCase):
         ss = _StubScreensaver(led_frame_player=player)
         player.play_frame.reset_mock()
 
-        frame, alive = ss.render_tick(0)
+        frame, alive = ss.render_tick()
         player.play_frame.assert_not_called()
 
     def test_restores_frame_player_after_tick(self):
         player = MagicMock()
         ss = _StubScreensaver(led_frame_player=player)
-        ss.render_tick(0)
+        ss.render_tick()
         self.assertIs(ss._led_frame_player, player)
 
     def test_restores_frame_player_on_exception(self):
         player = MagicMock()
         ss = _ExplodingTickScreensaver(led_frame_player=player, explode_after=0)
         with self.assertRaises(RuntimeError):
-            ss.render_tick(0)
+            ss.render_tick()
         self.assertIs(ss._led_frame_player, player)
 
     def test_returns_false_alive_when_tick_stops(self):
         ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
-        frame, alive = ss.render_tick(0)
+        frame, alive = ss.render_tick()
         self.assertFalse(alive)
 
     def test_calls_setup_on_first_invocation(self):
         ss = _RenderingSetupScreensaver(led_frame_player=None)
         self.assertFalse(ss._Screensaver__is_set_up)
-        frame, alive = ss.render_tick(0)
+        frame, alive = ss.render_tick()
         self.assertTrue(ss._Screensaver__is_set_up)
 
     def test_setup_frame_captured_not_displayed(self):
@@ -263,7 +275,7 @@ class TestRenderTick(unittest.TestCase):
         ss = _RenderingSetupScreensaver(led_frame_player=player)
         player.play_frame.reset_mock()
 
-        frame, alive = ss.render_tick(0)
+        frame, alive = ss.render_tick()
         # The real player should NOT have received any frames
         player.play_frame.assert_not_called()
         # But we should have captured a frame
@@ -414,7 +426,7 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
         self.assertTrue(to_ss.live_transition_warmed_up)
         # Warm-up should have ended early (from died after 1 tick), so
         # total ticks (warm-up + blend) should be far less than 60.
-        self.assertLess(to_ss.live_transition_warm_up_ticks, 30)
+        self.assertLess(to_ss.get_last_tick(), 30)
 
 
 class TestStaticTransition(unittest.TestCase):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -6,7 +6,7 @@ Covers:
 - supports_live_transition() contract
 - last_tick initialization and updates
 - Frame player restoration after transition (including on exception)
-- warmed_up state when warm-up fails
+- transition_warmed_up state when warm-up fails
 - auto_teardown=False skips teardown
 - warm_up_ticks=0 captures to_frame from _setup()
 - render_tick() captures frames without displaying
@@ -315,7 +315,7 @@ class TestTransitionFramePlayerIntegrity(unittest.TestCase):
 
 
 class TestWarmedUpState(unittest.TestCase):
-    """Test that warmed_up reflects whether warm-up actually succeeded."""
+    """Test that transition_warmed_up reflects whether warm-up actually succeeded."""
 
     def setUp(self):
         Config._Config__is_loaded = True
@@ -326,19 +326,19 @@ class TestWarmedUpState(unittest.TestCase):
         player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
         return player
 
-    def test_warmed_up_true_after_successful_warmup(self):
+    def test_transition_warmed_up_true_after_successful_warmup(self):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
         from_ss = _StubScreensaver(led_frame_player=None)
         to_ss = _StubScreensaver(led_frame_player=None)
-        self.assertFalse(to_ss.warmed_up)
+        self.assertFalse(to_ss.transition_warmed_up)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-        self.assertTrue(to_ss.warmed_up)
+        self.assertTrue(to_ss.transition_warmed_up)
 
-    def test_warmed_up_false_when_tick_returns_false_during_warmup(self):
-        """If _tick() returns False during warm-up, warmed_up stays False."""
+    def test_transition_warmed_up_false_when_tick_returns_false_during_warmup(self):
+        """If _tick() returns False during warm-up, transition_warmed_up stays False."""
         player = self._make_player()
         tp = TransitionPlayer(player)
 
@@ -348,7 +348,7 @@ class TestWarmedUpState(unittest.TestCase):
         to_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
-        self.assertFalse(to_ss.warmed_up)
+        self.assertFalse(to_ss.transition_warmed_up)
 
 
 class TestWarmUpTicksZero(unittest.TestCase):
@@ -409,10 +409,10 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
-        self.assertTrue(to_ss.warmed_up)
+        self.assertTrue(to_ss.transition_warmed_up)
         # Warm-up should have ended early — to_ss should have far fewer
-        # warm-up ticks than the configured 60.
-        self.assertLess(to_ss.warm_up_ticks, 10)
+        # warm-up ticks than the configured warm_up_ticks.
+        self.assertLess(to_ss.transition_warm_up_ticks, 10)
 
 
 class TestStaticTransition(unittest.TestCase):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -270,9 +270,9 @@ class TestRenderTick(unittest.TestCase):
 
     def test_calls_setup_on_first_invocation(self):
         ss = _RenderingSetupScreensaver(led_frame_player=None)
-        self.assertFalse(ss._is_set_up)
+        self.assertFalse(ss._Screensaver__is_set_up)
         frame, alive = ss.render_tick(0)
-        self.assertTrue(ss._is_set_up)
+        self.assertTrue(ss._Screensaver__is_set_up)
 
     def test_setup_frame_captured_not_displayed(self):
         """Frames rendered during _setup() should be captured, not sent to real display."""


### PR DESCRIPTION
This PR introduces logic that has the before and after screensavers of a transition continue rendering during the transition, making the transition smooth - no stutter, pause, or freeze during the transition. There are a few needed complexities such as matching framerate because some screensavers have different framerates. 