### PR TITLE
refactor: move nested imports to the top of files

### DIFF
--- a/pifi/config.py
+++ b/pifi/config.py
@@ -5,6 +5,7 @@ from typing import Any
 import pyjson5
 from pifi.logger import Logger
 from pifi.directoryutils import DirectoryUtils
+from pifi.settingsdb import SettingsDb
 
 class Config:
 
@@ -164,9 +165,6 @@ class Config:
             db_keys: list of SettingsDb key constants to read overrides from.
         """
         Config.load_config_if_not_loaded()
-
-        # Import here to avoid circular dependency
-        from pifi.settingsdb import SettingsDb
 
         settings_db = SettingsDb()
 

--- a/pifi/screensaver/airplaykaraoke.py
+++ b/pifi/screensaver/airplaykaraoke.py
@@ -10,6 +10,10 @@ import os
 import re
 import select
 import time
+from io import BytesIO
+
+import numpy as np
+from PIL import Image
 
 from pifi.config import Config
 from pifi.screensaver.karaokebase import KaraokeBase
@@ -225,10 +229,6 @@ class AirPlayKaraoke(KaraokeBase):
     def __process_album_art(self, raw_bytes):
         """Decode album art image and store as a dimmed background frame."""
         try:
-            from io import BytesIO
-            from PIL import Image
-            import numpy as np
-
             img = Image.open(BytesIO(raw_bytes))
             img = img.resize((self._width, self._height), Image.LANCZOS)  # pyright: ignore[reportAttributeAccessIssue]
             img = img.convert('RGB')

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -5,11 +5,16 @@ Shared rendering, lyrics fetching, and state management for karaoke screensavers
 Subclasses provide the music source (Sonos, AirPlay, etc.).
 """
 
-import numpy as np
+import json
 import re
 import threading
 import time
+import traceback
 from abc import abstractmethod
+
+import numpy as np
+import requests
+import syncedlyrics
 
 from pifi.config import Config
 from pifi.logger import Logger
@@ -283,30 +288,26 @@ class KaraokeBase(Screensaver):
 
             # Fall back to syncedlyrics text search for remaining providers
             if not lrc:
-                try:
-                    import syncedlyrics
-                    search_query = f"{title} {artist}"
-                    for provider in ['NetEase', 'Megalobiz']:
-                        try:
-                            result = syncedlyrics.search(
-                                search_query, synced_only=True,
-                                providers=[provider]
+                search_query = f"{title} {artist}"
+                for provider in ['NetEase', 'Megalobiz']:
+                    try:
+                        result = syncedlyrics.search(
+                            search_query, synced_only=True,
+                            providers=[provider]
+                        )
+                        if result:
+                            lrc = result
+                            source_provider = provider
+                            self._logger.info(f"Found lyrics via {provider}")
+                            self._logger.debug(
+                                f"{provider} response ({len(result)} bytes): " +
+                                f"{result[:500]}"
                             )
-                            if result:
-                                lrc = result
-                                source_provider = provider
-                                self._logger.info(f"Found lyrics via {provider}")
-                                self._logger.debug(
-                                    f"{provider} response ({len(result)} bytes): " +
-                                    f"{result[:500]}"
-                                )
-                                break
-                            else:
-                                self._logger.debug(f"{provider}: no results")
-                        except Exception as e:
-                            self._logger.debug(f"{provider} failed: {e}")
-                except ImportError:
-                    self._logger.debug("syncedlyrics not installed, skipping fallback providers")
+                            break
+                        else:
+                            self._logger.debug(f"{provider}: no results")
+                    except Exception as e:
+                        self._logger.debug(f"{provider} failed: {e}")
 
             if lrc:
                 is_enhanced = '<' in lrc and '>' in lrc
@@ -340,7 +341,6 @@ class KaraokeBase(Screensaver):
                     self.__lyrics_available = False
         except Exception as e:
             self._logger.error(f"Error fetching lyrics: {e}")
-            import traceback
             self._logger.debug(traceback.format_exc())
         finally:
             self.__fetch_in_progress = False
@@ -368,7 +368,6 @@ class KaraokeBase(Screensaver):
 
     def __mm_get_token(self):
         """Fetch a fresh Musixmatch API token. Returns token or None."""
-        import requests
         r = requests.get(KaraokeBase.__MM_URL + 'token.get', params={
             'app_id': 'web-desktop-app-v1.0',
             'user_language': 'en',
@@ -389,8 +388,6 @@ class KaraokeBase(Screensaver):
 
     def __mm_api(self, endpoint, params):
         """Make a Musixmatch API request. Retries with a fresh token on 401."""
-        import requests
-
         if not KaraokeBase.__mm_token:
             if not self.__mm_get_token():
                 self._logger.debug("Musixmatch: could not get token")
@@ -505,8 +502,7 @@ class KaraokeBase(Screensaver):
         rich_body = self.__mm_api('track.richsync.get', {'track_id': track_id})
         if rich_body and 'richsync' in rich_body:
             try:
-                import json as json_mod
-                richsync = json_mod.loads(rich_body['richsync']['richsync_body'])
+                richsync = json.loads(rich_body['richsync']['richsync_body'])
                 lrc_lines = []
                 for line in richsync:
                     ts = line['ts']
@@ -540,7 +536,6 @@ class KaraokeBase(Screensaver):
 
     def __fetch_lrclib(self, title, artist, duration):
         """Fetch lyrics from LRCLIB using structured metadata for version-accurate results."""
-        import requests
         params = {'track_name': title, 'artist_name': artist}
         if duration:
             params['duration'] = duration

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -11,10 +11,18 @@ Uses the MTA's GTFS-realtime feed via the underground library.
 import os
 os.environ.setdefault('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION', 'python')
 
-import numpy as np
-import time
+import csv
+import io
+import json
 import threading
+import time
+import zipfile
 from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import requests
+import underground  # imported after the protobuf env var above is set
 
 from pifi.config import Config
 from pifi.logger import Logger
@@ -102,7 +110,6 @@ class NycSubway(Screensaver):
             return True
 
         try:
-            import underground
             self.__underground = underground
             self.__logger.info("underground library loaded successfully")
 
@@ -111,10 +118,6 @@ class NycSubway(Screensaver):
                 self.__load_station_names()
 
             return True
-        except ImportError:
-            self.__error_message = "NO LIB"
-            self.__logger.error("underground not installed. Run: pip install underground")
-            return False
         except Exception as e:
             self.__error_message = "ERR"
             self.__logger.error(f"Failed to load underground: {e}")
@@ -123,9 +126,6 @@ class NycSubway(Screensaver):
     def __load_station_names(self):
         """Load station names from cache or MTA's GTFS static data."""
         self.__station_names_loaded = True
-
-        import json
-        from pathlib import Path
 
         # Cache file location
         cache_dir = Path.home() / '.cache' / 'pifi'
@@ -148,11 +148,6 @@ class NycSubway(Screensaver):
 
         # Fetch from MTA
         try:
-            import requests
-            import csv
-            import io
-            import zipfile
-
             # MTA's static GTFS feed URL
             gtfs_url = "http://web.mta.info/developers/data/nyct/subway/google_transit.zip"
 

--- a/pifi/screensaver/sonoskaraoke.py
+++ b/pifi/screensaver/sonoskaraoke.py
@@ -9,6 +9,7 @@ import numpy as np
 import time
 
 import requests
+import soco
 from io import BytesIO
 from PIL import Image
 
@@ -44,8 +45,6 @@ class SonosKaraoke(KaraokeBase):
         4. Fall back to any available speaker
         """
         try:
-            import soco
-
             speakers = soco.discover(timeout=5)
             if not speakers:
                 return False
@@ -118,8 +117,6 @@ class SonosKaraoke(KaraokeBase):
             self._logger.info(f"Fallback to: {self.__speaker.player_name}")
             return True
 
-        except ImportError:
-            self._logger.error("soco library not installed. Run: pip install soco")
         except Exception as e:
             self._logger.error(f"Error connecting to Sonos: {e}")
 

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -5,10 +5,13 @@ Displays the current track and artist from WFMU radio streams.
 Uses WFMU's XML API to fetch now-playing information.
 """
 
-import numpy as np
-import time
+import math
 import threading
+import time
 import xml.etree.ElementTree as ET
+
+import numpy as np
+import requests
 
 from pifi.config import Config
 from pifi.logger import Logger
@@ -66,8 +69,6 @@ class Wfmu(Screensaver):
     def __fetch_now_playing(self):
         """Fetch current track info from WFMU API."""
         try:
-            import requests
-
             url = f"https://wfmu.org/currentliveshows.php?xml=1&c={self.__channel}"
             response = requests.get(url, timeout=10)
             response.raise_for_status()
@@ -233,7 +234,6 @@ class Wfmu(Screensaver):
 
     def __draw_audio_bars(self, frame, y):
         """Draw animated audio visualization bars."""
-        import math
         bar_width = 3
         bar_gap = 1
         num_bars = self.__width // (bar_width + bar_gap)

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -39,7 +39,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config._Config__base_config = copy.deepcopy(self.BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
         Config._Config__applied_overrides = {}  # pyright: ignore[reportAttributeAccessIssue]
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_applies_overrides(self, MockSettingsDb):
         """Overrides from DB are applied to config."""
         overrides = {'screensavers': {'configs': {'boids': {'num_boids': 50}}}}
@@ -51,7 +51,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         # Non-overridden keys should be preserved
         self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.05)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_reset_restores_defaults(self, MockSettingsDb):
         """After overrides are removed from DB, config reverts to defaults."""
         mock_db = MockSettingsDb.return_value
@@ -66,7 +66,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_reset_restores_all_keys(self, MockSettingsDb):
         """Reset restores all keys in a section, not just overridden ones."""
         mock_db = MockSettingsDb.return_value
@@ -85,7 +85,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.boids.tick_sleep'), 0.05)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_independent_screensavers(self, MockSettingsDb):
         """Overriding one screensaver does not affect another."""
         mock_db = MockSettingsDb.return_value
@@ -96,7 +96,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.04)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_reset_one_keeps_other(self, MockSettingsDb):
         """Resetting one screensaver's overrides preserves another's."""
         mock_db = MockSettingsDb.return_value
@@ -122,7 +122,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_override_new_screensaver_then_reset(self, MockSettingsDb):
         """Overriding a screensaver not in base config, then resetting, removes it."""
         mock_db = MockSettingsDb.return_value
@@ -138,7 +138,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertIsNone(Config.get('screensavers.configs.newss.foo'))
         self.assertIsNone(Config.get('screensavers.configs.newss'))
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_non_screensaver_config_untouched(self, MockSettingsDb):
         """Non-screensaver config sections are never modified by overrides."""
         mock_db = MockSettingsDb.return_value
@@ -149,7 +149,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('leds.driver'), 'apa102')
         self.assertEqual(Config.get('leds.display_width'), 32)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_no_overrides_in_db(self, MockSettingsDb):
         """No overrides in DB leaves config unchanged."""
         mock_db = MockSettingsDb.return_value
@@ -160,7 +160,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.04)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_invalid_json_in_db(self, MockSettingsDb):
         """Invalid JSON in DB is handled gracefully without crashing."""
         mock_db = MockSettingsDb.return_value
@@ -171,7 +171,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         # Config should remain unchanged
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_non_dict_override_replaces_value(self, MockSettingsDb):
         """Non-dict override replaces the existing value."""
         mock_db = MockSettingsDb.return_value
@@ -182,7 +182,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids'), 'a string')
 
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_multiple_db_keys(self, MockSettingsDb):
         """Overrides from multiple DB keys are all applied."""
         mock_db = MockSettingsDb.return_value
@@ -200,7 +200,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_partial_reload_preserves_other_keys(self, MockSettingsDb):
         """Reloading one DB key doesn't clobber overrides from another."""
         mock_db = MockSettingsDb.return_value
@@ -216,7 +216,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_partial_reload_reset_preserves_other_keys(self, MockSettingsDb):
         """Removing overrides from one DB key doesn't affect another's overrides."""
         mock_db = MockSettingsDb.return_value
@@ -235,7 +235,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 15)
         self.assertEqual(Config.get('screensavers.configs.aurora.tick_sleep'), 0.1)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_skips_rebuild_when_unchanged(self, MockSettingsDb):
         """Config is not rebuilt when DB values haven't changed."""
         mock_db = MockSettingsDb.return_value
@@ -251,7 +251,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 999)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_rebuilds_when_changed(self, MockSettingsDb):
         """Config is rebuilt when DB values change."""
         mock_db = MockSettingsDb.return_value
@@ -268,7 +268,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         Config.reload_overrides(['screensaver_settings'])
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 75)
 
-    @patch('pifi.settingsdb.SettingsDb')
+    @patch('pifi.config.SettingsDb')
     def test_override_timeout_and_transitions(self, MockSettingsDb):
         """DB overrides can set timeout and transition settings."""
         mock_db = MockSettingsDb.return_value

--- a/tests/test_screensaver_interface.py
+++ b/tests/test_screensaver_interface.py
@@ -15,11 +15,15 @@ import os
 import subprocess
 from unittest.mock import MagicMock, patch  # pyright: ignore[reportUnusedImport]
 
+import pyjson5
+
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver.screensavermanager import ScreensaverManager
+from pifi.screensaver.videoscreensaver import VideoScreensaver
+from pifi.screensaver.cellularautomata.cellularautomaton import CellularAutomaton
 from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
 
@@ -141,8 +145,6 @@ class TestScreensaverInterface(unittest.TestCase):
         uses 'airplaykaraoke' but get_id() returns 'airplay_karaoke', overrides
         saved via the UI will be silently ignored.
         """
-        import pyjson5
-
         default_config_path = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'default_config.json'
@@ -175,8 +177,6 @@ class TestScreensaverInterface(unittest.TestCase):
         Keeping a deterministic order makes diffs cleaner and makes a key
         easy to find when scanning default_config.json by hand.
         """
-        import pyjson5
-
         default_config_path = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'default_config.json'
@@ -217,8 +217,6 @@ class TestSpecificScreensavers(unittest.TestCase):
 
     def test_video_screensaver_uses_config(self):
         """Verify VideoScreensaver gets video_list from Config, not constructor."""
-        from pifi.screensaver.videoscreensaver import VideoScreensaver
-
         # Should be able to instantiate without passing video_list
         instance = VideoScreensaver(led_frame_player=None)
         self.assertTrue(hasattr(instance, 'video_list'))
@@ -226,8 +224,6 @@ class TestSpecificScreensavers(unittest.TestCase):
 
     def test_video_screensaver_handles_empty_list(self):
         """Verify VideoScreensaver.play() handles empty video list gracefully."""
-        from pifi.screensaver.videoscreensaver import VideoScreensaver
-
         # Create instance with empty video list (from default config)
         instance = VideoScreensaver(led_frame_player=None)
 
@@ -242,8 +238,6 @@ class TestSpecificScreensavers(unittest.TestCase):
 
     def test_cellular_automaton_hierarchy(self):
         """Verify CellularAutomaton inherits from Screensaver."""
-        from pifi.screensaver.cellularautomata.cellularautomaton import CellularAutomaton
-
         self.assertTrue(issubclass(CellularAutomaton, Screensaver))  # pyright: ignore[reportUnnecessaryIsInstance]
 
 

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -26,6 +26,7 @@ from pifi.config import Config
 from pifi.led.ledframeplayer import LedFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver.transitionplayer import TransitionPlayer
+from pifi.screensaver.videoscreensaver import VideoScreensaver
 
 
 # --- Stub screensavers with controllable behavior ---
@@ -168,7 +169,6 @@ class TestSupportsLiveTransition(unittest.TestCase):
         Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_video_screensaver_returns_false(self):
-        from pifi.screensaver.videoscreensaver import VideoScreensaver
         ss = VideoScreensaver(led_frame_player=None)
         self.assertFalse(ss.supports_live_transition())
 

--- a/utils/screensaver_preview.py
+++ b/utils/screensaver_preview.py
@@ -2,16 +2,21 @@
 
 import argparse
 import os
+import random
 import sys
 import time
+import traceback
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # Build registry dynamically from ScreensaverManager
+from pifi.config import Config
 from pifi.led.frameplayerbase import FramePlayerBase
+from pifi.logger import Logger
 from pifi.screensaver.screensavermanager import ScreensaverManager
+from pifi.screensaver.transitionplayer import TransitionPlayer
 
 SCREENSAVER_REGISTRY = []
 for screensaver_id, cls in ScreensaverManager.SCREENSAVER_CLASSES.items():
@@ -179,10 +184,6 @@ def parse_config_options(config_args):
 
 def setup_mock_config(width, height, config_overrides=None):
     """Set up a mock configuration for testing."""
-    from pifi.config import Config
-    from pifi.logger import Logger
-    import traceback
-
     # Load actual config files using existing Config class
     # This reads and merges default_config.json and config.json
     try:
@@ -216,8 +217,6 @@ def setup_mock_config(width, height, config_overrides=None):
 
 def get_screensaver(name, frame_player):
     """Get a screensaver instance by name."""
-    from pifi.screensaver.screensavermanager import ScreensaverManager
-
     name = name.lower().replace('-', '_').replace(' ', '_')
 
     if name not in ScreensaverManager.SCREENSAVER_CLASSES:
@@ -347,11 +346,9 @@ Config values are auto-detected as int, float, bool, or string.
 
     # Apply duration as screensaver timeout if set
     if args.duration is not None:
-        from pifi.config import Config
         Config.set('screensavers.timeout', args.duration)
 
     # Apply transition config
-    from pifi.config import Config
     Config.set('screensavers.transitions.duration', args.transition_duration)
 
     # Build screensaver list
@@ -383,9 +380,6 @@ Config values are auto-detected as int, float, bool, or string.
 
 def run_sequence(screensaver_names, frame_player, args):
     """Run multiple screensavers in sequence with transitions, looping forever."""
-    import random
-    from pifi.screensaver.transitionplayer import TransitionPlayer
-
     use_transitions = not args.no_transitions
     transition_player = TransitionPlayer(frame_player) if use_transitions else None
 

--- a/utils/test_lyrics_providers.py
+++ b/utils/test_lyrics_providers.py
@@ -7,6 +7,8 @@ timestamp comparison.
 """
 
 import re
+import sys
+
 import syncedlyrics
 
 
@@ -170,8 +172,6 @@ TEST_CASES = [
 
 
 if __name__ == '__main__':
-    import sys
-
     # Run parsing tests first (no network needed)
     test_lrc_parsing()
 


### PR DESCRIPTION
## Summary

Nested/lazy imports were a legacy workaround for dev environments that didn't always have every dependency installed. Now that all runtime deps are pinned in `pyproject.toml`/`uv.lock`, these can follow the standard convention of living at the top of the file.

**11 files changed, net −27 lines.**

### What moved
- **5 screensavers** (`nycsubway`, `wfmu`, `karaokebase`, `sonoskaraoke`, `airplaykaraoke`) — hoisted imports and removed the now-dead `except ImportError` graceful-degradation branches (deps are guaranteed installed). In `nycsubway.py`, `import underground` is placed *after* the `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION` env-var line so the protobuf workaround still runs first.
- **Tests/utils** — `test_screensaver_interface.py`, `test_transitions.py`, `screensaver_preview.py`, `test_lyrics_providers.py`. Also dropped a duplicate `ScreensaverManager` import and two redundant `Config` re-imports in `screensaver_preview.py`.
- **`config.py`** — the `SettingsDb` import was wrapped in a "circular dependency" guard that turned out to be **stale** (verified there's no cycle), so it moves to the top. `test_config_overrides.py`'s 16 `@patch` decorators were retargeted to `pifi.config.SettingsDb` — the correct "patch where the name is looked up" location now that `config` binds the name in its own namespace.

### Intentionally left nested
The three driver imports in `pifi/led/ledframeplayer.py`. They're selected by `leds.driver` config **and** are genuinely optional, hardware-specific deps (`apa102-pi`/`rpi-ws281x`/rgbmatrix live in `[project.optional-dependencies]`, not core), so importing them at the top would crash on machines without that hardware lib.

### Tradeoff to note
The heavyweight feature libs `underground` (~550ms), `soco` (~640ms), and `syncedlyrics` (~900ms) now load at every server/queue startup, since `ScreensaverManager` imports all screensaver modules eagerly. This was a deliberate choice — consistency over the ~2s startup cost.

## Test plan
- [x] `pytest tests/` — 70 passed, 294 subtests
- [x] pyright gate (`tests/test_pyright.py`) — clean
- [x] both util scripts byte-compile
- [x] `screensaver_preview.py --list` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)