### PR TITLE
Provide _width/_height/_logger on the Screensaver base class

### DIFF
--- a/pifi/screensaver/aurora.py
+++ b/pifi/screensaver/aurora.py
@@ -21,9 +21,6 @@ class Aurora(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Curtains: each has properties defining its behavior
         self.__curtains = []
 
@@ -81,8 +78,8 @@ class Aurora(Screensaver):
             self.__stars = []
             for _ in range(num_stars):
                 self.__stars.append({
-                    'x': random.randint(0, self.__width - 1),
-                    'y': random.randint(0, self.__height // 2),  # Stars in upper half
+                    'x': random.randint(0, self._width - 1),
+                    'y': random.randint(0, self._height // 2),  # Stars in upper half
                     'brightness': random.uniform(0.3, 1.0),
                     'twinkle_speed': random.uniform(0.05, 0.15),
                     'twinkle_phase': random.uniform(0, 2 * math.pi),
@@ -124,7 +121,7 @@ class Aurora(Screensaver):
         }
 
     def __render(self):
-        frame = np.zeros([self.__height, self.__width, 3], dtype=np.float32)
+        frame = np.zeros([self._height, self._width, 3], dtype=np.float32)
 
         # Draw background stars first
         if Config.get('screensavers.configs.aurora.show_stars', True):
@@ -134,7 +131,7 @@ class Aurora(Screensaver):
                 brightness = star['brightness'] * twinkle * 0.6
 
                 x, y = star['x'], star['y']
-                if 0 <= x < self.__width and 0 <= y < self.__height:
+                if 0 <= x < self._width and 0 <= y < self._height:
                     # Dim white/blue for stars
                     frame[y, x, 0] = brightness * 200
                     frame[y, x, 1] = brightness * 200
@@ -152,16 +149,16 @@ class Aurora(Screensaver):
 
     def __draw_curtain(self, frame, curtain):
         """Draw a single aurora curtain onto the frame."""
-        base_x = curtain['base_x'] * self.__width
-        width = curtain['width'] * self.__width
+        base_x = curtain['base_x'] * self._width
+        width = curtain['width'] * self._width
         intensity = curtain['intensity'] * self.__activity
 
         # Depth affects brightness (farther = dimmer)
         depth_factor = 0.4 + 0.6 * (1 - curtain['depth'])
 
-        for y in range(self.__height):
+        for y in range(self._height):
             # Normalized y position (0 = top, 1 = bottom)
-            y_norm = y / max(1, self.__height - 1)
+            y_norm = y / max(1, self._height - 1)
 
             # Vertical brightness gradient (brighter at bottom, representing horizon)
             # Aurora is typically brighter lower in the sky
@@ -171,7 +168,7 @@ class Aurora(Screensaver):
             wave1 = math.sin(y_norm * curtain['wave_freq'] * 10 + self.__time * curtain['wave_speed'])
             wave2 = math.sin(y_norm * curtain['wave2_freq'] * 15 + self.__time * curtain['wave2_speed'] + 1.5)
 
-            x_offset = (wave1 * curtain['wave_amp'] + wave2 * curtain['wave2_amp']) * self.__width
+            x_offset = (wave1 * curtain['wave_amp'] + wave2 * curtain['wave2_amp']) * self._width
             center_x = base_x + x_offset
 
             # Shimmer effect (rapid brightness fluctuation)
@@ -180,7 +177,7 @@ class Aurora(Screensaver):
             )
 
             # Draw the curtain width at this y level
-            for x in range(self.__width):
+            for x in range(self._width):
                 # Distance from curtain center
                 dist = abs(x - center_x)
 

--- a/pifi/screensaver/blueprint.py
+++ b/pifi/screensaver/blueprint.py
@@ -24,9 +24,6 @@ class Blueprint(Screensaver):
     # Crosshair color
     _MARK = np.array([200, 80, 60], dtype=np.float64)
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
         w, h = self._width, self._height

--- a/pifi/screensaver/blueprint.py
+++ b/pifi/screensaver/blueprint.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -28,12 +27,9 @@ class Blueprint(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
     def _setup(self):
         self.__time = 0.0
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         # Pre-compute coordinates
         y = np.arange(h, dtype=np.float64)
@@ -58,7 +54,7 @@ class Blueprint(Screensaver):
     def _tick(self):
         self.__time += 0.02
         t = self.__time
-        w, h = self.__width, self.__height  # pyright: ignore[reportUnusedVariable]
+        w, h = self._width, self._height  # pyright: ignore[reportUnusedVariable]
 
         # Fade canvas toward background
         self.__canvas = self.__canvas * 0.97 + self._BG * 0.03
@@ -110,7 +106,7 @@ class Blueprint(Screensaver):
 
     def __spawn_element(self):
         """Spawn a new drawing element."""
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
         kind = random.choices(
             ['arc', 'line', 'perspective', 'dimension', 'crosshair', 'circle'],
             weights=[3, 2, 2, 2, 1, 2],
@@ -267,7 +263,7 @@ class Blueprint(Screensaver):
     def __render_perspective(self, elem, progress, brightness):
         """Render lines converging to a vanishing point."""
         vx, vy = elem['vp_x'], elem['vp_y']
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
         n = elem['num_lines']
         color = elem['color']
 
@@ -288,12 +284,12 @@ class Blueprint(Screensaver):
         if progress > 0.3:
             cap_brightness = brightness * min(1, (progress - 0.3) / 0.3)
             if abs(y2 - y1) < 0.1:  # horizontal
-                cap_len = min(2, self.__height * 0.15)
+                cap_len = min(2, self._height * 0.15)
                 self.__render_line(x1, y1 - cap_len, x1, y1 + cap_len, color, 1.0, cap_brightness)
                 ex = x1 + (x2 - x1) * progress
                 self.__render_line(ex, y2 - cap_len, ex, y2 + cap_len, color, 1.0, cap_brightness)
             else:  # vertical
-                cap_len = min(2, self.__width * 0.15)
+                cap_len = min(2, self._width * 0.15)
                 self.__render_line(x1 - cap_len, y1, x1 + cap_len, y1, color, 1.0, cap_brightness)
                 ey = y1 + (y2 - y1) * progress
                 self.__render_line(x2 - cap_len, ey, x2 + cap_len, ey, color, 1.0, cap_brightness)

--- a/pifi/screensaver/boids.py
+++ b/pifi/screensaver/boids.py
@@ -19,9 +19,6 @@ class Boids(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         self.__positions = None
         self.__velocities = None
 
@@ -38,8 +35,8 @@ class Boids(Screensaver):
 
         # Initialize random positions across the display
         self.__positions = np.random.rand(num_boids, 2)
-        self.__positions[:, 0] *= self.__width
-        self.__positions[:, 1] *= self.__height
+        self.__positions[:, 0] *= self._width
+        self.__positions[:, 1] *= self._height
 
         # Initialize random velocities
         max_speed = self.__get_max_speed()
@@ -55,7 +52,7 @@ class Boids(Screensaver):
         self.__hues = (base_hues + np.random.uniform(-0.05, 0.05, num_boids)) % 1.0
 
         # Trail canvas (float for smooth fading)
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
     def __update_velocities(self):
         separation = self.__calculate_separation()
@@ -146,16 +143,16 @@ class Boids(Screensaver):
         self.__positions += self.__velocities  # pyright: ignore[reportOperatorIssue]
 
         # Wrap around edges
-        self.__positions[:, 0] = self.__positions[:, 0] % self.__width
-        self.__positions[:, 1] = self.__positions[:, 1] % self.__height
+        self.__positions[:, 0] = self.__positions[:, 0] % self._width
+        self.__positions[:, 1] = self.__positions[:, 1] % self._height
 
     def __render(self):
         # Fade trail
         self.__canvas *= 0.82
 
         for i, pos in enumerate(self.__positions):  # pyright: ignore[reportArgumentType]
-            x = int(pos[0]) % self.__width
-            y = int(pos[1]) % self.__height
+            x = int(pos[0]) % self._width
+            y = int(pos[1]) % self._height
 
             color = np.array(hsv_to_rgb(self.__hues[i], 0.8, 1.0), dtype=np.float64)
 
@@ -165,16 +162,16 @@ class Boids(Screensaver):
             # Tail pixel — one pixel behind the direction of travel
             speed = math.sqrt(self.__velocities[i, 0] ** 2 + self.__velocities[i, 1] ** 2)  # pyright: ignore[reportOptionalSubscript]
             if speed > 0.01:
-                tx = int(round(pos[0] - self.__velocities[i, 0] / speed)) % self.__width  # pyright: ignore[reportOptionalSubscript]
-                ty = int(round(pos[1] - self.__velocities[i, 1] / speed)) % self.__height  # pyright: ignore[reportOptionalSubscript]
+                tx = int(round(pos[0] - self.__velocities[i, 0] / speed)) % self._width  # pyright: ignore[reportOptionalSubscript]
+                ty = int(round(pos[1] - self.__velocities[i, 1] / speed)) % self._height  # pyright: ignore[reportOptionalSubscript]
                 self.__canvas[ty, tx] = np.minimum(1.0, self.__canvas[ty, tx] + color * 0.15)
 
         # Composite: bright boid heads on top of the trail
         frame = (np.clip(self.__canvas, 0, 1) * 255).astype(np.uint8)
 
         for i, pos in enumerate(self.__positions):  # pyright: ignore[reportArgumentType]
-            x = int(pos[0]) % self.__width
-            y = int(pos[1]) % self.__height
+            x = int(pos[0]) % self._width
+            y = int(pos[1]) % self._height
             frame[y, x] = hsv_to_rgb_bytes(self.__hues[i], 0.6, 1.0)
 
         self._led_frame_player.play_frame(frame)

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 import hashlib
 import time
 
-from pifi.logger import Logger
 from pifi.datastructure.limitedsizedict import LimitedSizeDict
 from pifi.screensaver.screensaver import Screensaver
 
@@ -14,7 +13,6 @@ class CellularAutomaton(Screensaver, ABC):
 
     def __init__(self, led_frame_player = None):
         super().__init__(led_frame_player)
-        self._logger = Logger().set_namespace(self.__class__.__name__)
         self._board = None
 
     def _setup(self):

--- a/pifi/screensaver/cellularautomata/cyclicautomaton.py
+++ b/pifi/screensaver/cellularautomata/cyclicautomaton.py
@@ -24,7 +24,7 @@ class CyclicAutomaton(CellularAutomaton):
     def _seed_hook(self):
         # Create the board with an extra edge cell on all sides to simplify the
         # neighborhood calculation and avoid edge checks.
-        shape = [Config.get_or_throw('leds.display_height') + 2, Config.get_or_throw('leds.display_width') + 2]
+        shape = [self._height + 2, self._width + 2]
         self._board = np.random.randint(0, self.__num_states, shape)
 
     def _board_to_frame(self):  # pyright: ignore[reportIncompatibleMethodOverride]

--- a/pifi/screensaver/cellularautomata/gameoflife.py
+++ b/pifi/screensaver/cellularautomata/gameoflife.py
@@ -40,7 +40,7 @@ class GameOfLife(CellularAutomaton):
     def _seed_hook(self):
         # Create the board with an extra edge cell on all sides to simplify the
         # neighborhood calculation and avoid edge checks.
-        shape = [Config.get_or_throw('leds.display_height') + 2, Config.get_or_throw('leds.display_width') + 2]
+        shape = [self._height + 2, self._width + 2]
         self._board = np.zeros(shape, np.uint8)
         probability = Config.get('screensavers.configs.game_of_life.seed_liveness_probability')
         if self.__variant == self.__VARIANT_IMMIGRATION:
@@ -53,7 +53,7 @@ class GameOfLife(CellularAutomaton):
             self._board[1:-1, 1:-1][seed] = 1
 
     def _board_to_frame(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        frame = np.zeros([Config.get_or_throw('leds.display_height'), Config.get_or_throw('leds.display_width'), 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
         rgb = self.__game_color_helper.get_rgb(self.__game_color_mode, self.__COLOR_CHANGE_FREQ, self._num_ticks)
         frame[(self._board[1:-1, 1:-1] == 1)] = rgb  # pyright: ignore[reportArgumentType, reportCallIssue]
 

--- a/pifi/screensaver/colorfield.py
+++ b/pifi/screensaver/colorfield.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,8 +18,6 @@ class ColorField(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -58,7 +55,7 @@ class ColorField(Screensaver):
         self.__boundary_drifts = [random.uniform(-0.0005, 0.0005) for _ in self.__boundaries]
 
         # Pre-compute y coordinates normalized to 0-1
-        self.__y_norm = np.linspace(0, 1, self.__height, dtype=np.float64)
+        self.__y_norm = np.linspace(0, 1, self._height, dtype=np.float64)
 
         # Breathing phase offsets per band
         self.__breath_phases = [random.uniform(0, 2 * math.pi) for _ in range(self.__num_bands)]
@@ -87,14 +84,14 @@ class ColorField(Screensaver):
 
         # Build per-pixel color
         y = self.__y_norm
-        hue = np.zeros(self.__height, dtype=np.float64)
-        sat = np.zeros(self.__height, dtype=np.float64)
-        val = np.zeros(self.__height, dtype=np.float64)
+        hue = np.zeros(self._height, dtype=np.float64)
+        sat = np.zeros(self._height, dtype=np.float64)
+        val = np.zeros(self._height, dtype=np.float64)
 
         # For each pixel row, blend between adjacent bands
         boundaries = [0.0] + list(self.__boundaries) + [1.0]  # pyright: ignore[reportUnusedVariable]
 
-        for row in range(self.__height):
+        for row in range(self._height):
             yp = y[row]
 
             # Find which two bands this pixel is between
@@ -132,12 +129,12 @@ class ColorField(Screensaver):
             val[row] = band['val'] * breath
 
         # Broadcast to full width (uniform horizontally with very subtle noise)
-        hue_2d = np.tile(hue[:, np.newaxis], (1, self.__width))
-        sat_2d = np.tile(sat[:, np.newaxis], (1, self.__width))
-        val_2d = np.tile(val[:, np.newaxis], (1, self.__width))
+        hue_2d = np.tile(hue[:, np.newaxis], (1, self._width))
+        sat_2d = np.tile(sat[:, np.newaxis], (1, self._width))
+        val_2d = np.tile(val[:, np.newaxis], (1, self._width))
 
         # Very subtle luminance noise for texture
-        noise = np.random.uniform(-0.02, 0.02, (self.__height, self.__width))
+        noise = np.random.uniform(-0.02, 0.02, (self._height, self._width))
         val_2d = np.clip(val_2d + noise, 0, 1)
 
         frame = hsv_to_rgb_uint8_frame(hue_2d, sat_2d, val_2d)

--- a/pifi/screensaver/cosmicdream.py
+++ b/pifi/screensaver/cosmicdream.py
@@ -23,16 +23,13 @@ class CosmicDream(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Pre-compute coordinate grids for plasma
         self.__x_grid, self.__y_grid = np.meshgrid(
-            np.arange(self.__width),
-            np.arange(self.__height)
+            np.arange(self._width),
+            np.arange(self._height)
         )
-        self.__x_norm = self.__x_grid / max(self.__width, 1)
-        self.__y_norm = self.__y_grid / max(self.__height, 1)
+        self.__x_norm = self.__x_grid / max(self._width, 1)
+        self.__y_norm = self.__y_grid / max(self._height, 1)
 
         # Particle system state
         self.__particles = None
@@ -66,8 +63,8 @@ class CosmicDream(Screensaver):
         # Initialize particles for flow field
         num_particles = Config.get('screensavers.configs.cosmic_dream.num_particles', 20)
         self.__particles = np.random.rand(num_particles, 2)
-        self.__particles[:, 0] *= self.__width
-        self.__particles[:, 1] *= self.__height
+        self.__particles[:, 0] *= self._width
+        self.__particles[:, 1] *= self._height
 
         # Trail buffer: stores previous positions for motion blur
         trail_length = Config.get('screensavers.configs.cosmic_dream.trail_length', 8)
@@ -83,7 +80,7 @@ class CosmicDream(Screensaver):
         Classic plasma effect using interference of sine waves.
         Multiple frequencies create organic, flowing patterns.
         """
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
         # Time-varying frequencies for morphing effect
         freq1 = 3.0 + math.sin(t * 0.3) * 1.5
@@ -96,7 +93,7 @@ class CosmicDream(Screensaver):
         plasma3 = np.sin((self.__x_norm + self.__y_norm) * freq3 * math.pi + t * 0.9)
 
         # Radial wave from center
-        cx, cy = self.__width / 2, self.__height / 2
+        cx, cy = self._width / 2, self._height / 2
         dist = np.sqrt((self.__x_grid - cx)**2 + (self.__y_grid - cy)**2)
         max_dist = math.sqrt(cx**2 + cy**2)
         plasma4 = np.sin(dist / max_dist * 6 * math.pi - t * 1.2)
@@ -120,10 +117,10 @@ class CosmicDream(Screensaver):
         Breathing sacred geometry - pulsing circles, rotating polygons.
         Creates a hypnotic focal point.
         """
-        cx, cy = self.__width / 2, self.__height / 2
+        cx, cy = self._width / 2, self._height / 2
 
         # Breathing radius
-        base_radius = min(self.__width, self.__height) * 0.35
+        base_radius = min(self._width, self._height) * 0.35
         breath = math.sin(t * 0.8) * 0.3 + 1.0  # 0.7 to 1.3
         radius = base_radius * breath  # pyright: ignore[reportUnusedVariable]
 
@@ -141,7 +138,7 @@ class CosmicDream(Screensaver):
                 px = int(cx + math.cos(angle) * ring_radius)
                 py = int(cy + math.sin(angle) * ring_radius)
 
-                if 0 <= px < self.__width and 0 <= py < self.__height:
+                if 0 <= px < self._width and 0 <= py < self._height:
                     ring_color = hsv_to_rgb_bytes(ring_hue, 1.0, 1.0)
                     # Additive blend
                     for c in range(3):
@@ -155,7 +152,7 @@ class CosmicDream(Screensaver):
         for dy in range(-1, 2):
             for dx in range(-1, 2):
                 px, py = int(cx) + dx, int(cy) + dy
-                if 0 <= px < self.__width and 0 <= py < self.__height:
+                if 0 <= px < self._width and 0 <= py < self._height:
                     dist = math.sqrt(dx*dx + dy*dy)
                     falloff = max(0, 1 - dist / 1.5)
                     for c in range(3):
@@ -185,8 +182,8 @@ class CosmicDream(Screensaver):
             self.__particles[i, 1] += math.sin(angle) * speed  # pyright: ignore[reportOptionalSubscript]
 
             # Wrap around edges
-            self.__particles[i, 0] %= self.__width  # pyright: ignore[reportOptionalSubscript]
-            self.__particles[i, 1] %= self.__height  # pyright: ignore[reportOptionalSubscript]
+            self.__particles[i, 0] %= self._width  # pyright: ignore[reportOptionalSubscript]
+            self.__particles[i, 1] %= self._height  # pyright: ignore[reportOptionalSubscript]
 
         # Shift trail buffer and add new position
         self.__particle_trails[:, 1:, :] = self.__particle_trails[:, :-1, :]  # pyright: ignore[reportOptionalSubscript]
@@ -195,11 +192,11 @@ class CosmicDream(Screensaver):
         # Render trails with fading
         for i in range(num_particles):
             # Particle hue based on position and time
-            base_hue = (self.__particles[i, 0] / self.__width + t * 0.05) % 1.0  # pyright: ignore[reportOptionalSubscript]
+            base_hue = (self.__particles[i, 0] / self._width + t * 0.05) % 1.0  # pyright: ignore[reportOptionalSubscript]
 
             for trail_idx in range(trail_length):
                 tx, ty = self.__particle_trails[i, trail_idx]  # pyright: ignore[reportOptionalSubscript]
-                px, py = int(tx) % self.__width, int(ty) % self.__height
+                px, py = int(tx) % self._width, int(ty) % self._height
 
                 # Fade based on trail position (newer = brighter)
                 fade = 1.0 - (trail_idx / trail_length)
@@ -221,8 +218,8 @@ class CosmicDream(Screensaver):
         Creates organic, flowing patterns without requiring a noise library.
         """
         # Normalize coordinates
-        nx = x / self.__width * 4
-        ny = y / self.__height * 4
+        nx = x / self._width * 4
+        ny = y / self._height * 4
 
         # Multiple octaves of sine waves at different frequencies
         o = self.__noise_offsets
@@ -302,7 +299,7 @@ class CosmicDream(Screensaver):
         r[mask4], g[mask4], b[mask4] = t[mask4], p, v
         r[mask5], g[mask5], b[mask5] = v, p, q[mask5]
 
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.float32)
         frame[:, :, 0] = r * 255
         frame[:, :, 1] = g * 255
         frame[:, :, 2] = b * 255

--- a/pifi/screensaver/domainwarp.py
+++ b/pifi/screensaver/domainwarp.py
@@ -1,7 +1,6 @@
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -18,8 +17,6 @@ class DomainWarp(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -27,8 +24,8 @@ class DomainWarp(Screensaver):
         self.__hue_base = random.random()
 
         # Pre-compute coordinate grids (normalized 0-1)
-        y = np.linspace(0, 1, self.__height, dtype=np.float64)
-        x = np.linspace(0, 1, self.__width, dtype=np.float64)
+        y = np.linspace(0, 1, self._height, dtype=np.float64)
+        x = np.linspace(0, 1, self._width, dtype=np.float64)
         self.__gx, self.__gy = np.meshgrid(x, y)
 
         # Random parameters for variety

--- a/pifi/screensaver/doublependulum.py
+++ b/pifi/screensaver/doublependulum.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.logger import Logger  # pyright: ignore[reportUnusedImport]
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -15,9 +14,6 @@ class DoublePendulum(Screensaver):
     traces a path that never repeats, fading over time into a
     beautiful chaotic trail.
     """
-
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
 
     def _setup(self):
         self.__time = 0.0

--- a/pifi/screensaver/doublependulum.py
+++ b/pifi/screensaver/doublependulum.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.logger import Logger  # pyright: ignore[reportUnusedImport]
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
@@ -20,22 +19,19 @@ class DoublePendulum(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
     def _setup(self):
         self.__time = 0.0
         self.__hue_base = random.random()
 
         # Canvas for trail (float for smooth fading)
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
         # Pendulum parameters — scale to use most of the screen.
         # Total arm length is constrained by horizontal half-width,
         # then the pivot is placed so the fully extended pendulum
         # just touches the bottom of the screen.
         bob_radius = 2  # must match the radius used in __draw_arms
-        max_reach = (self.__width / 2 - 1 - bob_radius) * 0.85
+        max_reach = (self._width / 2 - 1 - bob_radius) * 0.85
         self.__l1 = max_reach * random.uniform(0.45, 0.55)
         self.__l2 = max_reach - self.__l1
         self.__m1 = random.uniform(0.8, 1.2)
@@ -50,8 +46,8 @@ class DoublePendulum(Screensaver):
 
         # Center point (pivot) — placed so fully extended pendulum
         # reaches the bottom row of the screen.
-        self.__cx = self.__width / 2
-        self.__cy = self.__height - 1 - bob_radius - (self.__l1 + self.__l2)
+        self.__cx = self._width / 2
+        self.__cy = self._height - 1 - bob_radius - (self.__l1 + self.__l2)
 
         # Previous tip position for line drawing
         self.__prev_x = None
@@ -163,7 +159,7 @@ class DoublePendulum(Screensaver):
             ix = int(round(px))
             iy = int(round(py))
 
-            if 0 <= ix < self.__width and 0 <= iy < self.__height:
+            if 0 <= ix < self._width and 0 <= iy < self._height:
                 self.__canvas[iy, ix, 0] = min(1.0, self.__canvas[iy, ix, 0] + r * 0.4)
                 self.__canvas[iy, ix, 1] = min(1.0, self.__canvas[iy, ix, 1] + g * 0.4)
                 self.__canvas[iy, ix, 2] = min(1.0, self.__canvas[iy, ix, 2] + b * 0.4)
@@ -186,7 +182,7 @@ class DoublePendulum(Screensaver):
                 px = ax1 + (ax2 - ax1) * t
                 py = ay1 + (ay2 - ay1) * t
                 ix, iy = int(round(px)), int(round(py))
-                if 0 <= ix < self.__width and 0 <= iy < self.__height:
+                if 0 <= ix < self._width and 0 <= iy < self._height:
                     canvas[iy, ix] = np.maximum(canvas[iy, ix], arm_color)
 
         # Draw bobs as bright discs — pivot, joint, and tip
@@ -203,7 +199,7 @@ class DoublePendulum(Screensaver):
                     if dx * dx + dy * dy <= radius * radius:
                         ix = int(round(bx)) + dx
                         iy = int(round(by)) + dy
-                        if 0 <= ix < self.__width and 0 <= iy < self.__height:
+                        if 0 <= ix < self._width and 0 <= iy < self._height:
                             canvas[iy, ix] = np.maximum(canvas[iy, ix], color)
 
     @classmethod

--- a/pifi/screensaver/dvdbounce.py
+++ b/pifi/screensaver/dvdbounce.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.colorutils import hsv_to_rgb_bytes
 from pifi.screensaver.screensaver import Screensaver
 
@@ -18,22 +17,18 @@ class DvdBounce(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
         # Logo dimensions (clamp to display size)
         requested_width = Config.get('screensavers.configs.dvd_bounce.logo_width', 8)
         requested_height = Config.get('screensavers.configs.dvd_bounce.logo_height', 4)
 
-        self.__logo_width = min(requested_width, self.__width - 1)
-        self.__logo_height = min(requested_height, self.__height - 1)
+        self.__logo_width = min(requested_width, self._width - 1)
+        self.__logo_height = min(requested_height, self._height - 1)
 
-        if requested_width >= self.__width or requested_height >= self.__height:
-            self.__logger.warning(
+        if requested_width >= self._width or requested_height >= self._height:
+            self._logger.warning(
                 f"Logo dimensions ({requested_width}x{requested_height}) too large for display " +
-                f"({self.__width}x{self.__height}). Clamped to {self.__logo_width}x{self.__logo_height}."
+                f"({self._width}x{self._height}). Clamped to {self.__logo_width}x{self.__logo_height}."
             )
 
         # Position (float for smooth movement)
@@ -68,8 +63,8 @@ class DvdBounce(Screensaver):
             self.__x = 0
             self.__vx = abs(self.__vx)
             bounced_x = True
-        elif self.__x >= self.__width - self.__logo_width:
-            self.__x = self.__width - self.__logo_width
+        elif self.__x >= self._width - self.__logo_width:
+            self.__x = self._width - self.__logo_width
             self.__vx = -abs(self.__vx)
             bounced_x = True
 
@@ -78,8 +73,8 @@ class DvdBounce(Screensaver):
             self.__y = 0
             self.__vy = abs(self.__vy)
             bounced_y = True
-        elif self.__y >= self.__height - self.__logo_height:
-            self.__y = self.__height - self.__logo_height
+        elif self.__y >= self._height - self.__logo_height:
+            self.__y = self._height - self.__logo_height
             self.__vy = -abs(self.__vy)
             bounced_y = True
 
@@ -90,15 +85,15 @@ class DvdBounce(Screensaver):
             # Check for corner hit!
             if bounced_x and bounced_y:
                 self.__corner_hits += 1
-                self.__logger.info(f"CORNER HIT! Total: {self.__corner_hits}")
+                self._logger.info(f"CORNER HIT! Total: {self.__corner_hits}")
 
         self.__render()
 
     def __reset(self):
         """Initialize the bouncing logo."""
         # Start at a random position
-        self.__x = random.uniform(0, self.__width - self.__logo_width)
-        self.__y = random.uniform(0, self.__height - self.__logo_height)
+        self.__x = random.uniform(0, self._width - self.__logo_width)
+        self.__y = random.uniform(0, self._height - self.__logo_height)
 
         # Random initial velocity
         speed = Config.get('screensavers.configs.dvd_bounce.speed', 0.5)
@@ -147,14 +142,14 @@ class DvdBounce(Screensaver):
 
     def __render(self):
         """Render the bouncing logo."""
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
 
         # Draw the logo as a filled rectangle
         # Clamp coordinates to prevent negative indices
         x_start = max(0, int(self.__x))
         y_start = max(0, int(self.__y))
-        x_end = min(x_start + self.__logo_width, self.__width)
-        y_end = min(y_start + self.__logo_height, self.__height)
+        x_end = min(x_start + self.__logo_width, self._width)
+        y_end = min(y_start + self.__logo_height, self._height)
 
         # Fill the rectangle
         show_border = Config.get('screensavers.configs.dvd_bounce.show_border', True)

--- a/pifi/screensaver/escher.py
+++ b/pifi/screensaver/escher.py
@@ -23,9 +23,6 @@ class Escher(Screensaver):
         [(0.60, 0.22, 0.10), (0.12, 0.22, 0.48)],  # Rust / cobalt
     ]
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
         w, h = self._width, self._height

--- a/pifi/screensaver/escher.py
+++ b/pifi/screensaver/escher.py
@@ -1,7 +1,6 @@
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -26,12 +25,10 @@ class Escher(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
     def _setup(self):
         self.__time = 0.0
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         # Tile size
         self.__tile_size = max(3.0, min(w, h) / random.uniform(2.5, 4.5))

--- a/pifi/screensaver/fire.py
+++ b/pifi/screensaver/fire.py
@@ -13,9 +13,6 @@ class Fire(Screensaver):
     Simple, iconic, mesmerizing.
     """
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         # Heat buffer — extra row at bottom for the heat source
         self.__heat = np.zeros((self._height + 1, self._width), dtype=np.float64)

--- a/pifi/screensaver/fire.py
+++ b/pifi/screensaver/fire.py
@@ -1,7 +1,6 @@
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -17,12 +16,9 @@ class Fire(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
     def _setup(self):
         # Heat buffer — extra row at bottom for the heat source
-        self.__heat = np.zeros((self.__height + 1, self.__width), dtype=np.float64)
+        self.__heat = np.zeros((self._height + 1, self._width), dtype=np.float64)
 
         # Build the fire palette (256 entries)
         self.__palette = self.__build_palette()
@@ -34,10 +30,10 @@ class Fire(Screensaver):
         self.__wind = random.uniform(-0.15, 0.15)
 
         # Persistent heat source that evolves smoothly
-        self.__base_heat = np.random.uniform(0.4, 0.9, self.__width)
+        self.__base_heat = np.random.uniform(0.4, 0.9, self._width)
 
     def _tick(self):
-        h, w = self.__height, self.__width
+        h, w = self._height, self._width
         heat = self.__heat
 
         # Smoothly evolve the persistent heat source rather than

--- a/pifi/screensaver/flowfield.py
+++ b/pifi/screensaver/flowfield.py
@@ -18,9 +18,6 @@ class FlowField(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Flow field and particles
         self.__particles = []
         self.__buffer = None
@@ -62,18 +59,18 @@ class FlowField(Screensaver):
 
             # Wrap around edges
             if particle['x'] < 0:
-                particle['x'] += self.__width
-            elif particle['x'] >= self.__width:
-                particle['x'] -= self.__width
+                particle['x'] += self._width
+            elif particle['x'] >= self._width:
+                particle['x'] -= self._width
             if particle['y'] < 0:
-                particle['y'] += self.__height
-            elif particle['y'] >= self.__height:
-                particle['y'] -= self.__height
+                particle['y'] += self._height
+            elif particle['y'] >= self._height:
+                particle['y'] -= self._height
 
             # Draw particle
             ix = int(particle['x'])
             iy = int(particle['y'])
-            if 0 <= ix < self.__width and 0 <= iy < self.__height:
+            if 0 <= ix < self._width and 0 <= iy < self._height:
                 # Color based on particle's hue + global palette
                 hue = (self.__hue_base + particle['hue'] * self.__hue_range) % 1.0
                 r, g, b = hsv_to_rgb(hue, 0.8, 1.0)
@@ -88,7 +85,7 @@ class FlowField(Screensaver):
         self.__time += 1
 
     def __reset(self):
-        self.__buffer = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__buffer = np.zeros((self._height, self._width, 3), dtype=np.float32)
         self.__time = 0
         self.__noise_z = random.random() * 100
 
@@ -104,8 +101,8 @@ class FlowField(Screensaver):
 
     def __create_particle(self):
         return {
-            'x': random.random() * self.__width,
-            'y': random.random() * self.__height,
+            'x': random.random() * self._width,
+            'y': random.random() * self._height,
             'hue': random.random(),
         }
 

--- a/pifi/screensaver/geodesic.py
+++ b/pifi/screensaver/geodesic.py
@@ -10,7 +10,6 @@ import math
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -260,8 +259,6 @@ class Geodesic(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
     def _setup(self):
         # Build all shapes once
@@ -297,7 +294,7 @@ class Geodesic(Screensaver):
         self.__morph_duration = random.uniform(2.0, 4.0)
 
         # Sphere radius in pixels
-        self.__radius = min(self.__width, self.__height) * 0.38
+        self.__radius = min(self._width, self._height) * 0.38
 
         # Perspective camera
         self.__cam_dist = 4.0
@@ -322,15 +319,15 @@ class Geodesic(Screensaver):
         self.__hue_speed = random.uniform(0.0008, 0.003)
 
         # Canvas
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float32)
         self.__decay = 0.82
 
         # Pixel grids
-        ys = np.arange(self.__height, dtype=np.float32)
-        xs = np.arange(self.__width, dtype=np.float32)
+        ys = np.arange(self._height, dtype=np.float32)
+        xs = np.arange(self._width, dtype=np.float32)
         self.__grid_x, self.__grid_y = np.meshgrid(xs, ys)
 
-        min_dim = min(self.__width, self.__height)
+        min_dim = min(self._width, self._height)
         self.__line_half_width = max(0.6, min_dim / 50.0)
         self.__vertex_radius = max(1.0, min_dim / 30.0)
 
@@ -395,8 +392,8 @@ class Geodesic(Screensaver):
         # Perspective projection
         z_vals = rotated[:, 2]
         depth_factor = self.__cam_dist / (self.__cam_dist - z_vals)
-        proj_x = rotated[:, 0] * depth_factor * self.__radius + self.__width / 2.0
-        proj_y = rotated[:, 1] * depth_factor * self.__radius + self.__height / 2.0
+        proj_x = rotated[:, 0] * depth_factor * self.__radius + self._width / 2.0
+        proj_y = rotated[:, 1] * depth_factor * self.__radius + self._height / 2.0
         depth_brightness = 0.25 + 0.75 * (z_vals + 1) / 2.0
 
         base_color = self.__get_base_color(tick)
@@ -467,9 +464,9 @@ class Geodesic(Screensaver):
 
             pad = hw + 1.5
             min_x = max(0, int(min(x0, x1) - pad))
-            max_x = min(self.__width, int(max(x0, x1) + pad) + 1)
+            max_x = min(self._width, int(max(x0, x1) + pad) + 1)
             min_y = max(0, int(min(y0, y1) - pad))
-            max_y = min(self.__height, int(max(y0, y1) + pad) + 1)
+            max_y = min(self._height, int(max(y0, y1) + pad) + 1)
             if max_x <= min_x or max_y <= min_y:
                 continue
 
@@ -506,9 +503,9 @@ class Geodesic(Screensaver):
 
             pad = vr + 1.0
             min_x = max(0, int(vx - pad))
-            max_x = min(self.__width, int(vx + pad) + 1)
+            max_x = min(self._width, int(vx + pad) + 1)
             min_y = max(0, int(vy - pad))
-            max_y = min(self.__height, int(vy + pad) + 1)
+            max_y = min(self._height, int(vy + pad) + 1)
             if max_x <= min_x or max_y <= min_y:
                 continue
 

--- a/pifi/screensaver/geodesic.py
+++ b/pifi/screensaver/geodesic.py
@@ -257,9 +257,6 @@ class Geodesic(Screensaver):
     _MODE_CYAN = 1
     _MODE_HUE_SHIFT = 2
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         # Build all shapes once
         self.__all_shapes = {}

--- a/pifi/screensaver/halftone.py
+++ b/pifi/screensaver/halftone.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -19,16 +18,14 @@ class Halftone(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
         self.__time = 0.0
 
         # Pre-compute coordinate grids
-        y = np.arange(self.__height, dtype=np.float64)
-        x = np.arange(self.__width, dtype=np.float64)
+        y = np.arange(self._height, dtype=np.float64)
+        x = np.arange(self._width, dtype=np.float64)
         self.__gx, self.__gy = np.meshgrid(x, y)
 
         # Screen angles for each color channel (classic CMYK-ish angles)
@@ -54,7 +51,7 @@ class Halftone(Screensaver):
         self.__pattern_phases = [random.uniform(0, 10) for _ in range(6)]
 
         # Reusable per-tick frame buffer (zeroed at the start of each tick)
-        self.__frame = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        self.__frame = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
     def _tick(self):
         self.__time += self.__pattern_speed
@@ -62,7 +59,7 @@ class Halftone(Screensaver):
 
         gx, gy = self.__gx, self.__gy
         p = self.__pattern_phases
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         frame = self.__frame
         frame.fill(0.0)

--- a/pifi/screensaver/hexgrid.py
+++ b/pifi/screensaver/hexgrid.py
@@ -28,9 +28,6 @@ class HexGrid(Screensaver):
         [(0.1, 0.7, 0.4), (0.1, 0.4, 0.7), (0.4, 0.1, 0.6), (0.2, 0.8, 0.6)],
     ]
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
         w, h = self._width, self._height

--- a/pifi/screensaver/hexgrid.py
+++ b/pifi/screensaver/hexgrid.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -32,12 +31,9 @@ class HexGrid(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
     def _setup(self):
         self.__time = 0.0
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         # Hex cell size (pixels per cell radius)
         self.__cell_size = max(2.0, min(w, h) / random.uniform(4, 8))
@@ -118,7 +114,7 @@ class HexGrid(Screensaver):
     def _tick(self):
         self.__time += 0.015
         t = self.__time
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         cx = self.__cell_cx
         cy = self.__cell_cy

--- a/pifi/screensaver/inkinwater.py
+++ b/pifi/screensaver/inkinwater.py
@@ -18,9 +18,6 @@ class InkInWater(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # RGB buffer for diffusion
         self.__buffer = None
         self.__time = 0
@@ -49,7 +46,7 @@ class InkInWater(Screensaver):
 
     def __reset(self):
         self.__time = 0
-        self.__buffer = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__buffer = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
         # Add several initial drops for immediate visual interest
         for _ in range(6):
@@ -57,8 +54,8 @@ class InkInWater(Screensaver):
 
     def __add_drop(self):
         """Add a new ink drop at a random location."""
-        x = random.randint(3, self.__width - 4)
-        y = random.randint(3, self.__height - 4)
+        x = random.randint(3, self._width - 4)
+        y = random.randint(3, self._height - 4)
 
         # Random vibrant color
         hue = random.random()
@@ -72,7 +69,7 @@ class InkInWater(Screensaver):
         for dy in range(-3, 4):
             for dx in range(-3, 4):
                 nx, ny = x + dx, y + dy
-                if 0 <= nx < self.__width and 0 <= ny < self.__height:
+                if 0 <= nx < self._width and 0 <= ny < self._height:
                     dist = math.sqrt(dx * dx + dy * dy)
                     if dist < radius:
                         falloff = 1.0 - (dist / radius)

--- a/pifi/screensaver/kaleidoscope.py
+++ b/pifi/screensaver/kaleidoscope.py
@@ -1,7 +1,6 @@
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -18,8 +17,6 @@ class Kaleidoscope(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -31,9 +28,9 @@ class Kaleidoscope(Screensaver):
         self.__num_axes = random.choice([3, 4, 5, 6, 8])
 
         # Pre-compute polar coordinates from center
-        cy, cx = self.__height / 2, self.__width / 2
-        y = np.arange(self.__height, dtype=np.float64) - cy
-        x = np.arange(self.__width, dtype=np.float64) - cx
+        cy, cx = self._height / 2, self._width / 2
+        y = np.arange(self._height, dtype=np.float64) - cy
+        x = np.arange(self._width, dtype=np.float64) - cx
         gx, gy = np.meshgrid(x, y)
 
         self.__radius = np.sqrt(gx ** 2 + gy ** 2)

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -16,8 +16,6 @@ import numpy as np
 import requests
 import syncedlyrics
 
-from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver import textutils
 
@@ -64,10 +62,6 @@ class KaraokeBase(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self._logger = Logger().set_namespace(self.__class__.__name__)
-
-        self._width = Config.get('leds.display_width', 64)
-        self._height = Config.get('leds.display_height', 32)
 
         self._pulse_lyrics = True
 

--- a/pifi/screensaver/klee.py
+++ b/pifi/screensaver/klee.py
@@ -39,9 +39,6 @@ class Klee(Screensaver):
         [8, 9, 10, 11, 0],  # Blau → Rot (through violet)
     ])
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
         w, h = self._width, self._height

--- a/pifi/screensaver/klee.py
+++ b/pifi/screensaver/klee.py
@@ -1,7 +1,6 @@
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -42,12 +41,10 @@ class Klee(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
     def _setup(self):
         self.__time = 0.0
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         y = np.arange(h, dtype=np.float64)
         x = np.arange(w, dtype=np.float64)
@@ -67,7 +64,7 @@ class Klee(Screensaver):
             self.__setup_grid()
 
     def __setup_diamond(self):
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
         self.__diamond_size = max(2.5, min(w, h) / random.uniform(3, 5))
         ds = self.__diamond_size
         # Rotated coordinates give a natural diamond tiling
@@ -75,7 +72,7 @@ class Klee(Screensaver):
         self.__v_base = (self.__gx - self.__gy) / ds
 
     def __setup_wheel(self):
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
         self.__cx = w / 2.0
         self.__cy = h / 2.0
         self.__radius = min(w, h) * 0.45
@@ -86,8 +83,8 @@ class Klee(Screensaver):
         self.__dist = np.sqrt(dx ** 2 + dy ** 2)
 
     def __setup_grid(self):
-        self.__grid_cols = random.randint(4, min(8, self.__width // 2))
-        self.__grid_rows = random.randint(3, min(6, self.__height // 2))
+        self.__grid_cols = random.randint(4, min(8, self._width // 2))
+        self.__grid_rows = random.randint(3, min(6, self._height // 2))
 
     def _tick(self):
         self.__time += 0.02
@@ -183,7 +180,7 @@ class Klee(Screensaver):
 
     def __tick_grid(self, t):
         """Rectangular grid: hue progression × tonal value steps."""
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
         cols, rows = self.__grid_cols, self.__grid_rows
 
         cell_w = w / cols

--- a/pifi/screensaver/lavalamp.py
+++ b/pifi/screensaver/lavalamp.py
@@ -18,9 +18,6 @@ class LavaLamp(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         self.__blobs = []
 
     def _setup(self):
@@ -38,14 +35,14 @@ class LavaLamp(Screensaver):
         for i in range(num_blobs):
             # Start some at top (cold) and some at bottom (hot) for immediate motion
             if i % 2 == 0:
-                y = random.uniform(0, self.__height * 0.3)
+                y = random.uniform(0, self._height * 0.3)
                 heat = random.uniform(0.2, 0.4)
             else:
-                y = random.uniform(self.__height * 0.7, self.__height)
+                y = random.uniform(self._height * 0.7, self._height)
                 heat = random.uniform(0.7, 0.9)
 
             self.__blobs.append({
-                'x': random.uniform(1, self.__width - 1),
+                'x': random.uniform(1, self._width - 1),
                 'y': y,
                 'vx': random.uniform(-0.1, 0.1),
                 'vy': 0,
@@ -65,7 +62,7 @@ class LavaLamp(Screensaver):
         for blob in self.__blobs:
             # Heat from bottom, cool from top
             # Temperature gradient based on y position
-            ambient_temp = 1.0 - (blob['y'] / self.__height)
+            ambient_temp = 1.0 - (blob['y'] / self._height)
 
             if blob['heat'] < ambient_temp:
                 blob['heat'] += heat_rate
@@ -76,7 +73,7 @@ class LavaLamp(Screensaver):
 
             # Buoyancy force based on heat differential
             # Hot blobs rise, cool blobs sink
-            target_y = (1.0 - blob['heat']) * self.__height
+            target_y = (1.0 - blob['heat']) * self._height
             blob['vy'] += (target_y - blob['y']) * buoyancy * 0.15
 
             # Add wobble motion using sine waves for organic movement
@@ -97,24 +94,24 @@ class LavaLamp(Screensaver):
             if blob['x'] < blob['radius']:
                 blob['x'] = blob['radius']
                 blob['vx'] *= -0.5
-            elif blob['x'] > self.__width - blob['radius']:
-                blob['x'] = self.__width - blob['radius']
+            elif blob['x'] > self._width - blob['radius']:
+                blob['x'] = self._width - blob['radius']
                 blob['vx'] *= -0.5
 
             # Contain vertically
             if blob['y'] < 0:
                 blob['y'] = 0
                 blob['vy'] *= -0.3
-            elif blob['y'] > self.__height - 1:
-                blob['y'] = self.__height - 1
+            elif blob['y'] > self._height - 1:
+                blob['y'] = self._height - 1
                 blob['vy'] *= -0.3
 
     def __render(self):
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.uint8)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
 
         # For each pixel, calculate metaball field value
-        for y in range(self.__height):
-            for x in range(self.__width):
+        for y in range(self._height):
+            for x in range(self._width):
                 field = 0
                 avg_heat = 0
                 total_influence = 0

--- a/pifi/screensaver/lenia.py
+++ b/pifi/screensaver/lenia.py
@@ -15,9 +15,6 @@ class Lenia(Screensaver):
     bell-curve growth functions.
     """
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__reset()
 

--- a/pifi/screensaver/lenia.py
+++ b/pifi/screensaver/lenia.py
@@ -1,8 +1,6 @@
 import numpy as np
 import random
 
-from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,10 +17,6 @@ class Lenia(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
     def _setup(self):
         self.__reset()
@@ -38,14 +32,14 @@ class Lenia(Screensaver):
         self.__render()
 
     def __reset(self):
-        self.__grid = np.zeros((self.__height, self.__width), dtype=np.float64)
+        self.__grid = np.zeros((self._height, self._width), dtype=np.float64)
         self.__prev_mean = None
         self.__stagnant_count = 0
 
         # Pick a random creature preset — these are (R, mu, sigma, dt) combos
         # known to produce dynamic behavior. R is kernel radius.
         # Smaller R values work better on small grids.
-        R_max = min(self.__width, self.__height) // 3
+        R_max = min(self._width, self._height) // 3
         self.__params = random.choice([
             # Orbium — classic glider, smooth and elegant
             {'R': min(7, R_max), 'mu': 0.15, 'sigma': 0.015, 'dt': 0.1, 'beta': [1]},
@@ -77,7 +71,7 @@ class Lenia(Screensaver):
         # Slowly rotating color palette
         self.__hue_base = random.random()
 
-        self.__logger.info(
+        self._logger.info(
             f"Lenia params: R={R}, mu={self.__mu}, sigma={self.__sigma}, " +
             f"dt={self.__dt}, beta={beta}"
         )
@@ -86,9 +80,9 @@ class Lenia(Screensaver):
         """Build ring kernel and return its FFT for convolution."""
         # Kernel is defined on the full grid with wrap-around
         # Create distance field from center
-        cy, cx = self.__height // 2, self.__width // 2
-        y = np.arange(self.__height) - cy
-        x = np.arange(self.__width) - cx
+        cy, cx = self._height // 2, self._width // 2
+        y = np.arange(self._height) - cy
+        x = np.arange(self._width) - cx
         yy, xx = np.meshgrid(y, x, indexing='ij')
         dist = np.sqrt(xx ** 2 + yy ** 2)
 
@@ -132,16 +126,16 @@ class Lenia(Screensaver):
         """Place random blob creatures on the grid."""
         R = self.__params['R']
         for _ in range(num_creatures):
-            cx = random.randint(R, self.__width - R - 1)  # pyright: ignore[reportArgumentType]
-            cy = random.randint(R, self.__height - R - 1)  # pyright: ignore[reportArgumentType]
+            cx = random.randint(R, self._width - R - 1)  # pyright: ignore[reportArgumentType]
+            cy = random.randint(R, self._height - R - 1)  # pyright: ignore[reportArgumentType]
             # Random organic blob
             size = random.randint(max(2, R // 2), R)  # pyright: ignore[reportArgumentType, reportOperatorIssue]
             for dy in range(-size, size + 1):
                 for dx in range(-size, size + 1):
                     dist = (dx ** 2 + dy ** 2) ** 0.5
                     if dist <= size:
-                        ny = (cy + dy) % self.__height
-                        nx = (cx + dx) % self.__width
+                        ny = (cy + dy) % self._height
+                        nx = (cx + dx) % self._width
                         # Smooth falloff from center
                         val = (1 - dist / size) * random.uniform(0.5, 1.0)
                         self.__grid[ny, nx] = max(self.__grid[ny, nx], val)
@@ -151,13 +145,13 @@ class Lenia(Screensaver):
         # 0.05 is the activity threshold — Lenia values stay close to 0
         # outside live regions, so > 0.05 reliably picks out "alive" cells.
         alive = (self.__grid > 0.05).sum()
-        total = self.__width * self.__height
+        total = self._width * self._height
         mean = float(self.__grid.mean())
 
         # Extinction: fewer than 2% of cells active means the pattern
         # has died out and won't recover on its own — re-seed.
         if alive < total * 0.02:
-            self.__logger.info("Lenia: extinction detected, re-seeding")
+            self._logger.info("Lenia: extinction detected, re-seeding")
             self.__seed_creatures(3)
             self.__stagnant_count = 0
             self.__prev_mean = None
@@ -172,7 +166,7 @@ class Lenia(Screensaver):
                 self.__stagnant_count = 0
 
             if self.__stagnant_count >= 3:
-                self.__logger.info("Lenia: stagnation detected, adding perturbation")
+                self._logger.info("Lenia: stagnation detected, adding perturbation")
                 # Add a new creature to disrupt the static pattern
                 self.__seed_creatures(2)
                 self.__stagnant_count = 0

--- a/pifi/screensaver/lorenz.py
+++ b/pifi/screensaver/lorenz.py
@@ -19,9 +19,6 @@ class Lorenz(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Lorenz system state
         self.__x = 0.0
         self.__y = 0.0
@@ -82,7 +79,7 @@ class Lorenz(Screensaver):
         self.__rotation = random.uniform(0, 2 * math.pi)
 
     def __render(self):
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
 
         if not self.__trail:
             self._led_frame_player.play_frame(frame)
@@ -100,9 +97,9 @@ class Lorenz(Screensaver):
         y_range = 50
         z_min, z_max = 0, 50
 
-        cx = self.__width / 2
-        cy = self.__height / 2
-        scale = min(self.__width / x_range, self.__height / y_range) * 0.9
+        cx = self._width / 2
+        cy = self._height / 2
+        scale = min(self._width / x_range, self._height / y_range) * 0.9
 
         # Render trail with 3D rotation
         cos_r = math.cos(self.__rotation)
@@ -117,7 +114,7 @@ class Lorenz(Screensaver):
             screen_x = int(cx + rx * scale)
             screen_y = int(cy - (ry * 0.7 + (z - 25) * 0.3) * scale)
 
-            if 0 <= screen_x < self.__width and 0 <= screen_y < self.__height:
+            if 0 <= screen_x < self._width and 0 <= screen_y < self._height:
                 # Color based on z-height (blue at bottom, red at top)
                 z_norm = (z - z_min) / (z_max - z_min)
                 z_norm = max(0, min(1, z_norm))

--- a/pifi/screensaver/mandelbrot.py
+++ b/pifi/screensaver/mandelbrot.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.colorutils import hsv_to_rgb_bytes
 from pifi.screensaver.screensaver import Screensaver
 
@@ -38,10 +37,6 @@ class Mandelbrot(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
         # Current view parameters
         self.__center_x = -0.5
@@ -77,7 +72,7 @@ class Mandelbrot(Screensaver):
         if black_ratio == 1.0:
             self.__black_frame_count += 1
             if self.__black_frame_count >= 5:
-                self.__logger.info("Zoomed into black region, picking new target")
+                self._logger.info("Zoomed into black region, picking new target")
                 self.__reset()
         else:
             self.__black_frame_count = 0
@@ -99,7 +94,7 @@ class Mandelbrot(Screensaver):
         # Reset black frame counter
         self.__black_frame_count = 0
 
-        self.__logger.info(f"Zoom target: ({self.__target_x}, {self.__target_y})")
+        self._logger.info(f"Zoom target: ({self.__target_x}, {self.__target_y})")
 
     def __generate_palette(self):
         """Generate a vibrant color palette for the fractal."""
@@ -124,7 +119,7 @@ class Mandelbrot(Screensaver):
         max_iter = Config.get('screensavers.configs.mandelbrot.max_iterations', 50)
 
         # Calculate view bounds
-        aspect = self.__width / self.__height
+        aspect = self._width / self._height
         view_height = 3.0 / self.__zoom
         view_width = view_height * aspect
 
@@ -134,8 +129,8 @@ class Mandelbrot(Screensaver):
         y_max = self.__center_y + view_height / 2
 
         # Create coordinate grids using float32 for speed
-        x = np.linspace(x_min, x_max, self.__width, dtype=np.float32)
-        y = np.linspace(y_min, y_max, self.__height, dtype=np.float32)
+        x = np.linspace(x_min, x_max, self._width, dtype=np.float32)
+        y = np.linspace(y_min, y_max, self._height, dtype=np.float32)
         X, Y = np.meshgrid(x, y)
         C = X + 1j * Y
 
@@ -170,7 +165,7 @@ class Mandelbrot(Screensaver):
         self._led_frame_player.play_frame(frame)
 
         # Return ratio of black (interior) pixels
-        total_pixels = self.__width * self.__height
+        total_pixels = self._width * self._height
         black_pixels = np.sum(interior_mask)
         return black_pixels / total_pixels
 

--- a/pifi/screensaver/matrixrain.py
+++ b/pifi/screensaver/matrixrain.py
@@ -21,9 +21,6 @@ class MatrixRain(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Each column has: [y_position, speed, length, active]
         self.__drops = []
 
@@ -52,17 +49,17 @@ class MatrixRain(Screensaver):
             head_y = int(drop['y'])
             tail_y = head_y - drop['length']
 
-            if tail_y < self.__height:
+            if tail_y < self._height:
                 new_drops.append(drop)
 
                 # Draw the drop head (brightest point)
-                if 0 <= head_y < self.__height:
+                if 0 <= head_y < self._height:
                     self.__trail_buffer[head_y, drop['x']] = 1.0
 
                 # Draw trail with gradient
                 for i in range(1, drop['length']):
                     trail_y = head_y - i
-                    if 0 <= trail_y < self.__height:
+                    if 0 <= trail_y < self._height:
                         # Brightness decreases along trail
                         brightness = 1.0 - (i / drop['length'])
                         brightness *= 0.7  # Trail is dimmer than head
@@ -74,7 +71,7 @@ class MatrixRain(Screensaver):
         self.__drops = new_drops
 
         # Spawn new drops in empty columns
-        for x in range(self.__width):
+        for x in range(self._width):
             if x not in active_columns and random.random() < spawn_rate:
                 self.__add_drop(x)
 
@@ -82,10 +79,10 @@ class MatrixRain(Screensaver):
 
     def __reset(self):
         self.__drops = []
-        self.__trail_buffer = np.zeros((self.__height, self.__width), dtype=np.float32)
+        self.__trail_buffer = np.zeros((self._height, self._width), dtype=np.float32)
 
         # Initialize some drops
-        for x in range(self.__width):
+        for x in range(self._width):
             if random.random() < 0.3:
                 self.__add_drop(x)
 
@@ -97,12 +94,12 @@ class MatrixRain(Screensaver):
         max_length = Config.get('screensavers.configs.matrix_rain.max_length', 12)
 
         speed = random.uniform(min_speed, max_speed)
-        length = random.randint(min_length, min(max_length, self.__height))
+        length = random.randint(min_length, min(max_length, self._height))
 
         if from_top:
             y = random.uniform(-length, 0)
         else:
-            y = random.uniform(-length, self.__height)
+            y = random.uniform(-length, self._height)
 
         self.__drops.append({
             'x': x,
@@ -113,15 +110,15 @@ class MatrixRain(Screensaver):
         })
 
     def __render(self):
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
 
         color_mode = Config.get('screensavers.configs.matrix_rain.color_mode', 'green')
 
         if color_mode == 'green':
             # Classic green matrix
             # Bright heads are white-green, trails are green
-            for y in range(self.__height):
-                for x in range(self.__width):
+            for y in range(self._height):
+                for x in range(self._width):
                     b = self.__trail_buffer[y, x]  # pyright: ignore[reportOptionalSubscript]
                     if b > 0.01:
                         if b > 0.9:
@@ -137,11 +134,11 @@ class MatrixRain(Screensaver):
 
         elif color_mode == 'rainbow':
             # Rainbow variation - each column has a different hue
-            for y in range(self.__height):
-                for x in range(self.__width):
+            for y in range(self._height):
+                for x in range(self._width):
                     b = self.__trail_buffer[y, x]  # pyright: ignore[reportOptionalSubscript]
                     if b > 0.01:
-                        hue = (x / self.__width) % 1.0
+                        hue = (x / self._width) % 1.0
                         if b > 0.9:
                             # Bright head
                             rgb = hsv_to_rgb_bytes(hue, 0.3, 1.0)
@@ -151,8 +148,8 @@ class MatrixRain(Screensaver):
 
         elif color_mode == 'blue':
             # Blue/cyan variation
-            for y in range(self.__height):
-                for x in range(self.__width):
+            for y in range(self._height):
+                for x in range(self._width):
                     b = self.__trail_buffer[y, x]  # pyright: ignore[reportOptionalSubscript]
                     if b > 0.01:
                         if b > 0.9:
@@ -165,8 +162,8 @@ class MatrixRain(Screensaver):
 
         else:  # 'white'
             # Monochrome white
-            for y in range(self.__height):
-                for x in range(self.__width):
+            for y in range(self._height):
+                for x in range(self._width):
                     b = self.__trail_buffer[y, x]  # pyright: ignore[reportOptionalSubscript]
                     if b > 0.01:
                         intensity = int(b * 255)

--- a/pifi/screensaver/meltingclock.py
+++ b/pifi/screensaver/meltingclock.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.colorutils import hsv_to_rgb_bytes
 from pifi.screensaver.screensaver import Screensaver
 
@@ -105,19 +104,15 @@ class MeltingClock(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
         # Get timezone configuration
         timezone_str = Config.get('screensavers.configs.melting_clock.timezone', None)
         if timezone_str:
             try:
                 self.__timezone = ZoneInfo(timezone_str)
-                self.__logger.info(f"Using timezone: {timezone_str}")
+                self._logger.info(f"Using timezone: {timezone_str}")
             except Exception as e:
-                self.__logger.warning(f"Invalid timezone '{timezone_str}': {e}. Using local time.")
+                self._logger.warning(f"Invalid timezone '{timezone_str}': {e}. Using local time.")
                 self.__timezone = None
         else:
             self.__timezone = None
@@ -168,7 +163,7 @@ class MeltingClock(Screensaver):
     def __reset(self):
         self.__current_time = ""
         self.__char_states = []
-        self.__buffer = np.zeros((self.__height, self.__width), dtype=np.float32)
+        self.__buffer = np.zeros((self._height, self._width), dtype=np.float32)
         self.__hue = random.random()
 
     def __handle_time_change(self, new_time):
@@ -250,7 +245,7 @@ class MeltingClock(Screensaver):
                     drop['brightness'] -= 0.02  # Fade out
 
                     # Keep drop if still visible
-                    if drop['y'] < self.__height and drop['brightness'] > 0:
+                    if drop['y'] < self._height and drop['brightness'] > 0:
                         new_drops.append(drop)
 
             state['drops'] = new_drops
@@ -270,7 +265,7 @@ class MeltingClock(Screensaver):
             # HH:MM = 5 chars
             total_width = 4 * self.DIGIT_WIDTH + 1 * 3 + 4  # 4 digits + 1 colon + spacing
 
-        start_x = (self.__width - total_width) // 2
+        start_x = (self._width - total_width) // 2
 
         # Position based on character index
         x = start_x
@@ -281,14 +276,14 @@ class MeltingClock(Screensaver):
 
     def __get_char_y(self):
         """Get y position for characters (centered vertically)."""
-        return (self.__height - self.DIGIT_HEIGHT) // 2
+        return (self._height - self.DIGIT_HEIGHT) // 2
 
     def __render(self):
         # Fade existing buffer (creates trails)
         fade = Config.get('screensavers.configs.melting_clock.trail_fade', 0.85)
         self.__buffer *= fade
 
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
         y_offset = self.__get_char_y()
 
         # Draw each character
@@ -305,7 +300,7 @@ class MeltingClock(Screensaver):
                         if font_data[row][col]:
                             px = x_offset + col
                             py = y_offset + row
-                            if 0 <= px < self.__width and 0 <= py < self.__height:
+                            if 0 <= px < self._width and 0 <= py < self._height:
                                 # Fade in from top
                                 row_progress = (forming * self.DIGIT_HEIGHT - (self.DIGIT_HEIGHT - 1 - row))
                                 pixel_brightness = max(0, min(1, row_progress))
@@ -315,19 +310,19 @@ class MeltingClock(Screensaver):
             for drop in state['drops']:
                 px = int(drop['x'])
                 py = int(drop['y'])
-                if 0 <= px < self.__width and 0 <= py < self.__height:
+                if 0 <= px < self._width and 0 <= py < self._height:
                     self.__buffer[py, px] = max(self.__buffer[py, px], drop['brightness'])
 
                 # Draw trail
                 trail_y = int(drop['y'] - drop['vy'] * 0.5)
-                if 0 <= px < self.__width and 0 <= trail_y < self.__height:
+                if 0 <= px < self._width and 0 <= trail_y < self._height:
                     self.__buffer[trail_y, px] = max(self.__buffer[trail_y, px], drop['brightness'] * 0.5)
 
         # Convert buffer to colored frame
         color_mode = Config.get('screensavers.configs.melting_clock.color_mode', 'rainbow')
 
-        for y in range(self.__height):
-            for x in range(self.__width):
+        for y in range(self._height):
+            for x in range(self._width):
                 b = self.__buffer[y, x]
                 if b > 0.01:
                     if color_mode == 'rainbow':

--- a/pifi/screensaver/metaballs.py
+++ b/pifi/screensaver/metaballs.py
@@ -19,16 +19,13 @@ class Metaballs(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Metaballs: each is [x, y, radius, vx, vy, hue]
         self.__balls = []
         self.__time = 0.0
 
         # Precompute coordinate grids
-        x = np.arange(self.__width)
-        y = np.arange(self.__height)
+        x = np.arange(self._width)
+        y = np.arange(self._height)
         self.__grid_x, self.__grid_y = np.meshgrid(x, y)
 
     def _setup(self):
@@ -50,12 +47,12 @@ class Metaballs(Screensaver):
 
     def __create_ball(self, index, total):
         """Create a metaball with random properties."""
-        x = random.uniform(0, self.__width)
-        y = random.uniform(0, self.__height)
+        x = random.uniform(0, self._width)
+        y = random.uniform(0, self._height)
 
         # Radius affects the "strength" of the metaball
-        min_radius = min(self.__width, self.__height) * 0.15
-        max_radius = min(self.__width, self.__height) * 0.35
+        min_radius = min(self._width, self._height) * 0.15
+        max_radius = min(self._width, self._height) * 0.35
         radius = random.uniform(min_radius, max_radius)
 
         # Random velocity
@@ -81,20 +78,20 @@ class Metaballs(Screensaver):
 
             # Bounce off edges with some padding
             padding = ball[2] * 0.3
-            if ball[0] < padding or ball[0] >= self.__width - padding:
+            if ball[0] < padding or ball[0] >= self._width - padding:
                 ball[3] *= -1
-                ball[0] = max(padding, min(self.__width - padding - 1, ball[0]))
-            if ball[1] < padding or ball[1] >= self.__height - padding:
+                ball[0] = max(padding, min(self._width - padding - 1, ball[0]))
+            if ball[1] < padding or ball[1] >= self._height - padding:
                 ball[4] *= -1
-                ball[1] = max(padding, min(self.__height - padding - 1, ball[1]))
+                ball[1] = max(padding, min(self._height - padding - 1, ball[1]))
 
     def __render(self):
         # Calculate metaball field
         # For each pixel, sum the contribution from each ball
         # Contribution = radius^2 / distance^2 (inverse square falloff)
 
-        field = np.zeros((self.__height, self.__width), dtype=np.float64)
-        color_field = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        field = np.zeros((self._height, self._width), dtype=np.float64)
+        color_field = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
         for ball in self.__balls:
             bx, by, radius, _, _, hue = ball
@@ -129,7 +126,7 @@ class Metaballs(Screensaver):
         intensity = np.clip((field - threshold * 0.5) / (threshold * 0.5), 0, 1)
 
         # Create frame
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
 
         for c in range(3):
             frame[:, :, c] = (color_field[:, :, c] * intensity * 255).astype(np.uint8)

--- a/pifi/screensaver/misprint.py
+++ b/pifi/screensaver/misprint.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -27,8 +26,6 @@ class Misprint(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -38,9 +35,9 @@ class Misprint(Screensaver):
         self.__num_passes = len(self.__colors)
 
         # Pre-compute coordinates
-        cy, cx = self.__height / 2, self.__width / 2
-        y = np.arange(self.__height, dtype=np.float64) - cy
-        x = np.arange(self.__width, dtype=np.float64) - cx
+        cy, cx = self._height / 2, self._width / 2
+        y = np.arange(self._height, dtype=np.float64) - cy
+        x = np.arange(self._width, dtype=np.float64) - cx
         self.__gx, self.__gy = np.meshgrid(x, y)
         self.__dist = np.sqrt(self.__gx ** 2 + self.__gy ** 2)
         self.__angle = np.arctan2(self.__gy, self.__gx)
@@ -80,7 +77,7 @@ class Misprint(Screensaver):
         self.__time += 0.012
         t = self.__time
 
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
         for i in range(self.__num_passes):
             color = np.array(self.__colors[i])
@@ -114,7 +111,7 @@ class Misprint(Screensaver):
 
     def __render_composition(self, gx, gy, t):
         """Render the composition shapes as a 0-1 mask."""
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
         scale = min(w, h)
 
         if self.__composition == 'circles':

--- a/pifi/screensaver/moire.py
+++ b/pifi/screensaver/moire.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -19,8 +18,6 @@ class Moire(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -29,8 +26,8 @@ class Moire(Screensaver):
         self.__speed = random.uniform(0.008, 0.015)
 
         # Pre-compute coordinate grid
-        y = np.arange(self.__height, dtype=np.float64)
-        x = np.arange(self.__width, dtype=np.float64)
+        y = np.arange(self._height, dtype=np.float64)
+        x = np.arange(self._width, dtype=np.float64)
         self.__gx, self.__gy = np.meshgrid(x, y)
 
         # 2-3 pattern layers, each with:
@@ -40,7 +37,7 @@ class Moire(Screensaver):
         # - drift speed and angle
         self.__num_layers = random.choice([2, 3])
         self.__layers = []
-        cx, cy = self.__width / 2, self.__height / 2
+        cx, cy = self._width / 2, self._height / 2
 
         for i in range(self.__num_layers):
             layer = {

--- a/pifi/screensaver/noisegradient.py
+++ b/pifi/screensaver/noisegradient.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,16 +19,14 @@ class NoiseGradient(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
         self.__time = 0.0
 
         # Pre-compute coordinate grids (normalized 0-1)
-        y = np.linspace(0, 1, self.__height, dtype=np.float64)
-        x = np.linspace(0, 1, self.__width, dtype=np.float64)
+        y = np.linspace(0, 1, self._height, dtype=np.float64)
+        x = np.linspace(0, 1, self._width, dtype=np.float64)
         self.__gx, self.__gy = np.meshgrid(x, y)
 
         # Starting hue and gradient angle

--- a/pifi/screensaver/nycsubway.py
+++ b/pifi/screensaver/nycsubway.py
@@ -25,7 +25,6 @@ import requests
 import underground  # imported after the protobuf env var above is set
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver import textutils
 
@@ -77,10 +76,6 @@ class NycSubway(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get('leds.display_width')
-        self.__height = Config.get('leds.display_height')
 
         # Configuration
         self.__stop_ids = Config.get('screensavers.configs.nyc_subway.stop_ids', ['127N', '127S'])
@@ -111,7 +106,7 @@ class NycSubway(Screensaver):
 
         try:
             self.__underground = underground
-            self.__logger.info("underground library loaded successfully")
+            self._logger.info("underground library loaded successfully")
 
             # Load station names on first init
             if not self.__station_names_loaded:
@@ -120,7 +115,7 @@ class NycSubway(Screensaver):
             return True
         except Exception as e:
             self.__error_message = "ERR"
-            self.__logger.error(f"Failed to load underground: {e}")
+            self._logger.error(f"Failed to load underground: {e}")
             return False
 
     def __load_station_names(self):
@@ -139,19 +134,19 @@ class NycSubway(Screensaver):
                 if cache_age < cache_max_age:
                     with open(cache_file, 'r') as f:
                         self.__station_names = json.load(f)
-                    self.__logger.info(f"Loaded {len(self.__station_names)} station names from cache")
+                    self._logger.info(f"Loaded {len(self.__station_names)} station names from cache")
                     return
                 else:
-                    self.__logger.info("Station cache expired, refreshing...")
+                    self._logger.info("Station cache expired, refreshing...")
         except Exception as e:
-            self.__logger.warning(f"Failed to load cache: {e}")
+            self._logger.warning(f"Failed to load cache: {e}")
 
         # Fetch from MTA
         try:
             # MTA's static GTFS feed URL
             gtfs_url = "http://web.mta.info/developers/data/nyct/subway/google_transit.zip"
 
-            self.__logger.info("Fetching MTA station names...")
+            self._logger.info("Fetching MTA station names...")
             response = requests.get(gtfs_url, timeout=30)
             response.raise_for_status()
 
@@ -179,19 +174,19 @@ class NycSubway(Screensaver):
                             short_name = short_name.replace('TIMES SQUARE', 'TIMES SQ')
                             self.__station_names[stop_id] = short_name
 
-            self.__logger.info(f"Loaded {len(self.__station_names)} station names from MTA")
+            self._logger.info(f"Loaded {len(self.__station_names)} station names from MTA")
 
             # Save to cache
             try:
                 cache_dir.mkdir(parents=True, exist_ok=True)
                 with open(cache_file, 'w') as f:
                     json.dump(self.__station_names, f)
-                self.__logger.info("Saved station names to cache")
+                self._logger.info("Saved station names to cache")
             except Exception as e:
-                self.__logger.warning(f"Failed to save cache: {e}")
+                self._logger.warning(f"Failed to save cache: {e}")
 
         except Exception as e:
-            self.__logger.warning(f"Failed to load station names: {e}")
+            self._logger.warning(f"Failed to load station names: {e}")
             # Continue without station names - will fall back to stop_id
 
     def __fetch_arrivals(self):
@@ -239,20 +234,20 @@ class NycSubway(Screensaver):
                                     })
 
                 except Exception as e:
-                    self.__logger.warning(f"Error fetching feed {feed_url}: {e}")
+                    self._logger.warning(f"Error fetching feed {feed_url}: {e}")
 
             # Sort by arrival time
             arrivals.sort(key=lambda x: x['minutes'])
             self.__arrivals = arrivals
             self.__error_message = None
-            self.__logger.info(f"Fetched {len(self.__arrivals)} arrivals")
+            self._logger.info(f"Fetched {len(self.__arrivals)} arrivals")
 
             # Group arrivals by stop_id
             self.__group_arrivals()
 
         except Exception as e:
             self.__error_message = "ERR"
-            self.__logger.error(f"Failed to fetch arrivals: {e}")
+            self._logger.error(f"Failed to fetch arrivals: {e}")
 
     def __group_arrivals(self):
         """Group arrivals by (stop_id, line) pair with multiple times."""
@@ -329,7 +324,7 @@ class NycSubway(Screensaver):
 
     def __render(self):
         """Render the current arrivals to the display."""
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.uint8)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
 
         # Thread-safe copy of arrivals
         with self.__fetch_lock:
@@ -354,7 +349,7 @@ class NycSubway(Screensaver):
 
     def __update_display_rows(self, new_arrivals):
         """Update display rows, triggering animations for changes."""
-        max_rows = self.__height // self.__row_height
+        max_rows = self._height // self.__row_height
 
         # Create keys for comparison
         def make_key(arrival):
@@ -376,7 +371,7 @@ class NycSubway(Screensaver):
         for row in self.__display_rows:
             if row.get('exiting'):
                 row['x_offset'] = row.get('x_offset', 0) + row.get('exit_speed', 4)
-                if row['x_offset'] > self.__width:
+                if row['x_offset'] > self._width:
                     rows_to_remove.append(row)
 
         for row in rows_to_remove:
@@ -441,9 +436,9 @@ class NycSubway(Screensaver):
         y = y_offset
 
         # Skip if completely off screen
-        if y < -self.__row_height or y >= self.__height:
+        if y < -self.__row_height or y >= self._height:
             return
-        if x_offset >= self.__width:
+        if x_offset >= self._width:
             return
 
         # Draw line bullet
@@ -472,14 +467,14 @@ class NycSubway(Screensaver):
         # Calculate total times width
         times_str = ','.join(t[0] for t in times_display)
         times_width = len(times_str) * 4
-        times_x = self.__width - times_width + x_offset
+        times_x = self._width - times_width + x_offset
 
         # Station name scrolls in the middle section
         name_start_x = after_bullet + 4
-        name_end_x = min(times_x - 1, self.__width)
+        name_end_x = min(times_x - 1, self._width)
         name_width = name_end_x - name_start_x
 
-        if name_width > 0 and name_start_x < self.__width:
+        if name_width > 0 and name_start_x < self._width:
             self.__draw_scrolling_text(
                 frame, station_name,
                 name_start_x, y + 1,
@@ -498,11 +493,11 @@ class NycSubway(Screensaver):
                     int(time_color[1] * (0.5 + 0.5 * pulse)),
                     int(time_color[2] * (0.5 + 0.5 * pulse))
                 )
-            if cursor_x < self.__width:
+            if cursor_x < self._width:
                 self.__draw_text(frame, time_text, cursor_x, y + 1, time_color)
             cursor_x += len(time_text) * 4
             if idx < len(times_display) - 1:
-                if cursor_x < self.__width:
+                if cursor_x < self._width:
                     self.__draw_char(frame, ',', cursor_x, y + 1, (100, 100, 100))
                 cursor_x += 4
 
@@ -510,7 +505,7 @@ class NycSubway(Screensaver):
         """Draw text that scrolls horizontally if too wide, with partial character clipping."""
         textutils.draw_scrolling_text(
             frame, text, x, y, max_width, color,
-            self.__scroll_offset, self.__width, self.__height
+            self.__scroll_offset, self._width, self._height
         )
 
     def __draw_bullet(self, frame, x, y, line, color):
@@ -531,7 +526,7 @@ class NycSubway(Screensaver):
             for dx in range(7):
                 if circle[dy][dx]:
                     px, py = x + dx, y + dy
-                    if 0 <= px < self.__width and 0 <= py < self.__height:
+                    if 0 <= px < self._width and 0 <= py < self._height:
                         frame[py, px] = color
 
         # Draw line letter/number centered (3x5 font centered in 7x7)
@@ -540,15 +535,15 @@ class NycSubway(Screensaver):
         brightness = (color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114)
         text_color = (0, 0, 0) if brightness > 128 else (255, 255, 255)
         # Center the 3x5 char in the 7x7 circle: x+2, y+1
-        textutils.draw_char(frame, char, x + 2, y + 1, text_color, self.__width, self.__height)
+        textutils.draw_char(frame, char, x + 2, y + 1, text_color, self._width, self._height)
 
     def __draw_char(self, frame, char, x, y, color):
         """Draw a single 3x5 character."""
-        textutils.draw_char(frame, char, x, y, color, self.__width, self.__height)
+        textutils.draw_char(frame, char, x, y, color, self._width, self._height)
 
     def __draw_text(self, frame, text, x, y, color):
         """Draw a text string."""
-        textutils.draw_text(frame, text, x, y, color, self.__width, self.__height)
+        textutils.draw_text(frame, text, x, y, color, self._width, self._height)
 
     @classmethod
     def get_id(cls) -> str:

--- a/pifi/screensaver/opart.py
+++ b/pifi/screensaver/opart.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math  # pyright: ignore[reportUnusedImport]
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,8 +19,6 @@ class OpArt(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -29,9 +26,9 @@ class OpArt(Screensaver):
         self.__speed = random.uniform(0.008, 0.015)
 
         # Pre-compute coordinate grids
-        cy, cx = self.__height / 2, self.__width / 2
-        y = np.arange(self.__height, dtype=np.float64) - cy
-        x = np.arange(self.__width, dtype=np.float64) - cx
+        cy, cx = self._height / 2, self._width / 2
+        y = np.arange(self._height, dtype=np.float64) - cy
+        x = np.arange(self._width, dtype=np.float64) - cx
         self.__gx, self.__gy = np.meshgrid(x, y)
         self.__dist = np.sqrt(self.__gx ** 2 + self.__gy ** 2)
         self.__angle = np.arctan2(self.__gy, self.__gx)

--- a/pifi/screensaver/pendulumwaves.py
+++ b/pifi/screensaver/pendulumwaves.py
@@ -19,9 +19,6 @@ class PendulumWaves(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get('leds.display_width')
-        self.__height = Config.get('leds.display_height')
-
         # Config
         self.__num_pendulums = Config.get('screensavers.configs.pendulumwaves.num_pendulums', 0)  # 0 = auto
         self.__base_period = Config.get('screensavers.configs.pendulumwaves.base_period', 60.0)  # frames for longest pendulum
@@ -32,10 +29,10 @@ class PendulumWaves(Screensaver):
 
         # Auto-calculate pendulum count if not specified
         if self.__num_pendulums <= 0:
-            self.__num_pendulums = self.__width
+            self.__num_pendulums = self._width
 
         # Canvas buffer
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
     def __init_pendulums(self):
         """Initialize pendulum parameters."""
@@ -79,7 +76,7 @@ class PendulumWaves(Screensaver):
                 py = int(cy + dy)
 
                 # Skip out of bounds
-                if px < 0 or px >= self.__width or py < 0 or py >= self.__height:
+                if px < 0 or px >= self._width or py < 0 or py >= self._height:
                     continue
 
                 # Distance from center
@@ -101,7 +98,7 @@ class PendulumWaves(Screensaver):
         self.__canvas *= self.__trail_fade
 
         # Calculate spacing
-        spacing = self.__width / self.__num_pendulums
+        spacing = self._width / self.__num_pendulums
         margin = spacing / 2
 
         # Draw each pendulum
@@ -116,8 +113,8 @@ class PendulumWaves(Screensaver):
 
             # Map to screen coordinates
             # Pendulum swings in the middle portion of the screen
-            amplitude = (self.__height - 2) / 2
-            center_y = self.__height / 2
+            amplitude = (self._height - 2) / 2
+            center_y = self._height / 2
             y = center_y + y_normalized * amplitude * 0.8
 
             # Get color and draw

--- a/pifi/screensaver/perlinworms.py
+++ b/pifi/screensaver/perlinworms.py
@@ -19,9 +19,6 @@ class PerlinWorms(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get('leds.display_width')
-        self.__height = Config.get('leds.display_height')
-
         # Config
         self.__num_worms = Config.get('screensavers.configs.perlinworms.num_worms', 8)
         self.__worm_length = Config.get('screensavers.configs.perlinworms.worm_length', 12)
@@ -39,7 +36,7 @@ class PerlinWorms(Screensaver):
         self.__worm_hues = []
 
         # Canvas buffer (float for smooth accumulation)
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
         self.__time = 0.0
 
@@ -96,8 +93,8 @@ class PerlinWorms(Screensaver):
 
         for i in range(self.__num_worms):
             # Start at random position
-            x = np.random.uniform(0, self.__width)
-            y = np.random.uniform(0, self.__height)
+            x = np.random.uniform(0, self._width)
+            y = np.random.uniform(0, self._height)
 
             # Initialize with single position (will grow)
             self.__worms.append([(x, y)])
@@ -131,8 +128,8 @@ class PerlinWorms(Screensaver):
             new_y = hy + math.sin(angle) * self.__speed
 
             # Wrap around edges
-            new_x = new_x % self.__width
-            new_y = new_y % self.__height
+            new_x = new_x % self._width
+            new_y = new_y % self._height
 
             # Add new head position
             worm.insert(0, (new_x, new_y))
@@ -169,8 +166,8 @@ class PerlinWorms(Screensaver):
 
         for dy in range(-radius, radius + 1):
             for dx in range(-radius, radius + 1):
-                px = int(cx + dx) % self.__width
-                py = int(cy + dy) % self.__height
+                px = int(cx + dx) % self._width
+                py = int(cy + dy) % self._height
 
                 # Distance from center
                 dist = math.sqrt((cx - int(cx) - dx) ** 2 + (cy - int(cy) - dy) ** 2)

--- a/pifi/screensaver/phyllotaxis.py
+++ b/pifi/screensaver/phyllotaxis.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -21,8 +20,6 @@ class Phyllotaxis(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -31,12 +28,12 @@ class Phyllotaxis(Screensaver):
         self.__speed = random.uniform(0.015, 0.025)
         self.__rotation_speed = random.uniform(0.005, 0.015) * random.choice([-1, 1])
 
-        self.__cx = self.__width / 2
-        self.__cy = self.__height / 2
-        self.__max_radius = min(self.__width, self.__height) / 2 * 0.95
+        self.__cx = self._width / 2
+        self.__cy = self._height / 2
+        self.__max_radius = min(self._width, self._height) / 2 * 0.95
 
         # How many dots fill the display nicely
-        area = self.__width * self.__height
+        area = self._width * self._height
         self.__max_dots = int(area * 0.6)
 
         # Color scheme — controls how hue varies across the spiral
@@ -57,7 +54,7 @@ class Phyllotaxis(Screensaver):
             self.__hue_spread = 1.0
 
         # Pre-allocate canvas
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
     def _tick(self):
         self.__time += self.__speed
@@ -86,7 +83,7 @@ class Phyllotaxis(Screensaver):
             ix = int(round(px))
             iy = int(round(py))
 
-            if 0 <= ix < self.__width and 0 <= iy < self.__height:
+            if 0 <= ix < self._width and 0 <= iy < self._height:
                 norm_r = r / self.__max_radius
 
                 # Color depends on scheme

--- a/pifi/screensaver/pixelsort.py
+++ b/pifi/screensaver/pixelsort.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb_uint8_frame
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,8 +19,6 @@ class PixelSort(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
         self.__time = 0.0
 
     def _setup(self):
@@ -33,8 +30,8 @@ class PixelSort(Screensaver):
         self.__sort_axis = random.choice(['horizontal', 'vertical'])
 
         # Pre-compute coordinate grids
-        y = np.linspace(0, 1, self.__height, dtype=np.float64)
-        x = np.linspace(0, 1, self.__width, dtype=np.float64)
+        y = np.linspace(0, 1, self._height, dtype=np.float64)
+        x = np.linspace(0, 1, self._width, dtype=np.float64)
         self.__gx, self.__gy = np.meshgrid(x, y)
 
         # Random source pattern parameters
@@ -82,11 +79,11 @@ class PixelSort(Screensaver):
         result = frame.copy()
 
         if self.__sort_axis == 'horizontal':
-            for y in range(self.__height):
+            for y in range(self._height):
                 result[y] = self.__sort_row(frame[y], brightness[y], lo, hi)
         else:
             # Sort columns by transposing, sorting rows, transposing back
-            for x in range(self.__width):
+            for x in range(self._width):
                 result[:, x] = self.__sort_row(frame[:, x], brightness[:, x], lo, hi)
 
         return result

--- a/pifi/screensaver/purkinje.py
+++ b/pifi/screensaver/purkinje.py
@@ -2,7 +2,6 @@ import math
 import numpy as np
 import random
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -33,19 +32,16 @@ class Purkinje(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Pre-compute coordinate grids (done once, reused every tick)
-        y_coords, x_coords = np.mgrid[0:self.__height, 0:self.__width]
+        y_coords, x_coords = np.mgrid[0:self._height, 0:self._width]
         self.__x_grid = x_coords.astype(np.float32)
         self.__y_grid = y_coords.astype(np.float32)
-        self.__x_norm = self.__x_grid / max(self.__width, 1)
-        self.__y_norm = self.__y_grid / max(self.__height, 1)
+        self.__x_norm = self.__x_grid / max(self._width, 1)
+        self.__y_norm = self.__y_grid / max(self._height, 1)
 
         # Center coordinates
-        self.__cx = self.__width / 2.0
-        self.__cy = self.__height / 2.0
+        self.__cx = self._width / 2.0
+        self.__cy = self._height / 2.0
 
         # Distance from center (used by several modes)
         dx = self.__x_grid - self.__cx
@@ -71,7 +67,7 @@ class Purkinje(Screensaver):
         dt = 0.025
         self.__time += dt
 
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
         if self.__mode == self.MODE_LATTICE:
             self.__tick_lattice(frame)
@@ -177,8 +173,8 @@ class Purkinje(Screensaver):
         self.__vasc_regrow_interval = random.uniform(12.0, 20.0)
         self.__vasc_last_regrow = 0.0
         # Current and target fields for smooth morphing
-        self.__vascular_field = np.zeros((self.__height, self.__width), dtype=np.float32)
-        self.__vasc_target_field = np.zeros((self.__height, self.__width), dtype=np.float32)
+        self.__vascular_field = np.zeros((self._height, self._width), dtype=np.float32)
+        self.__vasc_target_field = np.zeros((self._height, self._width), dtype=np.float32)
         self.__vasc_morph_progress = 1.0  # start by generating first tree immediately
         self.__generate_vascular_tree()
         self.__vascular_field = self.__vasc_target_field.copy()
@@ -186,12 +182,12 @@ class Purkinje(Screensaver):
     def __generate_vascular_tree(self):
         """Generate a new random vascular tree and store as target field."""
         self.__branches = []
-        ox = self.__cx + random.uniform(-self.__width * 0.2, self.__width * 0.2)
-        oy = self.__cy + random.uniform(-self.__height * 0.2, self.__height * 0.2)
+        ox = self.__cx + random.uniform(-self._width * 0.2, self._width * 0.2)
+        oy = self.__cy + random.uniform(-self._height * 0.2, self._height * 0.2)
         n_main = random.randint(3, 5)
         for i in range(n_main):
             angle = (2 * math.pi * i / n_main) + random.uniform(-0.4, 0.4)
-            length = min(self.__width, self.__height) * random.uniform(0.3, 0.55)
+            length = min(self._width, self._height) * random.uniform(0.3, 0.55)
             self.__grow_branch(ox, oy, angle, length, thickness=1.8, depth=0, max_depth=4)
         self.__vasc_target_field = self.__compute_branch_field()
         self.__vasc_morph_progress = 0.0
@@ -220,7 +216,7 @@ class Purkinje(Screensaver):
         weighted by branch thickness. Returns a float32 array where higher
         values mean closer to a branch.
         """
-        field = np.zeros((self.__height, self.__width), dtype=np.float32)
+        field = np.zeros((self._height, self._width), dtype=np.float32)
 
         for (x1, y1, x2, y2, thickness) in self.__branches:
             # Vectorised point-to-segment distance
@@ -301,15 +297,15 @@ class Purkinje(Screensaver):
             self.__bf_particles.append({
                 'phase': random.uniform(0, 2 * math.pi),
                 'speed': random.uniform(0.8, 2.5),
-                'y_base': random.uniform(0, self.__height),
+                'y_base': random.uniform(0, self._height),
                 'x_freq': random.uniform(0.3, 1.0),
-                'x_amp': random.uniform(self.__width * 0.1, self.__width * 0.4),
-                'x_center': random.uniform(self.__width * 0.2, self.__width * 0.8),
+                'x_amp': random.uniform(self._width * 0.1, self._width * 0.4),
+                'x_center': random.uniform(self._width * 0.2, self._width * 0.8),
                 'brightness': random.uniform(0.7, 1.0),
                 'size': random.uniform(0.6, 1.2),
             })
         # Trail buffer: small 2D accumulation buffer that fades each frame
-        self.__bf_trail = np.zeros((self.__height, self.__width), dtype=np.float32)
+        self.__bf_trail = np.zeros((self._height, self._width), dtype=np.float32)
 
     def __tick_bluefield(self, frame):
         t = self.__time
@@ -332,12 +328,12 @@ class Purkinje(Screensaver):
         for p in self.__bf_particles:
             # Curved path: x follows a sinusoidal course, y advances linearly
             progress = (t * p['speed'] + p['phase'])
-            py = (p['y_base'] + progress * 4.0) % self.__height
+            py = (p['y_base'] + progress * 4.0) % self._height
             px = p['x_center'] + math.sin(progress * p['x_freq']) * p['x_amp']
-            px = px % self.__width
+            px = px % self._width
 
-            ix = int(px) % self.__width
-            iy = int(py) % self.__height
+            ix = int(px) % self._width
+            iy = int(py) % self._height
 
             # Deposit into trail buffer (soft dot)
             bright = p['brightness'] * (0.7 + 0.3 * math.sin(t * 3.0 + p['phase']))
@@ -347,8 +343,8 @@ class Purkinje(Screensaver):
             r_int = int(math.ceil(radius)) + 1
             for dy in range(-r_int, r_int + 1):
                 for dx in range(-r_int, r_int + 1):
-                    nx = (ix + dx) % self.__width
-                    ny = (iy + dy) % self.__height
+                    nx = (ix + dx) % self._width
+                    ny = (iy + dy) % self._height
                     d = math.sqrt(dx * dx + dy * dy)
                     if d < radius + 0.5:
                         falloff = max(0, 1.0 - d / (radius + 0.5))
@@ -369,7 +365,7 @@ class Purkinje(Screensaver):
         self.__ai_shape_time = 0.0
         self.__ai_cycle_period = random.uniform(4.0, 7.0)
         # Accumulation buffer for the afterimage (RGB float)
-        self.__ai_ghost = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__ai_ghost = np.zeros((self._height, self._width, 3), dtype=np.float32)
         # Choose shape types
         self.__ai_shapes = ['circle', 'ring', 'bar', 'diamond']
 
@@ -426,7 +422,7 @@ class Purkinje(Screensaver):
         """Return a float32 mask (0-1) for the given shape type."""
         # Gentle pulsing size
         pulse = 0.8 + 0.2 * math.sin(t * 1.5)
-        base_size = min(self.__width, self.__height) * 0.3 * pulse
+        base_size = min(self._width, self._height) * 0.3 * pulse
 
         if shape == 'circle':
             return np.clip(1.0 - self.__dist_center / max(base_size, 1), 0, 1)
@@ -458,7 +454,7 @@ class Purkinje(Screensaver):
             diamond_dist = dx + dy
             return np.clip(1.0 - diamond_dist / max(base_size * 1.2, 1), 0, 1)
 
-        return np.zeros((self.__height, self.__width), dtype=np.float32)
+        return np.zeros((self._height, self._width), dtype=np.float32)
 
     # ------------------------------------------------------------------ #
     #  Class metadata                                                      #

--- a/pifi/screensaver/screensaver.py
+++ b/pifi/screensaver/screensaver.py
@@ -19,8 +19,6 @@ class Screensaver(ABC):
     - _tick() returns False (for subclass-specific stop conditions)
     """
 
-    _screensaver_logger = Logger().set_namespace('Screensaver')
-
     def __init__(self, led_frame_player=None):
         """
         Standard constructor signature for all screensavers.
@@ -34,6 +32,12 @@ class Screensaver(ABC):
         """
         # Flag to verify subclasses call super().__init__()
         self.__screensaver_base_init_called = True
+
+        # Logger namespaced to the concrete subclass (e.g. 'Boids'), and the
+        # display dimensions — all available to every screensaver by default.
+        self._logger = Logger().set_namespace(self.__class__.__name__)
+        self._width = Config.get_or_throw('leds.display_width')
+        self._height = Config.get_or_throw('leds.display_height')
 
         if led_frame_player is None:
             led_frame_player = LedFramePlayer()
@@ -133,7 +137,7 @@ class Screensaver(ABC):
                 loop ends. Set to False to keep the screensaver alive for
                 transitions — the caller must call teardown() manually.
         """
-        self._screensaver_logger.info(f"Starting {self.get_name()} screensaver")
+        self._logger.info(f"Starting {self.get_name()} screensaver")
         self.__start_time = time.time()
         self.setup()
 
@@ -148,7 +152,7 @@ class Screensaver(ABC):
             raise
         if auto_teardown:
             self.teardown()
-        self._screensaver_logger.info(f"{self.get_name()} screensaver ended")
+        self._logger.info(f"{self.get_name()} screensaver ended")
 
     def _setup(self):
         """Called once before the tick loop. Override for initialization."""

--- a/pifi/screensaver/selfhealingsquares.py
+++ b/pifi/screensaver/selfhealingsquares.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -20,26 +19,23 @@ class SelfHealingSquares(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
     def _setup(self):
         self.__time = 0.0
 
         # Grid spacing
-        self.__spacing = max(3, min(self.__width, self.__height) // 8)
+        self.__spacing = max(3, min(self._width, self._height) // 8)
 
         # Number of grid nodes (one extra on each side for edge coverage)
-        self.__cols = int(self.__width / self.__spacing) + 3
-        self.__rows = int(self.__height / self.__spacing) + 3
+        self.__cols = int(self._width / self.__spacing) + 3
+        self.__rows = int(self._height / self.__spacing) + 3
 
         # Starting offset so grid is centered
-        self.__ox = (self.__width - (self.__cols - 1) * self.__spacing) / 2.0
-        self.__oy = (self.__height - (self.__rows - 1) * self.__spacing) / 2.0
+        self.__ox = (self._width - (self.__cols - 1) * self.__spacing) / 2.0
+        self.__oy = (self._height - (self.__rows - 1) * self.__spacing) / 2.0
 
         # Center of the display
-        self.__cx = self.__width / 2.0
-        self.__cy = self.__height / 2.0
+        self.__cx = self._width / 2.0
+        self.__cy = self._height / 2.0
 
         # Maximum distance from center (for normalizing distortion)
         self.__max_dist = math.sqrt(self.__cx ** 2 + self.__cy ** 2)
@@ -52,7 +48,7 @@ class SelfHealingSquares(Screensaver):
         self.__hue = random.random()
 
         # Frame buffer
-        self.__frame = np.zeros((self.__height, self.__width, 3), dtype=np.uint8)
+        self.__frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
 
     def _tick(self):
         self.__time += 0.015
@@ -120,7 +116,7 @@ class SelfHealingSquares(Screensaver):
             t = s / steps
             px = int(round(x1 + dx * t))
             py = int(round(y1 + dy * t))
-            if 0 <= px < self.__width and 0 <= py < self.__height:
+            if 0 <= px < self._width and 0 <= py < self._height:
                 self.__frame[py, px] = color
 
     @classmethod

--- a/pifi/screensaver/selfhealingsquares.py
+++ b/pifi/screensaver/selfhealingsquares.py
@@ -16,9 +16,6 @@ class SelfHealingSquares(Screensaver):
     grid continuously breaks apart and heals back.
     """
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
 

--- a/pifi/screensaver/shadebobs.py
+++ b/pifi/screensaver/shadebobs.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -18,10 +17,6 @@ class Shadebobs(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
         # Frame buffer as float for smooth accumulation
         self.__buffer = None
@@ -48,8 +43,8 @@ class Shadebobs(Screensaver):
             y = math.sin(bob['freq_y'] * t + bob['phase_y'])
 
             # Map from [-1, 1] to screen coordinates
-            screen_x = (x + 1) / 2 * (self.__width - 1)
-            screen_y = (y + 1) / 2 * (self.__height - 1)
+            screen_x = (x + 1) / 2 * (self._width - 1)
+            screen_y = (y + 1) / 2 * (self._height - 1)
 
             # Draw the bob with additive blending
             self.__draw_bob(screen_x, screen_y, bob)
@@ -59,7 +54,7 @@ class Shadebobs(Screensaver):
 
     def __reset(self):
         # Float buffer for smooth color accumulation
-        self.__buffer = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__buffer = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
         # Create bobs with different Lissajous parameters
         num_bobs = Config.get('screensavers.configs.shadebobs.num_bobs', 5)
@@ -84,7 +79,7 @@ class Shadebobs(Screensaver):
             }
             self.__bobs.append(bob)
 
-        self.__logger.info(f"Created {num_bobs} shadebobs")
+        self._logger.info(f"Created {num_bobs} shadebobs")
 
     def __draw_bob(self, cx, cy, bob):
         """Draw a glowing bob at the given position with additive blending."""
@@ -95,9 +90,9 @@ class Shadebobs(Screensaver):
 
         # Calculate bounding box
         x_min = max(0, int(cx - radius - 1))
-        x_max = min(self.__width, int(cx + radius + 2))
+        x_max = min(self._width, int(cx + radius + 2))
         y_min = max(0, int(cy - radius - 1))
-        y_max = min(self.__height, int(cy + radius + 2))
+        y_max = min(self._height, int(cy + radius + 2))
 
         for y in range(y_min, y_max):
             for x in range(x_min, x_max):

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -20,9 +20,6 @@ class Spirograph(Screensaver):
 
     VARIANTS = ['hypotrochoid', 'epitrochoid', 'compound', 'star_ring']
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
         self.__variant = random.choice(self.VARIANTS)

--- a/pifi/screensaver/spirograph.py
+++ b/pifi/screensaver/spirograph.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.colorutils import hsv_to_rgb
 from pifi.screensaver.screensaver import Screensaver
 
@@ -23,10 +22,6 @@ class Spirograph(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
     def _setup(self):
         self.__time = 0.0
@@ -34,11 +29,11 @@ class Spirograph(Screensaver):
 
         self.__speed = random.uniform(0.04, 0.08)
         self.__hue_speed = random.uniform(0.001, 0.003)
-        self.__cx = self.__width / 2.0
-        self.__cy = self.__height / 2.0
+        self.__cx = self._width / 2.0
+        self.__cy = self._height / 2.0
 
         # Trail canvas (persistent, fading)
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float64)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float64)
 
         setup_fn, self.__compute_fn = {
             'hypotrochoid': (self.__setup_hypotrochoid, self.__compute_hypotrochoid),
@@ -60,10 +55,10 @@ class Spirograph(Screensaver):
 
         # Hypotrochoid stays within R, but d > r creates loops outside (R-r)+d
         max_extent = max(R, (R - r) + d)
-        self.__scale = min(self.__width, self.__height) / 2.0 * 0.92 / max_extent
+        self.__scale = min(self._width, self._height) / 2.0 * 0.92 / max_extent
         self.__R, self.__r, self.__d = R, r, d
 
-        self.__logger.info(
+        self._logger.info(
             f"Spirograph hypotrochoid: R={R:.3f}, r={r:.3f}, d={d:.3f}")
 
     def __setup_epitrochoid(self):
@@ -76,10 +71,10 @@ class Spirograph(Screensaver):
             r *= 1.1
 
         max_extent = R + r + d
-        self.__scale = min(self.__width, self.__height) / 2.0 * 0.92 / max_extent
+        self.__scale = min(self._width, self._height) / 2.0 * 0.92 / max_extent
         self.__R, self.__r, self.__d = R, r, d  # pyright: ignore[reportConstantRedefinition]
 
-        self.__logger.info(
+        self._logger.info(
             f"Spirograph epitrochoid: R={R:.3f}, r={r:.3f}, d={d:.3f}")
 
     def __setup_compound(self):
@@ -99,11 +94,11 @@ class Spirograph(Screensaver):
             f2 = -f2
 
         max_extent = a1 + a2
-        self.__scale = min(self.__width, self.__height) / 2.0 * 0.90 / max_extent
+        self.__scale = min(self._width, self._height) / 2.0 * 0.90 / max_extent
         self.__a1, self.__a2 = a1, a2
         self.__f1, self.__f2 = f1, f2
 
-        self.__logger.info(
+        self._logger.info(
             f"Spirograph compound: a1={a1:.3f}, a2={a2:.3f}, " +
             f"f1={f1:.3f}, f2={f2:.3f}")
 
@@ -119,12 +114,12 @@ class Spirograph(Screensaver):
             r *= 1.1
 
         max_extent = R * (1 + amplitude)
-        self.__scale = min(self.__width, self.__height) / 2.0 * 0.90 / max_extent
+        self.__scale = min(self._width, self._height) / 2.0 * 0.90 / max_extent
         self.__R, self.__r, self.__d = R, r, d  # pyright: ignore[reportConstantRedefinition]
         self.__n_points = n_points
         self.__amplitude = amplitude
 
-        self.__logger.info(
+        self._logger.info(
             f"Spirograph star_ring: R={R:.3f}, r={r:.3f}, d={d:.3f}, " +
             f"n={n_points}, amp={amplitude:.3f}")
 
@@ -148,7 +143,7 @@ class Spirograph(Screensaver):
         color = hsv_to_rgb(hue, 0.85, 1.0)
 
         ix, iy = int(round(sx)), int(round(sy))
-        if 0 <= ix < self.__width and 0 <= iy < self.__height:
+        if 0 <= ix < self._width and 0 <= iy < self._height:
             self.__canvas[iy, ix] = np.minimum(
                 1.0, self.__canvas[iy, ix] + np.array(color) * 0.5
             )
@@ -300,7 +295,7 @@ class Spirograph(Screensaver):
                 R_eff = R_base * (1 + amp * math.cos(n * angle))
                 px = int(round(cx + R_eff * math.cos(angle)))
                 py = int(round(cy + R_eff * math.sin(angle)))
-                if 0 <= px < self.__width and 0 <= py < self.__height:
+                if 0 <= px < self._width and 0 <= py < self._height:
                     canvas[py, px] = np.maximum(canvas[py, px], ring_color)
 
             # Rolling gear
@@ -323,7 +318,7 @@ class Spirograph(Screensaver):
 
     def __draw_dot(self, canvas, x, y, color):
         ix, iy = int(round(x)), int(round(y))
-        if 0 <= ix < self.__width and 0 <= iy < self.__height:
+        if 0 <= ix < self._width and 0 <= iy < self._height:
             canvas[iy, ix] = np.maximum(canvas[iy, ix], color)
 
     def __draw_circle(self, canvas, cx, cy, radius, color):
@@ -333,7 +328,7 @@ class Spirograph(Screensaver):
             angle = 2 * math.pi * i / circumference
             px = int(round(cx + radius * math.cos(angle)))
             py = int(round(cy + radius * math.sin(angle)))
-            if 0 <= px < self.__width and 0 <= py < self.__height:
+            if 0 <= px < self._width and 0 <= py < self._height:
                 canvas[py, px] = np.maximum(canvas[py, px], color)
 
     def __draw_line(self, canvas, x1, y1, x2, y2, color):
@@ -344,7 +339,7 @@ class Spirograph(Screensaver):
             frac = s / steps
             px = int(round(x1 + dx * frac))
             py = int(round(y1 + dy * frac))
-            if 0 <= px < self.__width and 0 <= py < self.__height:
+            if 0 <= px < self._width and 0 <= py < self._height:
                 canvas[py, px] = np.maximum(canvas[py, px], color)
 
     @classmethod

--- a/pifi/screensaver/starfield.py
+++ b/pifi/screensaver/starfield.py
@@ -18,9 +18,6 @@ class Starfield(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Stars: each is [x, y, z] where z is depth (0 = closest, 1 = farthest)
         self.__stars = []
 
@@ -76,10 +73,10 @@ class Starfield(Screensaver):
         self.__stars.append([x, y, z])
 
     def __render(self):
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
 
-        cx = self.__width / 2
-        cy = self.__height / 2
+        cx = self._width / 2
+        cy = self._height / 2
 
         show_trails = Config.get('screensavers.configs.starfield.show_trails', True)
         trail_length = Config.get('screensavers.configs.starfield.trail_length', 3)
@@ -114,7 +111,7 @@ class Starfield(Screensaver):
             ix = int(screen_x)
             iy = int(screen_y)
 
-            if 0 <= ix < self.__width and 0 <= iy < self.__height:
+            if 0 <= ix < self._width and 0 <= iy < self._height:
                 # Draw the star
                 frame[iy, ix] = np.maximum(frame[iy, ix], color)
 
@@ -131,7 +128,7 @@ class Starfield(Screensaver):
                         tix = int(trail_x)
                         tiy = int(trail_y)
 
-                        if 0 <= tix < self.__width and 0 <= tiy < self.__height:
+                        if 0 <= tix < self._width and 0 <= tiy < self._height:
                             trail_int = int(trail_brightness * 255 * (1 - t / (trail_length + 1)))
                             trail_color = [trail_int, trail_int, trail_int]
                             frame[tiy, tix] = np.maximum(frame[tiy, tix], trail_color)

--- a/pifi/screensaver/stringart.py
+++ b/pifi/screensaver/stringart.py
@@ -19,9 +19,6 @@ class StringArt(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get('leds.display_width')
-        self.__height = Config.get('leds.display_height')
-
         # Config
         self.__num_points = Config.get('screensavers.configs.stringart.num_points', 64)
         self.__num_strings = Config.get('screensavers.configs.stringart.num_strings', 32)
@@ -31,7 +28,7 @@ class StringArt(Screensaver):
         self.__line_brightness = Config.get('screensavers.configs.stringart.line_brightness', 0.4)
 
         # Canvas buffer
-        self.__canvas = np.zeros((self.__height, self.__width, 3), dtype=np.float32)
+        self.__canvas = np.zeros((self._height, self._width, 3), dtype=np.float32)
 
         # Animation state
         self.__multiplier = 2.0  # Connection multiplier (creates different patterns)
@@ -59,10 +56,10 @@ class StringArt(Screensaver):
         x1, y1 = int(x1), int(y1)
 
         # Clip to bounds
-        x0 = max(0, min(self.__width - 1, x0))
-        y0 = max(0, min(self.__height - 1, y0))
-        x1 = max(0, min(self.__width - 1, x1))
-        y1 = max(0, min(self.__height - 1, y1))
+        x0 = max(0, min(self._width - 1, x0))
+        y0 = max(0, min(self._height - 1, y0))
+        x1 = max(0, min(self._width - 1, x1))
+        y1 = max(0, min(self._height - 1, y1))
 
         dx = abs(x1 - x0)
         dy = abs(y1 - y0)
@@ -73,7 +70,7 @@ class StringArt(Screensaver):
         x, y = x0, y0
 
         for _ in range(max(dx, dy) + 1):  # Safeguard against infinite loop
-            if 0 <= x < self.__width and 0 <= y < self.__height:
+            if 0 <= x < self._width and 0 <= y < self._height:
                 self.__canvas[y, x, 0] = min(1.0, self.__canvas[y, x, 0] + r * self.__line_brightness)
                 self.__canvas[y, x, 1] = min(1.0, self.__canvas[y, x, 1] + g * self.__line_brightness)
                 self.__canvas[y, x, 2] = min(1.0, self.__canvas[y, x, 2] + b * self.__line_brightness)
@@ -95,9 +92,9 @@ class StringArt(Screensaver):
         self.__canvas *= (1.0 - self.__fade)
 
         # Calculate circle parameters
-        center_x = self.__width / 2
-        center_y = self.__height / 2
-        radius = min(self.__width, self.__height) / 2 - 1
+        center_x = self._width / 2
+        center_y = self._height / 2
+        radius = min(self._width, self._height) / 2 - 1
 
         # Draw strings
         for i in range(self.__num_strings):

--- a/pifi/screensaver/testprint.py
+++ b/pifi/screensaver/testprint.py
@@ -25,9 +25,6 @@ class TestPrint(Screensaver):
         (0, 0, 191),      # blue
     ]
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
 

--- a/pifi/screensaver/testprint.py
+++ b/pifi/screensaver/testprint.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 import math
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -29,15 +28,12 @@ class TestPrint(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
     def _setup(self):
         self.__time = 0.0
 
         # Pre-compute coordinate grids
-        y = np.arange(self.__height, dtype=np.float64)
-        x = np.arange(self.__width, dtype=np.float64)
+        y = np.arange(self._height, dtype=np.float64)
+        x = np.arange(self._width, dtype=np.float64)
         self.__gx, self.__gy = np.meshgrid(x, y)
 
         # Randomize layout: which zones go where
@@ -48,16 +44,16 @@ class TestPrint(Screensaver):
         self.__gradient_speed = random.uniform(0.2, 0.5)
         self.__pulse_speed = random.uniform(1.0, 2.0)
         self.__crosshair_center = (
-            self.__width * random.uniform(0.3, 0.7),
-            self.__height * random.uniform(0.3, 0.7),
+            self._width * random.uniform(0.3, 0.7),
+            self._height * random.uniform(0.3, 0.7),
         )
 
     def _tick(self):
         self.__time += 0.015
         t = self.__time
 
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.uint8)
-        w, h = self.__width, self.__height
+        frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
+        w, h = self._width, self._height
 
         if self.__layout == 'standard':
             # Top 60%: color bars, bottom 20%: gradient, bottom 20%: line test
@@ -204,7 +200,7 @@ class TestPrint(Screensaver):
     def __draw_crosshair(self, frame, t):
         """Pulsing crosshair / registration mark overlay."""
         cx, cy = self.__crosshair_center
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         # Slowly drift the center
         cx = cx + math.sin(t * 0.2) * w * 0.1

--- a/pifi/screensaver/unknownpleasures.py
+++ b/pifi/screensaver/unknownpleasures.py
@@ -18,9 +18,6 @@ class UnknownPleasures(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get('leds.display_width')
-        self.__height = Config.get('leds.display_height')
-
         # Config
         self.__num_lines = Config.get('screensavers.configs.unknownpleasures.num_lines', 0)  # 0 = auto
         self.__wave_speed = Config.get('screensavers.configs.unknownpleasures.wave_speed', 0.05)
@@ -32,12 +29,12 @@ class UnknownPleasures(Screensaver):
 
         # Auto-calculate line count
         if self.__num_lines <= 0:
-            self.__num_lines = max(6, self.__height // 2)
+            self.__num_lines = max(6, self._height // 2)
 
         # Pre-compute arrays for vectorized operations
-        self.__x_coords = np.arange(self.__width, dtype=np.float32)
-        self.__x_indices = np.arange(self.__width, dtype=np.int32)
-        self.__y_grid = np.arange(self.__height, dtype=np.int32)[:, np.newaxis]
+        self.__x_coords = np.arange(self._width, dtype=np.float32)
+        self.__x_indices = np.arange(self._width, dtype=np.int32)
+        self.__y_grid = np.arange(self._height, dtype=np.int32)[:, np.newaxis]
 
         # Perlin noise setup
         self.__perm = None
@@ -95,7 +92,7 @@ class UnknownPleasures(Screensaver):
         x = self.__x_coords
 
         # Multiple octaves of noise
-        value = np.zeros(self.__width, dtype=np.float32)
+        value = np.zeros(self._width, dtype=np.float32)
         freq = 1.0
         amp = 1.0
 
@@ -113,12 +110,12 @@ class UnknownPleasures(Screensaver):
 
     def __render(self):
         """Render the waveforms."""
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.uint8)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
 
-        line_spacing = self.__height / (self.__num_lines + 1)
+        line_spacing = self._height / (self.__num_lines + 1)
 
         # Pre-compute all wave heights as a 2D array (num_lines x width)
-        all_heights = np.zeros((self.__num_lines, self.__width), dtype=np.float32)
+        all_heights = np.zeros((self.__num_lines, self._width), dtype=np.float32)
         all_base_y = np.zeros(self.__num_lines, dtype=np.float32)
 
         for line_idx in range(self.__num_lines):
@@ -129,8 +126,8 @@ class UnknownPleasures(Screensaver):
 
         # Draw from back to front (top to bottom) for occlusion
         for line_idx in range(self.__num_lines):
-            pixel_heights = np.clip(all_heights[line_idx].astype(np.int32), 0, self.__height - 1)
-            fill_end = min(int(all_base_y[line_idx]), self.__height - 1)
+            pixel_heights = np.clip(all_heights[line_idx].astype(np.int32), 0, self._height - 1)
+            fill_end = min(int(all_base_y[line_idx]), self._height - 1)
             color = self.__line_colors[line_idx]  # pyright: ignore[reportOptionalSubscript]
 
             if self.__fill_below:

--- a/pifi/screensaver/vortices.py
+++ b/pifi/screensaver/vortices.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from pifi.config import Config
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -24,12 +23,10 @@ class Vortices(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
 
     def _setup(self):
         self.__time = 0.0
-        w, h = self.__width, self.__height
+        w, h = self._width, self._height
 
         circles = self.__pack_circles(w, h)
         n = len(circles)
@@ -113,7 +110,7 @@ class Vortices(Screensaver):
     def _tick(self):
         self.__time += 0.02
         t = self.__time
-        h, w = self.__height, self.__width
+        h, w = self._height, self._width
 
         if self.__num_circles == 0:
             self._led_frame_player.play_frame(np.zeros((h, w, 3), dtype=np.uint8))

--- a/pifi/screensaver/vortices.py
+++ b/pifi/screensaver/vortices.py
@@ -21,9 +21,6 @@ class Vortices(Screensaver):
         (0.50, 0.65, 0.80),  # Pale blue
     ]
 
-    def __init__(self, led_frame_player=None):
-        super().__init__(led_frame_player)
-
     def _setup(self):
         self.__time = 0.0
         w, h = self._width, self._height

--- a/pifi/screensaver/waveinterference.py
+++ b/pifi/screensaver/waveinterference.py
@@ -18,16 +18,13 @@ class WaveInterference(Screensaver):
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
 
-        self.__width = Config.get_or_throw('leds.display_width')
-        self.__height = Config.get_or_throw('leds.display_height')
-
         # Wave sources: each is [x, y, phase_offset, vx, vy]
         self.__sources = []
         self.__time = 0.0
 
         # Precompute coordinate grids for efficiency
-        x = np.arange(self.__width)
-        y = np.arange(self.__height)
+        x = np.arange(self._width)
+        y = np.arange(self._height)
         self.__grid_x, self.__grid_y = np.meshgrid(x, y)
 
         # Color palette
@@ -55,8 +52,8 @@ class WaveInterference(Screensaver):
 
     def __add_random_source(self):
         """Add a new wave source at a random position with random velocity."""
-        x = random.uniform(0, self.__width)
-        y = random.uniform(0, self.__height)
+        x = random.uniform(0, self._width)
+        y = random.uniform(0, self._height)
         phase_offset = random.uniform(0, 2 * math.pi)
 
         # Slow drift velocity
@@ -75,19 +72,19 @@ class WaveInterference(Screensaver):
             source[1] += source[4]  # y += vy
 
             # Bounce off edges
-            if source[0] < 0 or source[0] >= self.__width:
+            if source[0] < 0 or source[0] >= self._width:
                 source[3] *= -1
-                source[0] = max(0, min(self.__width - 1, source[0]))
-            if source[1] < 0 or source[1] >= self.__height:
+                source[0] = max(0, min(self._width - 1, source[0]))
+            if source[1] < 0 or source[1] >= self._height:
                 source[4] *= -1
-                source[1] = max(0, min(self.__height - 1, source[1]))
+                source[1] = max(0, min(self._height - 1, source[1]))
 
     def __render(self):
         wave_frequency = Config.get('screensavers.configs.wave_interference.wave_frequency', 0.5)
         color_mode = Config.get('screensavers.configs.wave_interference.color_mode', 'rainbow')
 
         # Calculate combined wave amplitude at each pixel
-        amplitude = np.zeros((self.__height, self.__width), dtype=np.float64)
+        amplitude = np.zeros((self._height, self._width), dtype=np.float64)
 
         for source in self.__sources:
             sx, sy, phase_offset, _, _ = source
@@ -106,7 +103,7 @@ class WaveInterference(Screensaver):
         amplitude = amplitude / num_sources
 
         # Convert to frame
-        frame = np.zeros([self.__height, self.__width, 3], np.uint8)
+        frame = np.zeros([self._height, self._width, 3], np.uint8)
 
         if color_mode == 'rainbow':
             # Map amplitude to hue, with time-based offset for color cycling

--- a/pifi/screensaver/wfmu.py
+++ b/pifi/screensaver/wfmu.py
@@ -14,7 +14,6 @@ import numpy as np
 import requests
 
 from pifi.config import Config
-from pifi.logger import Logger
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver import textutils
 
@@ -40,10 +39,6 @@ class Wfmu(Screensaver):
 
     def __init__(self, led_frame_player=None):
         super().__init__(led_frame_player)
-        self.__logger = Logger().set_namespace(self.__class__.__name__)
-
-        self.__width = Config.get('leds.display_width')
-        self.__height = Config.get('leds.display_height')
 
         # Configuration
         channel_name = Config.get('screensavers.configs.wfmu.channel', 'wfmu')
@@ -114,10 +109,10 @@ class Wfmu(Screensaver):
                 self.__show_name = show
                 self.__error_message = None
 
-            self.__logger.info(f"Now playing: {artist} - {title} on {show}")
+            self._logger.info(f"Now playing: {artist} - {title} on {show}")
 
         except Exception as e:
-            self.__logger.error(f"Failed to fetch now playing: {e}")
+            self._logger.error(f"Failed to fetch now playing: {e}")
             with self.__fetch_lock:
                 self.__error_message = "NO SIGNAL"
 
@@ -152,7 +147,7 @@ class Wfmu(Screensaver):
 
     def __render(self):
         """Render the current track info."""
-        frame = np.zeros((self.__height, self.__width, 3), dtype=np.uint8)
+        frame = np.zeros((self._height, self._width, 3), dtype=np.uint8)
 
         # Thread-safe copy
         with self.__fetch_lock:
@@ -166,7 +161,7 @@ class Wfmu(Screensaver):
                 self.__current_display = target
 
         if error:
-            self.__draw_text(frame, error, 2, self.__height // 2 - 2, (255, 100, 100))
+            self.__draw_text(frame, error, 2, self._height // 2 - 2, (255, 100, 100))
         elif not self.__current_display['title'] and not self.__current_display['artist']:
             # Waiting for data
             self.__draw_text(frame, "WFMU", 2, 2, self.COLORS['logo'])
@@ -197,14 +192,14 @@ class Wfmu(Screensaver):
         if show:
             show_y = 1
             show_width = len(show) * 4
-            if show_width <= self.__width:
+            if show_width <= self._width:
                 self.__draw_text(frame, show, 1, show_y, self.COLORS['show'])
             else:
-                self.__draw_scrolling_text(frame, show, 1, show_y, self.__width - 2, self.COLORS['show'])
+                self.__draw_scrolling_text(frame, show, 1, show_y, self._width - 2, self.COLORS['show'])
 
         # Divider line
         divider_y = 8
-        for x in range(self.__width):
+        for x in range(self._width):
             if x % 2 == 0:  # Dashed line
                 frame[divider_y, x] = self.COLORS['divider']
 
@@ -212,22 +207,22 @@ class Wfmu(Screensaver):
         if title:
             title_y = 11
             title_width = len(title) * 4
-            if title_width <= self.__width:
+            if title_width <= self._width:
                 # Center if it fits
-                x_offset = max(0, (self.__width - title_width) // 2)
+                x_offset = max(0, (self._width - title_width) // 2)
                 self.__draw_text(frame, title, x_offset, title_y, self.COLORS['track'])
             else:
-                self.__draw_scrolling_text(frame, title, 0, title_y, self.__width, self.COLORS['track'])
+                self.__draw_scrolling_text(frame, title, 0, title_y, self._width, self.COLORS['track'])
 
         # Artist name
         if artist:
             artist_y = 19
             artist_width = len(artist) * 4
-            if artist_width <= self.__width:
-                x_offset = max(0, (self.__width - artist_width) // 2)
+            if artist_width <= self._width:
+                x_offset = max(0, (self._width - artist_width) // 2)
                 self.__draw_text(frame, artist, x_offset, artist_y, self.COLORS['artist'])
             else:
-                self.__draw_scrolling_text(frame, artist, 0, artist_y, self.__width, self.COLORS['artist'])
+                self.__draw_scrolling_text(frame, artist, 0, artist_y, self._width, self.COLORS['artist'])
 
         # Audio visualization bars at bottom
         self.__draw_audio_bars(frame, 26)
@@ -236,7 +231,7 @@ class Wfmu(Screensaver):
         """Draw animated audio visualization bars."""
         bar_width = 3
         bar_gap = 1
-        num_bars = self.__width // (bar_width + bar_gap)
+        num_bars = self._width // (bar_width + bar_gap)
 
         for i in range(num_bars):
             # Create pseudo-random but smooth animation
@@ -245,7 +240,7 @@ class Wfmu(Screensaver):
 
             x = i * (bar_width + bar_gap)
             for dy in range(height):
-                bar_y = self.__height - 1 - dy
+                bar_y = self._height - 1 - dy
                 if bar_y >= y:
                     # Gradient from orange at bottom to yellow at top
                     intensity = 1.0 - (dy / 6.0)
@@ -255,19 +250,19 @@ class Wfmu(Screensaver):
                         int(50 * intensity)
                     )
                     for dx in range(bar_width):
-                        if x + dx < self.__width:
+                        if x + dx < self._width:
                             frame[bar_y, x + dx] = color
 
     def __draw_scrolling_text(self, frame, text, x, y, max_width, color):
         """Draw scrolling text with easing."""
         textutils.draw_scrolling_text(
             frame, text, x, y, max_width, color,
-            self.__scroll_offset, self.__width, self.__height
+            self.__scroll_offset, self._width, self._height
         )
 
     def __draw_text(self, frame, text, x, y, color):
         """Draw a text string."""
-        textutils.draw_text(frame, text, x, y, color, self.__width, self.__height)
+        textutils.draw_text(frame, text, x, y, color, self._width, self._height)
 
     @classmethod
     def get_id(cls) -> str:

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -56,7 +56,11 @@ class TestTimeoutResolution(unittest.TestCase):
         Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
 
     def _make(self, config):
-        Config._Config__config = copy.deepcopy(config)  # pyright: ignore[reportAttributeAccessIssue]
+        config = copy.deepcopy(config)
+        # The base Screensaver reads display dimensions on construction.
+        config.setdefault('leds', {}).setdefault('display_width', 64)
+        config['leds'].setdefault('display_height', 32)
+        Config._Config__config = config  # pyright: ignore[reportAttributeAccessIssue]
         return _StubScreensaver(led_frame_player=None)
 
     def test_default_timeout_is_120(self):
@@ -150,7 +154,11 @@ class TestTickSleepResolution(unittest.TestCase):
         Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
 
     def _make(self, config):
-        Config._Config__config = copy.deepcopy(config)  # pyright: ignore[reportAttributeAccessIssue]
+        config = copy.deepcopy(config)
+        # The base Screensaver reads display dimensions on construction.
+        config.setdefault('leds', {}).setdefault('display_width', 64)
+        config['leds'].setdefault('display_height', 32)
+        Config._Config__config = config  # pyright: ignore[reportAttributeAccessIssue]
         return _StubScreensaver(led_frame_player=None)
 
     def test_default_tick_sleep(self):


### PR DESCRIPTION
## Summary

Every screensaver was defining its own display dimensions and logger in `__init__`, with two competing conventions — most used name-mangled private attrs (`self.__width`, `self.__logger`) while the karaoke/cellular families used protected attrs (`self._width`, `self._logger`) — and width/height were read inconsistently (`get_or_throw` vs `get` vs `get`-with-default).

This moves all three onto `Screensaver.__init__` as protected attributes, available to every screensaver by default:

```python
self._logger = Logger().set_namespace(self.__class__.__name__)
self._width  = Config.get_or_throw('leds.display_width')
self._height = Config.get_or_throw('leds.display_height')
```

## Changes

- **Base class**: adds the three attributes; removes the old `_screensaver_logger` class attribute and points `play()`'s log lines at `self._logger` (so "Starting/ended" messages are namespaced to the concrete screensaver, e.g. `Boids`, instead of a generic `Screensaver`).
- **47 subclasses**: deleted their own `_width`/`_height`/`_logger` definitions and rewrote references to the inherited attributes. Cellular-automata classes had inline `Config.get_or_throw('leds.display_width')` lookups — those now use `self._width`/`self._height` too. Dropped `Config`/`Logger` imports that became unused.
- **Not touched**: `transitionplayer.py` and `screensavermanager.py` (not `Screensaver` subclasses).

## Standardizations folded in

- Width/height now uniformly use `get_or_throw`. The keys always exist in `default_config.json`, so this is behavior-neutral in practice but fails loudly if display dimensions are ever missing.
- The `_width`/`__width` and `_logger`/`__logger` split between the karaoke/cellular families and everyone else is gone — one protected convention now.

Net: **50 files, +404 / −556** (≈150 fewer lines).

## Test plan

- `uv run pyright` — 0 errors, 0 warnings repo-wide.
- `uv run pytest tests/` — 75 passed (245 subtests). Updated `test_screensaver_timeout.py`'s `_make` helper to inject display dims, since the base now reads them at construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)