### PR TITLE
Remove pyright suppressions: possibly-unbound and incompatible overrides

### DIFF
--- a/pifi/games/snakeplayer.py
+++ b/pifi/games/snakeplayer.py
@@ -138,18 +138,20 @@ class SnakePlayer:
             new_head = (old_head_y, (old_head_x - 1) % display_width)
         elif self.__direction == self.RIGHT:
             new_head = (old_head_y, (old_head_x + 1) % display_width)
+        else:
+            raise Exception(f"Unexpected snake direction: {self.__direction}")
 
-        self.__snake_linked_list.insert(0, new_head)  # pyright: ignore[reportPossiblyUnboundVariable]
+        self.__snake_linked_list.insert(0, new_head)
 
         # Must call this before placing the apple to ensure the apple is not placed on the new head
-        self.__snake_set.add(new_head)  # pyright: ignore[reportPossiblyUnboundVariable]
+        self.__snake_set.add(new_head)
 
-        if new_head == self.__snake_game.get_apple():  # pyright: ignore[reportOptionalMemberAccess, reportPossiblyUnboundVariable]
+        if new_head == self.__snake_game.get_apple():  # pyright: ignore[reportOptionalMemberAccess]
             was_apple_eaten = True
         else:
             old_tail = self.__snake_linked_list[-1]
             del self.__snake_linked_list[-1]
-            if old_tail != new_head:  # pyright: ignore[reportPossiblyUnboundVariable]
+            if old_tail != new_head:
                 # Prevent edge case when the head is "following" the tail.
                 # If the old_tail is the same as the new_head, we don't want to remove the old_tail from the set
                 # because  the call to `self.__snake_set.add(new_head)` would have been a no-op above.

--- a/pifi/led/drivers/driverbase.py
+++ b/pifi/led/drivers/driverbase.py
@@ -33,5 +33,5 @@ class DriverBase(ABC):
     # See: https://github.com/hzeller/rpi-rgb-led-matrix/issues/640
     #      https://github.com/dasl-/pifi/pull/32
     #      https://github.com/dasl-/pifi/issues/33
-    def can_multiple_driver_instances_coexist(self):
+    def can_multiple_driver_instances_coexist(self) -> bool:
         return True

--- a/pifi/led/drivers/driverrgbmatrix.py
+++ b/pifi/led/drivers/driverrgbmatrix.py
@@ -78,5 +78,5 @@ class DriverRgbMatrix(DriverBase):
     # See: https://github.com/hzeller/rpi-rgb-led-matrix/issues/640
     #      https://github.com/dasl-/pifi/pull/32
     #      https://github.com/dasl-/pifi/issues/33
-    def can_multiple_driver_instances_coexist(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def can_multiple_driver_instances_coexist(self) -> bool:
         return False

--- a/pifi/led/ledframeplayer.py
+++ b/pifi/led/ledframeplayer.py
@@ -150,6 +150,7 @@ class LedFramePlayer(FramePlayerBase):
         transformed_frame = np.zeros(shape, np.uint8)
 
         if self.__gamma_enabled:
+            gamma_index = Gamma.DEFAULT_GAMMA_INDEX
             if not VideoColorMode.is_color_mode_rgb(self.__video_color_mode):
                 gamma_index = self.__gamma_controller.getGammaIndexForMonochromeFrame(frame)
 
@@ -158,23 +159,23 @@ class LedFramePlayer(FramePlayerBase):
                 transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curve, frame[:, :, 1])  # pyright: ignore[reportArgumentType, reportCallIssue]
                 transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curve, frame[:, :, 2])  # pyright: ignore[reportArgumentType, reportCallIssue]
             elif self.__video_color_mode == VideoColorMode.COLOR_MODE_R:
-                transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
+                transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript]
             elif self.__video_color_mode == VideoColorMode.COLOR_MODE_G:
-                transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
+                transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript]
             elif self.__video_color_mode == VideoColorMode.COLOR_MODE_B:
-                transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
+                transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript]
             elif self.__video_color_mode == VideoColorMode.COLOR_MODE_BW:
-                transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
-                transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
-                transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
+                transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript]
+                transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript]
+                transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curves[gamma_index], frame[:, :])  # pyright: ignore[reportOptionalSubscript]
             elif self.__video_color_mode == VideoColorMode.COLOR_MODE_INVERT_COLOR:
                 transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curve, 255 - frame[:, :, 0])  # pyright: ignore[reportArgumentType, reportCallIssue]
                 transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curve, 255 - frame[:, :, 1])  # pyright: ignore[reportArgumentType, reportCallIssue]
                 transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curve, 255 - frame[:, :, 2])  # pyright: ignore[reportArgumentType, reportCallIssue]
             elif self.__video_color_mode == VideoColorMode.COLOR_MODE_INVERT_BW:
-                transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curves[gamma_index], 255 - frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
-                transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curves[gamma_index], 255 - frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
-                transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curves[gamma_index], 255 - frame[:, :])  # pyright: ignore[reportOptionalSubscript, reportPossiblyUnboundVariable]
+                transformed_frame[:, :, 0] = np.take(self.__scale_red_gamma_curves[gamma_index], 255 - frame[:, :])  # pyright: ignore[reportOptionalSubscript]
+                transformed_frame[:, :, 1] = np.take(self.__scale_green_gamma_curves[gamma_index], 255 - frame[:, :])  # pyright: ignore[reportOptionalSubscript]
+                transformed_frame[:, :, 2] = np.take(self.__scale_blue_gamma_curves[gamma_index], 255 - frame[:, :])  # pyright: ignore[reportOptionalSubscript]
             else:
                 raise Exception(f'Unexpected color mode: {self.__video_color_mode}.')
         else:

--- a/pifi/screensaver/cellularautomata/cellularautomaton.py
+++ b/pifi/screensaver/cellularautomata/cellularautomaton.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 import hashlib
 import time
 
+import numpy as np
+
 from pifi.datastructure.limitedsizedict import LimitedSizeDict
 from pifi.screensaver.screensaver import Screensaver
 
@@ -78,7 +80,7 @@ class CellularAutomaton(Screensaver, ABC):
         pass
 
     @abstractmethod
-    def _board_to_frame(self):
+    def _board_to_frame(self) -> np.ndarray:
         pass
 
     @abstractmethod
@@ -97,5 +99,5 @@ class CellularAutomaton(Screensaver, ABC):
         return self._DEFAULT_MAX_STATE_REPETITIONS_FOR_GAME_OVER
 
     # 0 means unlimited
-    def _get_max_game_length_seconds(self):
+    def _get_max_game_length_seconds(self) -> int:
         return self._DEFAULT_MAX_GAME_LENGTH_SECONDS

--- a/pifi/screensaver/cellularautomata/cyclicautomaton.py
+++ b/pifi/screensaver/cellularautomata/cyclicautomaton.py
@@ -14,7 +14,7 @@ class CyclicAutomaton(CellularAutomaton):
     def _should_fade_to_frame(self):
         return Config.get('screensavers.configs.cyclic_automaton.fade')
 
-    def _get_max_game_length_seconds(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _get_max_game_length_seconds(self) -> int:
         return 60
 
     def _reset_hook(self):
@@ -27,7 +27,7 @@ class CyclicAutomaton(CellularAutomaton):
         shape = [self._height + 2, self._width + 2]
         self._board = np.random.randint(0, self.__num_states, shape)
 
-    def _board_to_frame(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _board_to_frame(self) -> np.ndarray:
         board_shape = self._board.shape + (3,)
         foo = self.__palette[self._board.ravel()].reshape(board_shape)
         return foo[1:-1, 1:-1]

--- a/pifi/screensaver/cellularautomata/gameoflife.py
+++ b/pifi/screensaver/cellularautomata/gameoflife.py
@@ -52,7 +52,7 @@ class GameOfLife(CellularAutomaton):
             seed = np.random.random_sample([x - 2 for x in shape]) < probability
             self._board[1:-1, 1:-1][seed] = 1
 
-    def _board_to_frame(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _board_to_frame(self) -> np.ndarray:
         frame = np.zeros([self._height, self._width, 3], np.uint8)
         rgb = self.__game_color_helper.get_rgb(self.__game_color_mode, self.__COLOR_CHANGE_FREQ, self._num_ticks)
         frame[(self._board[1:-1, 1:-1] == 1)] = rgb  # pyright: ignore[reportArgumentType, reportCallIssue]

--- a/pifi/screensaver/karaokebase.py
+++ b/pifi/screensaver/karaokebase.py
@@ -466,6 +466,8 @@ class KaraokeBase(Screensaver):
 
         best_id = None
         best_diff = float('inf')
+        best_name = ''
+        best_length = 0
         for item in body['track_list']:
             track = item['track']
             length = track.get('track_length', 0)
@@ -480,7 +482,7 @@ class KaraokeBase(Screensaver):
 
         if best_id and best_diff <= 10:
             self._logger.debug(
-                f"Musixmatch search: '{best_name}' (id={best_id}, length={best_length}s, " +  # pyright: ignore[reportPossiblyUnboundVariable]
+                f"Musixmatch search: '{best_name}' (id={best_id}, length={best_length}s, " +
                 f"diff={best_diff}s)"
             )
             return best_id


### PR DESCRIPTION
Second batch of pyright suppression cleanup (follows #75). Fixes root causes across two rule categories:

| Rule | Removed |
|---|---|
| reportPossiblyUnboundVariable | 4 (+ 9 narrowed in ledframeplayer) |
| reportIncompatibleMethodOverride | 4 |

### reportPossiblyUnboundVariable — latent-bug fixes
- **`snakeplayer.tick()`**: the `if/elif` chain over `self.__direction` had no `else`, so `new_head` was provably unbound for any unexpected direction (today that path crashes with `UnboundLocalError`). Added an explicit `else` that raises a clear exception, documenting the invariant. In practice the snake is always seeded with a direction, so the branch is unreachable.
- **`karaokebase.__mm_search_by_duration()`**: `best_name`/`best_length` were only bound inside the loop's `if diff < best_diff` block. Initialized them before the loop. The defaults are never read (they're guarded by `if best_id`, which is only truthy once that block has run).
- **`ledframeplayer.__transform_frame()`**: `gamma_index` was only assigned in the non-RGB branch. Initialized it to `Gamma.DEFAULT_GAMMA_INDEX` up front — `is_color_mode_rgb()` is true exactly for the branches that don't use `gamma_index`, so the default is never read and behavior is unchanged. (The `reportOptionalSubscript` suppressions on those 9 lines remain, scoped for the later None-init cleanup.)

### reportIncompatibleMethodOverride — base annotations
The overrides were "widening" from inferred `None` (abstract `pass` bodies) or literal return types. Added explicit return annotations to the **base** methods:
- `DriverBase.can_multiple_driver_instances_coexist -> bool`
- `CellularAutomaton._board_to_frame -> np.ndarray`
- `CellularAutomaton._get_max_game_length_seconds -> int`

### Note
This PR originally also renamed `reportConstantRedefinition` attributes in `volumecontroller.py` and `spirograph.py`; that change was dropped per review — those keep their existing suppressions.

### Verification
- `uv run pyright`: **0 errors, 0 warnings, 0 informations**
- `uv run pytest tests/`: **74 passed, 245 subtests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)