### PR TITLE
Remove pyright suppressions: allow private access in tests

### DIFF
--- a/pifi/config.py
+++ b/pifi/config.py
@@ -62,6 +62,26 @@ class Config:
         Config.__is_loaded = True
 
     @staticmethod
+    def _load_for_test(config, base_config = None, applied_overrides = None):
+        """Test seam: inject config state directly, bypassing config-file loading.
+
+        Unit tests can't rely on config.json (gitignored, absent in CI), so they
+        seed the singleton here rather than going through load_config_if_not_loaded().
+        """
+        Config.__config = config
+        Config.__base_config = base_config if base_config is not None else {}
+        Config.__applied_overrides = applied_overrides if applied_overrides is not None else {}
+        Config.__is_loaded = True
+
+    @staticmethod
+    def _reset_for_test():
+        """Test seam: restore the singleton to its unloaded, empty default state."""
+        Config.__config = {}
+        Config.__base_config = {}
+        Config.__applied_overrides = {}
+        Config.__is_loaded = False
+
+    @staticmethod
     def get_default(key, default = None):
         """Get a key's value from the base config (before any runtime overrides)."""
         return Config.__get(key, default=default, config_dict=Config.__base_config)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -26,5 +26,20 @@
     "reportCallInDefaultInitializer": "error",
     "reportUnsupportedDunderAll": "error",
     "reportAssertAlwaysTrue": "error",
-    "reportMissingTypeArgument": "error"
+    "reportMissingTypeArgument": "error",
+    // Tests legitimately reach into the internals of the classes under test:
+    // protected members (ss._teardown) and name-mangled private state
+    // (ss._Screensaver__timeout). Both are allowed here so tests can assert and
+    // manipulate internal state without per-line suppressions. Where it dedupes
+    // setup, prefer the Config fixture loader (Config._load_for_test) instead.
+    // extraPaths keeps `pifi` importable from tests/ (mirrors the runtime
+    // sys.path insert each test file does).
+    "executionEnvironments": [
+        {
+            "root": "tests",
+            "extraPaths": ["."],
+            "reportPrivateUsage": "none",
+            "reportAttributeAccessIssue": "none"
+        }
+    ]
 }

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -34,10 +34,10 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
 
     def setUp(self):
         """Reset Config state before each test."""
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(self.BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__base_config = copy.deepcopy(self.BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__applied_overrides = {}  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(
+            copy.deepcopy(self.BASE_CONFIG),
+            base_config=copy.deepcopy(self.BASE_CONFIG),
+        )
 
     @patch('pifi.config.SettingsDb')
     def test_applies_overrides(self, MockSettingsDb):
@@ -245,7 +245,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Mutate config directly to detect if rebuild happens
-        Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999  # pyright: ignore[reportAttributeAccessIssue]
+        Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999
 
         # Same DB value — should skip rebuild, keeping the mutation
         Config.reload_overrides(['screensaver_settings'])
@@ -261,7 +261,7 @@ class TestReloadScreensaverOverrides(unittest.TestCase):
         self.assertEqual(Config.get('screensavers.configs.boids.num_boids'), 50)
 
         # Mutate config directly
-        Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999  # pyright: ignore[reportAttributeAccessIssue]
+        Config._Config__config['screensavers']['configs']['boids']['num_boids'] = 999
 
         # Different DB value — should rebuild, overwriting the mutation
         mock_db.get.return_value = json.dumps({'screensavers': {'configs': {'boids': {'num_boids': 75}}}})

--- a/tests/test_screensaver_timeout.py
+++ b/tests/test_screensaver_timeout.py
@@ -16,12 +16,10 @@ import time
 import unittest
 import sys
 import os
-from unittest.mock import MagicMock
-
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
+from pifi.led.blackholeframeplayer import BlackHoleFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 
 
@@ -43,40 +41,34 @@ class _StubScreensaver(Screensaver):
         return 'Test stub'
 
 
-def setUpModule():
-    # Mock LedFramePlayer to avoid hardware initialization
-    LedFramePlayer.__init__ = lambda self: None  # pyright: ignore[reportAttributeAccessIssue]
-    LedFramePlayer.play_frame = MagicMock()
-
-
 class TestTimeoutResolution(unittest.TestCase):
     """Test the timeout config resolution chain."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
+        Config._reset_for_test()
 
     def _make(self, config):
         config = copy.deepcopy(config)
         # The base Screensaver reads display dimensions on construction.
         config.setdefault('leds', {}).setdefault('display_width', 64)
         config['leds'].setdefault('display_height', 32)
-        Config._Config__config = config  # pyright: ignore[reportAttributeAccessIssue]
-        return _StubScreensaver(led_frame_player=None)
+        Config._load_for_test(config)
+        return _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
 
     def test_default_timeout_is_120(self):
         """When timeout is set to 120 in config (as in default_config.json), it's used."""
         ss = self._make({'screensavers': {'timeout': 120}})
-        self.assertEqual(ss._Screensaver__timeout, 120)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(ss._Screensaver__timeout, 120)
 
     def test_timeout_absent_means_unlimited(self):
         """When timeout key is absent from config entirely, it's unlimited."""
         ss = self._make({'screensavers': {}})
-        self.assertEqual(ss._Screensaver__timeout, 0)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(ss._Screensaver__timeout, 0)
 
     def test_global_timeout_overrides_default(self):
         """Global screensavers.timeout overrides the hardcoded default."""
         ss = self._make({'screensavers': {'timeout': 60}})
-        self.assertEqual(ss._Screensaver__timeout, 60)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(ss._Screensaver__timeout, 60)
 
     def test_per_screensaver_timeout_overrides_global(self):
         """Per-screensaver timeout overrides the global timeout."""
@@ -86,7 +78,7 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': 30}},
             }
         })
-        self.assertEqual(ss._Screensaver__timeout, 30)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(ss._Screensaver__timeout, 30)
 
     def test_no_per_screensaver_timeout_falls_back_to_global(self):
         """When per-screensaver timeout is absent, global timeout is used."""
@@ -96,21 +88,21 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'tick_sleep': 0.01}},
             }
         })
-        self.assertEqual(ss._Screensaver__timeout, 90)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(ss._Screensaver__timeout, 90)
 
     def test_timeout_zero_means_unlimited(self):
         """Timeout of 0 means unlimited — _is_past_timeout always returns False."""
         ss = self._make({'screensavers': {'timeout': 0}})
-        self.assertEqual(ss._Screensaver__timeout, 0)  # pyright: ignore[reportAttributeAccessIssue]
-        ss._Screensaver__start_time = time.time() - 99999  # pyright: ignore[reportAttributeAccessIssue]
-        self.assertFalse(ss._is_past_timeout())  # pyright: ignore[reportPrivateUsage]
+        self.assertEqual(ss._Screensaver__timeout, 0)
+        ss._Screensaver__start_time = time.time() - 99999
+        self.assertFalse(ss._is_past_timeout())
 
     def test_global_timeout_none_means_unlimited(self):
         """Global timeout of None means unlimited (same as 0)."""
         ss = self._make({'screensavers': {'timeout': None}})
-        self.assertEqual(ss._Screensaver__timeout, 0)  # pyright: ignore[reportAttributeAccessIssue]
-        ss._Screensaver__start_time = time.time() - 99999  # pyright: ignore[reportAttributeAccessIssue]
-        self.assertFalse(ss._is_past_timeout())  # pyright: ignore[reportPrivateUsage]
+        self.assertEqual(ss._Screensaver__timeout, 0)
+        ss._Screensaver__start_time = time.time() - 99999
+        self.assertFalse(ss._is_past_timeout())
 
     def test_per_screensaver_timeout_null_falls_back_to_global(self):
         """Per-screensaver timeout of null falls back to global timeout."""
@@ -120,7 +112,7 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': None}},
             }
         })
-        self.assertEqual(ss._Screensaver__timeout, 60)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(ss._Screensaver__timeout, 60)
 
     def test_per_screensaver_timeout_zero_means_unlimited(self):
         """Per-screensaver timeout of 0 means unlimited, not fallback."""
@@ -130,36 +122,36 @@ class TestTimeoutResolution(unittest.TestCase):
                 'configs': {'stub': {'timeout': 0}},
             }
         })
-        self.assertEqual(ss._Screensaver__timeout, 0)  # pyright: ignore[reportAttributeAccessIssue]
-        ss._Screensaver__start_time = time.time() - 99999  # pyright: ignore[reportAttributeAccessIssue]
-        self.assertFalse(ss._is_past_timeout())  # pyright: ignore[reportPrivateUsage]
+        self.assertEqual(ss._Screensaver__timeout, 0)
+        ss._Screensaver__start_time = time.time() - 99999
+        self.assertFalse(ss._is_past_timeout())
 
     def test_positive_timeout_expires(self):
         """A positive timeout causes _is_past_timeout to return True after elapsed time."""
         ss = self._make({'screensavers': {'timeout': 10}})
-        ss._Screensaver__start_time = time.time() - 11  # pyright: ignore[reportAttributeAccessIssue]
-        self.assertTrue(ss._is_past_timeout())  # pyright: ignore[reportPrivateUsage]
+        ss._Screensaver__start_time = time.time() - 11
+        self.assertTrue(ss._is_past_timeout())
 
     def test_positive_timeout_not_expired(self):
         """A positive timeout returns False before the time elapses."""
         ss = self._make({'screensavers': {'timeout': 10}})
-        ss._Screensaver__start_time = time.time()  # pyright: ignore[reportAttributeAccessIssue]
-        self.assertFalse(ss._is_past_timeout())  # pyright: ignore[reportPrivateUsage]
+        ss._Screensaver__start_time = time.time()
+        self.assertFalse(ss._is_past_timeout())
 
 
 class TestTickSleepResolution(unittest.TestCase):
     """Test the tick_sleep config resolution chain."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
+        Config._reset_for_test()
 
     def _make(self, config):
         config = copy.deepcopy(config)
         # The base Screensaver reads display dimensions on construction.
         config.setdefault('leds', {}).setdefault('display_width', 64)
         config['leds'].setdefault('display_height', 32)
-        Config._Config__config = config  # pyright: ignore[reportAttributeAccessIssue]
-        return _StubScreensaver(led_frame_player=None)
+        Config._load_for_test(config)
+        return _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
 
     def test_default_tick_sleep(self):
         """When tick_sleep is set to 0.05 in config (as in default_config.json), it's used."""

--- a/tests/test_screensavers.py
+++ b/tests/test_screensavers.py
@@ -44,8 +44,7 @@ def setUpModule():
     # control here keeps this suite deterministic regardless of run order.
     default_config_path = DirectoryUtils().root_dir + '/default_config.json'
     with open(default_config_path) as f:
-        Config._Config__config = pyjson5.decode(f.read())  # pyright: ignore[reportAttributeAccessIssue]
-    Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(pyjson5.decode(f.read()))
 
     # default_config.json ships display dimensions of 0 (real values come from
     # config.json on a device); set real ones so frames aren't empty.
@@ -60,10 +59,7 @@ def tearDownModule():
     # after this one starts from a clean, unloaded Config rather than inheriting
     # our screensaver config. Reset all four mutable class attributes back to
     # their declared defaults (see Config in pifi/config.py).
-    Config._Config__is_loaded = False  # pyright: ignore[reportAttributeAccessIssue]
-    Config._Config__config = {}  # pyright: ignore[reportAttributeAccessIssue]
-    Config._Config__base_config = {}  # pyright: ignore[reportAttributeAccessIssue]
-    Config._Config__applied_overrides = {}  # pyright: ignore[reportAttributeAccessIssue]
+    Config._reset_for_test()
 
 
 # Screensavers that need external resources (video files, network, audio

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -23,7 +23,7 @@ import numpy as np
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pifi.config import Config
-from pifi.led.ledframeplayer import LedFramePlayer
+from pifi.led.blackholeframeplayer import BlackHoleFramePlayer
 from pifi.screensaver.screensaver import Screensaver
 from pifi.screensaver.transitionplayer import TransitionPlayer
 from pifi.screensaver.videoscreensaver import VideoScreensaver
@@ -154,22 +154,14 @@ BASE_CONFIG = {
 }
 
 
-def setUpModule():
-    LedFramePlayer.__init__ = lambda self: None  # pyright: ignore[reportAttributeAccessIssue]
-    LedFramePlayer.play_frame = MagicMock()
-    LedFramePlayer.fade_to_frame = MagicMock()
-    LedFramePlayer.get_current_frame = MagicMock(return_value=np.zeros([4, 4, 3], np.uint8))
-
-
 class TestSupportsLiveTransition(unittest.TestCase):
     """Test the supports_live_transition() method."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def test_video_screensaver_returns_false(self):
-        ss = VideoScreensaver(led_frame_player=None)
+        ss = VideoScreensaver(led_frame_player=BlackHoleFramePlayer())
         self.assertFalse(ss.supports_live_transition())
 
 
@@ -177,23 +169,22 @@ class TestLastTick(unittest.TestCase):
     """Test last_tick initialization and updates."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def test_updated_after_play(self):
-        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=5)
+        ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=5)
         ss.play()
         self.assertEqual(ss.get_last_tick(), 5)
 
     def test_updated_after_render_tick(self):
-        ss = _StubScreensaver(led_frame_player=None)
+        ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
         ss.render_tick()
         self.assertEqual(ss.get_last_tick(), 1)
         ss.render_tick()
         self.assertEqual(ss.get_last_tick(), 2)
 
     def test_not_updated_when_tick_fails(self):
-        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=0)
         ss.render_tick()
         self.assertEqual(ss.get_last_tick(), 0)
 
@@ -202,31 +193,29 @@ class TestAutoTeardown(unittest.TestCase):
     """Test auto_teardown parameter of play()."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def test_auto_teardown_true_calls_teardown(self):
-        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
-        ss._teardown = MagicMock()  # pyright: ignore[reportPrivateUsage]
+        ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=0)
+        ss._teardown = MagicMock()
         ss.play(auto_teardown=True)
-        ss._teardown.assert_called_once()  # pyright: ignore[reportPrivateUsage]
+        ss._teardown.assert_called_once()
 
     def test_auto_teardown_false_skips_teardown(self):
-        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
-        ss._teardown = MagicMock()  # pyright: ignore[reportPrivateUsage]
+        ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=0)
+        ss._teardown = MagicMock()
         ss.play(auto_teardown=False)
-        ss._teardown.assert_not_called()  # pyright: ignore[reportPrivateUsage]
+        ss._teardown.assert_not_called()
 
 
 class TestRenderTick(unittest.TestCase):
     """Test render_tick() captures frames without displaying."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def test_returns_frame_and_alive(self):
-        ss = _StubScreensaver(led_frame_player=None)
+        ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
         frame, alive = ss.render_tick()
         self.assertTrue(alive)
         self.assertIsNotNone(frame)
@@ -247,25 +236,25 @@ class TestRenderTick(unittest.TestCase):
         player = MagicMock()
         ss = _StubScreensaver(led_frame_player=player)
         ss.render_tick()
-        self.assertIs(ss._led_frame_player, player)  # pyright: ignore[reportPrivateUsage]
+        self.assertIs(ss._led_frame_player, player)
 
     def test_restores_frame_player_on_exception(self):
         player = MagicMock()
         ss = _ExplodingTickScreensaver(led_frame_player=player, explode_after=0)
         with self.assertRaises(RuntimeError):
             ss.render_tick()
-        self.assertIs(ss._led_frame_player, player)  # pyright: ignore[reportPrivateUsage]
+        self.assertIs(ss._led_frame_player, player)
 
     def test_returns_false_alive_when_tick_stops(self):
-        ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=0)
         _, alive = ss.render_tick()
         self.assertFalse(alive)
 
     def test_calls_setup_on_first_invocation(self):
-        ss = _RenderingSetupScreensaver(led_frame_player=None)
-        self.assertFalse(ss._Screensaver__is_set_up)  # pyright: ignore[reportAttributeAccessIssue]
+        ss = _RenderingSetupScreensaver(led_frame_player=BlackHoleFramePlayer())
+        self.assertFalse(ss._Screensaver__is_set_up)
         ss.render_tick()
-        self.assertTrue(ss._Screensaver__is_set_up)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertTrue(ss._Screensaver__is_set_up)
 
     def test_setup_frame_captured_not_displayed(self):
         """Frames rendered during _setup() should be captured, not sent to real display."""
@@ -286,8 +275,7 @@ class TestTransitionFramePlayerIntegrity(unittest.TestCase):
     """Test that frame players are never corrupted by transitions."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def _make_player(self):
         player = MagicMock()
@@ -300,38 +288,37 @@ class TestTransitionFramePlayerIntegrity(unittest.TestCase):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
-        from_ss = _StubScreensaver(led_frame_player=None)
-        to_ss = _StubScreensaver(led_frame_player=None)
-        from_original = from_ss._led_frame_player  # pyright: ignore[reportPrivateUsage]
-        to_original = to_ss._led_frame_player  # pyright: ignore[reportPrivateUsage]
+        from_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
+        to_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
+        from_original = from_ss._led_frame_player
+        to_original = to_ss._led_frame_player
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
-        self.assertIs(from_ss._led_frame_player, from_original)  # pyright: ignore[reportPrivateUsage]
-        self.assertIs(to_ss._led_frame_player, to_original)  # pyright: ignore[reportPrivateUsage]
+        self.assertIs(from_ss._led_frame_player, from_original)
+        self.assertIs(to_ss._led_frame_player, to_original)
 
     def test_screensaver_player_intact_after_exception(self):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
-        from_ss = _StubScreensaver(led_frame_player=None)
-        to_ss = _ExplodingTickScreensaver(led_frame_player=None, explode_after=0)
-        from_original = from_ss._led_frame_player  # pyright: ignore[reportPrivateUsage]
-        to_original = to_ss._led_frame_player  # pyright: ignore[reportPrivateUsage]
+        from_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
+        to_ss = _ExplodingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), explode_after=0)
+        from_original = from_ss._led_frame_player
+        to_original = to_ss._led_frame_player
 
         with self.assertRaises(RuntimeError):
             tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
-        self.assertIs(from_ss._led_frame_player, from_original)  # pyright: ignore[reportPrivateUsage]
-        self.assertIs(to_ss._led_frame_player, to_original)  # pyright: ignore[reportPrivateUsage]
+        self.assertIs(from_ss._led_frame_player, from_original)
+        self.assertIs(to_ss._led_frame_player, to_original)
 
 
 class TestWarmedUpState(unittest.TestCase):
     """Test that live_transition_warmed_up reflects whether warm-up actually succeeded."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def _make_player(self):
         player = MagicMock()
@@ -342,8 +329,8 @@ class TestWarmedUpState(unittest.TestCase):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
-        from_ss = _StubScreensaver(led_frame_player=None)
-        to_ss = _StubScreensaver(led_frame_player=None)
+        from_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
+        to_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
         self.assertFalse(to_ss.live_transition_warmed_up)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
@@ -354,10 +341,10 @@ class TestWarmedUpState(unittest.TestCase):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
-        from_ss = _StubScreensaver(led_frame_player=None)
+        from_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
 
         # Fails immediately during warm-up
-        to_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=0)
+        to_ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=0)
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
         self.assertFalse(to_ss.live_transition_warmed_up)
@@ -369,8 +356,7 @@ class TestWarmUpTicksZero(unittest.TestCase):
     def setUp(self):
         config = copy.deepcopy(BASE_CONFIG)
         config['screensavers']['transitions']['warm_up_ticks'] = 0
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = config  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(config)
 
     def _make_player(self):
         player = MagicMock()
@@ -383,7 +369,7 @@ class TestWarmUpTicksZero(unittest.TestCase):
         player = self._make_player()
         tp = TransitionPlayer(player)
 
-        to_ss = _RenderingSetupScreensaver(led_frame_player=None)
+        to_ss = _RenderingSetupScreensaver(led_frame_player=BlackHoleFramePlayer())
 
         # Run transition with only to_screensaver (from_frame will be black)
         tp.play_transition(to_screensaver=to_ss)
@@ -408,8 +394,7 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
     def setUp(self):
         config = copy.deepcopy(BASE_CONFIG)
         config['screensavers']['transitions']['warm_up_ticks'] = 60
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = config  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(config)
 
     def test_to_still_warms_up(self):
         """If from_screensaver dies during warm-up, warm-up ends early
@@ -418,8 +403,8 @@ class TestFromDiesDuringWarmup(unittest.TestCase):
         player.get_current_frame.return_value = np.zeros([4, 4, 3], np.uint8)
         tp = TransitionPlayer(player)
 
-        from_ss = _FailingTickScreensaver(led_frame_player=None, fail_after=1)
-        to_ss = _StubScreensaver(led_frame_player=None)
+        from_ss = _FailingTickScreensaver(led_frame_player=BlackHoleFramePlayer(), fail_after=1)
+        to_ss = _StubScreensaver(led_frame_player=BlackHoleFramePlayer())
 
         tp.play_transition(from_screensaver=from_ss, to_screensaver=to_ss)
 
@@ -433,8 +418,7 @@ class TestStaticTransition(unittest.TestCase):
     """Test static-frame transitions (no live screensavers)."""
 
     def setUp(self):
-        Config._Config__is_loaded = True  # pyright: ignore[reportAttributeAccessIssue]
-        Config._Config__config = copy.deepcopy(BASE_CONFIG)  # pyright: ignore[reportAttributeAccessIssue]
+        Config._load_for_test(copy.deepcopy(BASE_CONFIG))
 
     def test_static_transition_runs(self):
         """play_transition() with no screensavers should crossfade to black."""


### PR DESCRIPTION
Third batch of pyright suppression cleanup (follows #75, #76), targeting the ~70 test-only suppressions where tests reach into the internals of the classes under test. **Total repo suppressions: 210 → 145.**

### Background: two different rules
Tests poke internals in two forms, which surface as *different* pyright rules:
- **`reportPrivateUsage`** — single-underscore protected access (`ss._teardown`, `ss._led_frame_player`, `ss._is_past_timeout()`).
- **`reportAttributeAccessIssue`** — name-mangled private access (`Config._Config__config`, `ss._Screensaver__timeout`), which tests must write in mangled form to work at runtime.

### Approach (hybrid)
- **`pyrightconfig.json`**: a `tests/` `executionEnvironment` sets both `reportPrivateUsage` and `reportAttributeAccessIssue` to `none`. Tests legitimately assert on and manipulate internal state, so allowing it beats per-line suppressions or adding production getters just for a test. `extraPaths: ["."]` keeps `pifi` importable from `tests/`. `reportAttributeAccessIssue` stays `error` everywhere **outside** `tests/`.
- **`config.py`**: added `Config._load_for_test()` / `_reset_for_test()` seams that dedupe the repeated 4-attribute fixture setup previously copy-pasted (via name-mangled access) across four test files.
- **tests**: route fixture setup through the seams; drop all now-unnecessary suppression comments.
- **tests**: replaced the global `LedFramePlayer.__init__ = lambda ...` monkeypatch in `test_transitions`/`test_screensaver_timeout` with the purpose-built **`BlackHoleFramePlayer`** — the hardware-free `FramePlayerBase` already used by `test_screensavers`. This is cleaner than globally mutating the `LedFramePlayer` class (and removes the need to import it just to neuter it).

### Result
- Test suppressions: ~70 → 1 (the lone remainder is a `reportOptionalMemberAccess`, slated for the None-init cluster).
- `uv run pyright`: **0 errors, 0 warnings, 0 informations**
- `uv run pytest tests/`: **74 passed, 245 subtests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)